### PR TITLE
Windows hardening: CRLF-safe gates + Windows-aware CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,7 @@ claude-starter/hooks/commit-msg text eol=lf
 # strip '\r' defensively, but keeping these LF means the parsers never see one.
 claude-starter/profiles.conf text eol=lf
 *.conf text eol=lf
+# Blocklists/allowlists and other data files the hooks read line-by-line as patterns: a CRLF checkout leaves a '\r'
+# on every pattern, which then never matches the LF diff — silently blinding the trace/secret gate on Windows. The
+# pre-commit also strips a trailing '\r' defensively, but keeping these LF means it never sees one.
+*.txt text eol=lf

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -160,6 +160,9 @@ BASHBIN="$(command -v bash 2>/dev/null || echo bash)"   # absolute -> the stripp
 for t in awk sed grep head tail cat ls tr; do
   tp="$(command -v "$t" 2>/dev/null)" && ln -s "$tp" "$JXBIN/$t" 2>/dev/null || JXOK=0
 done
+# Git-Bash on Windows can't make real symlinks — `ln -s` silently COPIES, so JXOK stays 1 but the PATH is not a
+# faithful jq-less POSIX env. Require a real symlink; otherwise skip (the no-jq path is exercised on the POSIX runners).
+[ "$JXOK" = 1 ] && [ ! -L "$JXBIN/awk" ] && JXOK=0
 if [ "$JXOK" = 1 ] && ! PATH="$JXBIN" command -v jq >/dev/null 2>&1; then
   SX="$(mktemp)"
   printf '%s\n' '{"type":"assistant","isSidechain":false,"message":{"usage":{"input_tokens":20,"cache_read_input_tokens":760000,"cache_creation_input_tokens":11936}}}' >  "$SX"
@@ -202,6 +205,7 @@ CUJX="$(mktemp -d)"; CUJXOK=1; CUBASH="$(command -v bash 2>/dev/null || echo bas
 for t in awk sed grep head tail cat ls tr dirname; do
   tp="$(command -v "$t" 2>/dev/null)" && ln -s "$tp" "$CUJX/$t" 2>/dev/null || CUJXOK=0
 done
+[ "$CUJXOK" = 1 ] && [ ! -L "$CUJX/awk" ] && CUJXOK=0   # Windows Git-Bash copies instead of symlinking -> not a faithful jq-less PATH; skip
 cu(){    CONTEXT_WINDOW=1000000 bash "$HOOKS/context-usage.sh" --verbose "$1" 2>/dev/null; }
 cu_nojq(){ PATH="$CUJX" CONTEXT_WINDOW=1000000 "$CUBASH" "$HOOKS/context-usage.sh" --verbose "$1" 2>/dev/null; }
 # assert the SAME expected total on both engines — they must never drift apart
@@ -468,6 +472,7 @@ o="$(gj auto 'git commit -m \"reset --hard bug\"' | bash "$HOOKS/guard-bash.sh" 
 # Fallback (no jq AND no python3 — stock Git Bash on Windows): the matchers must still fire on the raw JSON blob (M1).
 GBX="$(mktemp -d)"; GBOK=1; GBBASH="$(command -v bash 2>/dev/null || echo bash)"
 for t in awk sed grep head cat tr git cut; do tp="$(command -v "$t" 2>/dev/null)" && ln -s "$tp" "$GBX/$t" 2>/dev/null || GBOK=0; done
+[ "$GBOK" = 1 ] && [ ! -L "$GBX/awk" ] && GBOK=0   # Windows Git-Bash copies instead of symlinking -> not a faithful jq-less PATH; skip
 if [ "$GBOK" = 1 ] && ! PATH="$GBX" command -v jq >/dev/null 2>&1 && ! PATH="$GBX" command -v python3 >/dev/null 2>&1; then
   o="$(gj auto 'git commit -m x' | PATH="$GBX" "$GBBASH" "$HOOKS/guard-bash.sh" 2>/dev/null)"
   echo "$o" | grep -q '"permissionDecision":"ask"' && pass "no-jq/py: commit still ASKs (M1 fallback closed)" || fail "no-jq/py: commit gate FAILS OPEN (M1): $o"
@@ -539,9 +544,18 @@ DOC="$(mktemp -d)"
   chmod +x .claude/hooks/*.sh .claude/hooks/pre-commit .claude/hooks/commit-msg
   git config core.hooksPath .claude/hooks )
 bash "$ROOT/eval/doctor.sh" "$DOC" >/dev/null 2>&1 && pass "doctor: healthy install -> exit 0" || fail "doctor flagged a healthy install"
-chmod -x "$DOC/.claude/hooks/guard-write.sh" 2>/dev/null
-bash "$ROOT/eval/doctor.sh" "$DOC" >/dev/null 2>&1 && fail "doctor PASSED a broken install (non-exec hook)" || pass "doctor: broken install -> exit != 0"
-chmod +x "$DOC/.claude/hooks/guard-write.sh" 2>/dev/null   # restore for the next mutations
+# The "non-executable hook" probe only means something where the FS enforces the exec bit. Windows (NTFS via
+# Git-Bash) does not — `chmod -x` is a no-op and the file stays executable to `[ -x ]` — so the broken state can't
+# even be created there; skip the probe rather than assert a condition the platform can't represent.
+EXECPROBE="$DOC/.execprobe"; : > "$EXECPROBE"; chmod +x "$EXECPROBE" 2>/dev/null; chmod -x "$EXECPROBE" 2>/dev/null
+if [ ! -x "$EXECPROBE" ]; then
+  chmod -x "$DOC/.claude/hooks/guard-write.sh" 2>/dev/null
+  bash "$ROOT/eval/doctor.sh" "$DOC" >/dev/null 2>&1 && fail "doctor PASSED a broken install (non-exec hook)" || pass "doctor: broken install -> exit != 0"
+  chmod +x "$DOC/.claude/hooks/guard-write.sh" 2>/dev/null   # restore for the next mutations
+else
+  pass "doctor: non-exec-hook probe skipped (this filesystem does not enforce the exec bit)"
+fi
+rm -f "$EXECPROBE"
 # M2c: a present + executable but NEUTERED hook (body replaced with exit 0) must be caught by the behaviour probe.
 printf '#!/usr/bin/env bash\nexit 0\n' > "$DOC/.claude/hooks/guard-bash.sh"; chmod +x "$DOC/.claude/hooks/guard-bash.sh"
 bash "$ROOT/eval/doctor.sh" "$DOC" >/dev/null 2>&1 && fail "doctor PASSED a neutered guard-bash (M2c)" || pass "doctor: neutered guard-bash -> exit != 0 (M2c probe)"

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -544,18 +544,16 @@ DOC="$(mktemp -d)"
   chmod +x .claude/hooks/*.sh .claude/hooks/pre-commit .claude/hooks/commit-msg
   git config core.hooksPath .claude/hooks )
 bash "$ROOT/eval/doctor.sh" "$DOC" >/dev/null 2>&1 && pass "doctor: healthy install -> exit 0" || fail "doctor flagged a healthy install"
-# The "non-executable hook" probe only means something where the FS enforces the exec bit. Windows (NTFS via
-# Git-Bash) does not — `chmod -x` is a no-op and the file stays executable to `[ -x ]` — so the broken state can't
-# even be created there; skip the probe rather than assert a condition the platform can't represent.
-EXECPROBE="$DOC/.execprobe"; : > "$EXECPROBE"; chmod +x "$EXECPROBE" 2>/dev/null; chmod -x "$EXECPROBE" 2>/dev/null
-if [ ! -x "$EXECPROBE" ]; then
-  chmod -x "$DOC/.claude/hooks/guard-write.sh" 2>/dev/null
+# The "non-executable hook" probe only means something where `chmod -x` actually takes effect. On Windows via
+# Git-Bash/MSYS a file with a `#!` shebang is reported executable regardless of the bit, so the broken state can't
+# be created — probe the REAL hook: only assert when chmod -x actually cleared its executability.
+chmod -x "$DOC/.claude/hooks/guard-write.sh" 2>/dev/null
+if [ ! -x "$DOC/.claude/hooks/guard-write.sh" ]; then
   bash "$ROOT/eval/doctor.sh" "$DOC" >/dev/null 2>&1 && fail "doctor PASSED a broken install (non-exec hook)" || pass "doctor: broken install -> exit != 0"
-  chmod +x "$DOC/.claude/hooks/guard-write.sh" 2>/dev/null   # restore for the next mutations
 else
-  pass "doctor: non-exec-hook probe skipped (this filesystem does not enforce the exec bit)"
+  pass "doctor: non-exec-hook probe skipped (Git-Bash keeps shebang scripts executable regardless of the bit)"
 fi
-rm -f "$EXECPROBE"
+chmod +x "$DOC/.claude/hooks/guard-write.sh" 2>/dev/null   # restore for the next mutations
 # M2c: a present + executable but NEUTERED hook (body replaced with exit 0) must be caught by the behaviour probe.
 printf '#!/usr/bin/env bash\nexit 0\n' > "$DOC/.claude/hooks/guard-bash.sh"; chmod +x "$DOC/.claude/hooks/guard-bash.sh"
 bash "$ROOT/eval/doctor.sh" "$DOC" >/dev/null 2>&1 && fail "doctor PASSED a neutered guard-bash (M2c)" || pass "doctor: neutered guard-bash -> exit != 0 (M2c probe)"

--- a/claude-starter/hooks/pre-commit
+++ b/claude-starter/hooks/pre-commit
@@ -74,7 +74,8 @@ done < <(git diff --cached --name-only --diff-filter=AM -- . 2>/dev/null)
 # (1) trace scan — case-INsensitive (vendor / AI-authorship strings), project files only
 if [ -f "$BL" ] && [ -s "$TRACE_F" ]; then
   while IFS= read -r pat || [ -n "$pat" ]; do
-    case "$pat" in ''|\#*) continue;; esac
+    pat="${pat%$'\r'}"                       # tolerate a CRLF blocklist (Windows/autocrlf checkout) — a trailing \r
+    case "$pat" in ''|\#*) continue;; esac   # in the pattern never matches the LF-normalised diff, blinding the gate
     if [ -n "$AL" ] && grep -qxF -- "$pat" "$AL"; then continue; fi
     if grep -iqE -- "$pat" "$TRACE_F"; then
       echo "TRACE-SCANNER: forbidden expression in added code -> '$pat' (§4.1/§4.2)"
@@ -85,6 +86,7 @@ fi
 # (2) secret scan — case-SENSITIVE (token prefixes are case-specific); prints the PATTERN, never the value
 if [ -f "$SL" ] && [ -s "$SECRET_F" ]; then
   while IFS= read -r pat || [ -n "$pat" ]; do
+    pat="${pat%$'\r'}"                       # tolerate a CRLF blocklist (Windows/autocrlf checkout)
     case "$pat" in ''|\#*) continue;; esac
     if [ -n "$SAL" ] && grep -qxF -- "$pat" "$SAL"; then continue; fi
     if grep -qE -- "$pat" "$SECRET_F"; then

--- a/packaging/e2e.sh
+++ b/packaging/e2e.sh
@@ -83,25 +83,30 @@ head -1 "$U/CLAUDE.md" | grep -q 'project rules'        || { echo "FAIL: update 
 # (B) SAME, but with NO jq and NO python3 on PATH (the real Windows Git-Bash case) -> kit-only settings safely
 # REPLACED + backup kept. The strip needs a symlink farm; Git-Bash on Windows can't make one, so there we skip this
 # sub-test (with a note) and rely on (A) + the portable-bash fallback proven on the POSIX runners.
-N="$WORK/selfheal-nojq"; mk_stale_install "$N"
-NODEPS="$WORK/nodeps-bin"; rm -rf "$NODEPS"; mkdir -p "$NODEPS"    # mirror every tool on PATH, then drop jq + python*
-oldIFS="$IFS"; IFS=:
-for d in $PATH; do [ -d "$d" ] || continue
-  for f in "$d"/*; do b="$(basename "$f" 2>/dev/null)"; [ -n "$b" ] && [ -x "$f" ] && [ ! -e "$NODEPS/$b" ] && ln -s "$f" "$NODEPS/$b" 2>/dev/null; done
-done; IFS="$oldIFS"
-rm -f "$NODEPS"/jq "$NODEPS"/jq.* "$NODEPS"/python "$NODEPS"/python3 "$NODEPS"/python.* "$NODEPS"/python3.* 2>/dev/null
-if PATH="$NODEPS" bash -c 'command -v grep >/dev/null 2>&1 && command -v cp >/dev/null 2>&1' \
-   && ! PATH="$NODEPS" bash -c 'command -v jq >/dev/null 2>&1' \
-   && ! PATH="$NODEPS" bash -c 'command -v python3 >/dev/null 2>&1'; then
-  ( cd "$N" && PATH="$NODEPS" bash adopt.sh --here </dev/null >/dev/null 2>&1 )
-  grep -q 'SessionStart' "$N/.claude/settings.json"     || { echo "FAIL: no-jq/python update did not self-heal the settings"; exit 1; }
-  grep -q '"timeout": 30' "$N/.claude/settings.json"    || { echo "FAIL: no-jq/python update did not refresh the timeout"; exit 1; }
-  ls "$N"/.claude/settings.json.bak-* >/dev/null 2>&1   || { echo "FAIL: no-jq/python replace did not keep a backup"; exit 1; }
-  head -1 "$N/CLAUDE.md" | grep -q 'project rules'      || { echo "FAIL: no-jq/python update clobbered CLAUDE.md"; exit 1; }
-  NOJQ_NOTE="with + WITHOUT jq/python"
+# Probe ONCE whether this filesystem makes real symlinks. Git-Bash on Windows copies instead — a copied .exe is
+# DLL-fragile and can't run, so a mirror-farm PATH there is both broken and slow (thousands of copies). Only build
+# the jq-less strip where symlinks are real; elsewhere skip this leg (the no-jq code is proven on the POSIX runners).
+SYMPROBE="$WORK/.symprobe"; rm -f "$SYMPROBE"; ln -s "$(command -v bash 2>/dev/null)" "$SYMPROBE" 2>/dev/null
+if [ -L "$SYMPROBE" ]; then
+  N="$WORK/selfheal-nojq"; mk_stale_install "$N"
+  NODEPS="$WORK/nodeps-bin"; rm -rf "$NODEPS"; mkdir -p "$NODEPS"    # mirror every tool on PATH, then drop jq + python*
+  oldIFS="$IFS"; IFS=:
+  for d in $PATH; do [ -d "$d" ] || continue
+    for f in "$d"/*; do b="$(basename "$f" 2>/dev/null)"; [ -n "$b" ] && [ -x "$f" ] && [ ! -e "$NODEPS/$b" ] && ln -s "$f" "$NODEPS/$b" 2>/dev/null; done
+  done; IFS="$oldIFS"
+  rm -f "$NODEPS"/jq "$NODEPS"/jq.* "$NODEPS"/python "$NODEPS"/python3 "$NODEPS"/python.* "$NODEPS"/python3.* 2>/dev/null
+  if ! PATH="$NODEPS" bash -c 'command -v jq >/dev/null 2>&1' && ! PATH="$NODEPS" bash -c 'command -v python3 >/dev/null 2>&1'; then
+    ( cd "$N" && PATH="$NODEPS" bash adopt.sh --here </dev/null >/dev/null 2>&1 )
+    grep -q 'SessionStart' "$N/.claude/settings.json"     || { echo "FAIL: no-jq/python update did not self-heal the settings"; exit 1; }
+    grep -q '"timeout": 30' "$N/.claude/settings.json"    || { echo "FAIL: no-jq/python update did not refresh the timeout"; exit 1; }
+    ls "$N"/.claude/settings.json.bak-* >/dev/null 2>&1   || { echo "FAIL: no-jq/python replace did not keep a backup"; exit 1; }
+    head -1 "$N/CLAUDE.md" | grep -q 'project rules'      || { echo "FAIL: no-jq/python update clobbered CLAUDE.md"; exit 1; }
+    NOJQ_NOTE="with + WITHOUT jq/python"
+  else NOJQ_NOTE="with jq/python (couldn't build a jq-less PATH here)"; fi
 else
   NOJQ_NOTE="with jq/python (no-jq PATH-strip needs POSIX symlinks — that leg runs on Linux/macOS)"
 fi
+rm -f "$SYMPROBE"
 # (C) FIRST adopt (no kit present) · non-interactive · NO --yes -> declines (a brownfield change still needs consent)
 F="$WORK/firstadopt"; rm -rf "$F"; mkdir -p "$F"
 cp adopt.sh "$F/"; cp -R claude-starter "$F/"; cp VERSION "$F/"; printf '{"name":"x"}' > "$F/package.json"


### PR DESCRIPTION
Makes the kit pass CI on Windows (Git-Bash) as well as Linux and macOS.

- **Real bug:** the pre-commit trace/secret gate was blind on a CRLF/autocrlf checkout (patterns carried a trailing CR). Now strips CR + pins `*.txt` to LF.
- **Test harness:** no-jq (symlink strip) and exec-bit probes assumed POSIX; they now detect Git-Bash's copy-instead-of-symlink and no-op chmod and skip cleanly.

Follows the self-heal update fix. No release until CI is green on all three OSes.