### PR TITLE
Detect python/py (not just python3) for the settings merge

### DIFF
--- a/adopt.sh
+++ b/adopt.sh
@@ -577,8 +577,10 @@ elif command -v jq >/dev/null 2>&1; then
       warn "settings.json: jq merge failed -> project setting PRESERVED (not overwritten)."
     fi
   fi
-elif command -v python3 >/dev/null 2>&1; then   # Windows Git-Bash rarely ships jq; python3 is far more common
-  if python3 - "$KSET" "$PSET" "$PSET.tmp" 2>/dev/null <<'PYEOF' && [ -s "$PSET.tmp" ]; then
+elif PYBIN="$(command -v python3 2>/dev/null || command -v python 2>/dev/null || command -v py 2>/dev/null)"; [ -n "$PYBIN" ]; then
+  # Windows Git-Bash rarely ships jq; Python is far more common but is exposed as python3, python, OR `py` (the
+  # Windows Python Launcher) depending on the install — check all three, not just python3.
+  if "$PYBIN" - "$KSET" "$PSET" "$PSET.tmp" 2>/dev/null <<'PYEOF' && [ -s "$PSET.tmp" ]; then
 import json,sys
 kit=json.load(open(sys.argv[1])); proj=json.load(open(sys.argv[2]))
 def ddedup(a):
@@ -601,9 +603,9 @@ def merge_hooks(kh,ph):
 m=dm(kit,proj); m["hooks"]=merge_hooks(kit.get("hooks",{}),proj.get("hooks",{}))
 open(sys.argv[3],"w").write(json.dumps(m,indent=2)+"\n")
 PYEOF
-    mv "$PSET.tmp" "$PSET"; echo "  settings.json: hook-aware MERGE via python3 (kit hooks refreshed - custom hooks/permissions PRESERVED)"
+    mv "$PSET.tmp" "$PSET"; echo "  settings.json: hook-aware MERGE via ${PYBIN##*/} (kit hooks refreshed - custom hooks/permissions PRESERVED)"
   else
-    rm -f "$PSET.tmp"; warn "settings.json: python3 merge failed -> project setting PRESERVED (not overwritten)."
+    rm -f "$PSET.tmp"; warn "settings.json: ${PYBIN##*/} merge failed -> project setting PRESERVED (not overwritten)."
   fi
 else
   # No jq AND no python3 (common on Windows Git-Bash) — we can't parse JSON to merge. But if the project's

--- a/packaging/e2e.sh
+++ b/packaging/e2e.sh
@@ -102,6 +102,18 @@ if [ -L "$SYMPROBE" ]; then
     ls "$N"/.claude/settings.json.bak-* >/dev/null 2>&1   || { echo "FAIL: no-jq/python replace did not keep a backup"; exit 1; }
     head -1 "$N/CLAUDE.md" | grep -q 'project rules'      || { echo "FAIL: no-jq/python update clobbered CLAUDE.md"; exit 1; }
     NOJQ_NOTE="with + WITHOUT jq/python"
+    # (D) Python exposed ONLY as `py` (the Windows Python Launcher) — no jq, no python3/python. The merge must run
+    #     via py and heal, NOT fall through to the .kit reference (the exact case a Git-Bash Windows user hit).
+    REALPY="$(command -v python3 2>/dev/null || command -v python 2>/dev/null)"
+    if [ -n "$REALPY" ]; then
+      P="$WORK/selfheal-py"; mk_stale_install "$P"
+      printf '#!/bin/sh\nexec "%s" "$@"\n' "$REALPY" > "$NODEPS/py"; chmod +x "$NODEPS/py"
+      ( cd "$P" && PATH="$NODEPS" bash adopt.sh --here </dev/null >/dev/null 2>&1 )
+      grep -q 'SessionStart' "$P/.claude/settings.json"   || { echo "FAIL: py-launcher update did not self-heal (SessionStart)"; exit 1; }
+      grep -q '"timeout": 30' "$P/.claude/settings.json"  || { echo "FAIL: py-launcher update did not refresh the timeout"; exit 1; }
+      [ ! -e "$P/.claude/settings.json.kit" ]             || { echo "FAIL: py present but the merge fell back to .kit"; exit 1; }
+      rm -f "$NODEPS/py"
+    fi
   else NOJQ_NOTE="with jq/python (couldn't build a jq-less PATH here)"; fi
 else
   NOJQ_NOTE="with jq/python (no-jq PATH-strip needs POSIX symlinks — that leg runs on Linux/macOS)"


### PR DESCRIPTION
Fixes a real Windows case: Python is often exposed only as `py` (the Python Launcher) in Git-Bash, so the settings merge missed it and left a `settings.json.kit` reference instead of healing. The merge now probes python3 → python → py. Proven locally against a py-only environment; adds an e2e regression leg.

No release until CI is green on Linux, macOS, and Windows.