### PR TITLE
ci(stats): capture distribution reach before GitHub deletes it

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,0 +1,99 @@
+name: stats
+
+# Weekly capture of distribution reach into an append-only ledger on the `stats` branch.
+#
+# GitHub's traffic API keeps fourteen days. Nothing here was recording it, so every clone count older than two
+# weeks is already unrecoverable — this workflow exists to stop that loss going forward, not to recover it.
+#
+# The ledger lives on its own ROOT-HISTORY branch (`stats`, one file: stats.jsonl) rather than on main: a
+# weekly bot commit on main would bury the release history this project keeps deliberately readable. The branch
+# is written with git plumbing (hash-object / mktree / commit-tree), so nothing is ever checked out over the
+# working tree and the branch bootstraps itself on the first run.
+#
+# Traffic needs a fine-grained PAT with `Administration: read` in the STATS_TOKEN secret — `administration` is
+# not a permission the automatic GITHUB_TOKEN can be granted. Without it the run still records npm and release
+# numbers, and annotates itself so the gap is visible rather than silently logged as zero reach.
+
+on:
+  schedule:
+    - cron: '17 6 * * 1'   # Mondays, 06:17 UTC. Off the hour on purpose: GitHub's scheduler is most congested
+                           # at :00 and delays (or drops) runs there. Weekly beats the 14-day window twice over.
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: stats-ledger      # two appends racing would each build a tree from the same parent and one would lose
+  cancel-in-progress: false
+
+jobs:
+  capture:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Collect the week's numbers
+        env:
+          STATS_TOKEN: ${{ secrets.STATS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          bash packaging/collect-stats.sh > row.json
+          # A row with no traffic is still worth keeping, but it must not pass as a complete one.
+          if [ "$(jq -r '.github.traffic == null' row.json)" = true ]; then
+            echo "::warning title=Traffic not captured::$(jq -r '.github.traffic_error' row.json)"
+          fi
+          jq -r '"npm last-week: \(.npm.total // "n/a") · traffic clones: \(.github.traffic.clones.count // "n/a")"' row.json
+
+      - name: Append to the ledger
+        run: |
+          set -euo pipefail
+          git fetch --depth=1 origin stats 2>/dev/null || true
+
+          PARENT="$(git rev-parse --verify -q origin/stats || true)"
+          if [ -n "$PARENT" ]; then
+            git cat-file -p "origin/stats:stats.jsonl" > ledger.jsonl 2>/dev/null || : > ledger.jsonl
+          else
+            : > ledger.jsonl
+            echo "no stats branch yet — bootstrapping it"
+          fi
+          cat row.json >> ledger.jsonl
+
+          cat > ledger-readme.md <<'EOF'
+          # stats
+
+          Append-only ledger of this project's distribution reach, one JSON object per line in `stats.jsonl`,
+          written weekly by `.github/workflows/stats.yml`.
+
+          It exists because GitHub's traffic API keeps only a **fourteen day** window: clone and view counts
+          older than that are deleted and cannot be recovered. npm and release-asset totals are permanent and
+          are recorded alongside so the numbers can be read against each other.
+
+          Reading the rows:
+
+          - `npm.by_version` — most of every version's weekly downloads are **mirror traffic**, a similar
+            baseline on versions nobody installs. The signal is the spike on the current version above it.
+          - `npm.current_version_downloads` lags a release by a few days: npm's window closes before a
+            just-published version has been out a full week.
+          - `github.traffic` is `null` when the run had no `Administration: read` token. Null means *not
+            measured* — it is deliberately not written as zero.
+          - Runs overlap (weekly capture, fourteen-day window), so `daily` arrays repeat days. Deduplicate by
+            date when aggregating.
+
+          This branch has its own root history and shares no commits with `main`.
+          EOF
+
+          BLOB_LEDGER="$(git hash-object -w ledger.jsonl)"
+          BLOB_README="$(git hash-object -w ledger-readme.md)"
+          TREE="$(printf '100644 blob %s\tREADME.md\n100644 blob %s\tstats.jsonl\n' \
+                    "$BLOB_README" "$BLOB_LEDGER" | git mktree)"
+
+          export GIT_AUTHOR_NAME="github-actions[bot]" GIT_COMMITTER_NAME="github-actions[bot]"
+          export GIT_AUTHOR_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
+          export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+          MSG="chore(stats): weekly snapshot $(date -u +%Y-%m-%d)"
+          COMMIT="$(git commit-tree "$TREE" ${PARENT:+-p "$PARENT"} -m "$MSG")"
+
+          git push origin "$COMMIT:refs/heads/stats"
+          echo "ledger now has $(wc -l < ledger.jsonl | tr -d ' ') row(s)"

--- a/packaging/collect-stats.sh
+++ b/packaging/collect-stats.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Distribution reach, captured before GitHub deletes it.
+#
+# GitHub's traffic API keeps only a FOURTEEN DAY window: clone and view counts older than that are gone, and
+# nothing in this repo was writing them down. Every other number the project reports is either derivable from
+# the tree (agent/skill counts) or permanent (npm totals); traffic is the one that evaporates. This script is
+# the capture step — `.github/workflows/stats.yml` runs it weekly and appends the row to the `stats` branch.
+#
+# Emits ONE JSON object on stdout (a JSONL row). Everything else goes to stderr, so the caller can redirect
+# stdout straight into the ledger.
+#
+# Sources, and what each is worth:
+#   npm downloads      permanent, but almost entirely MIRROR NOISE — every published version, including ones
+#                      nobody installs, draws a similar few-downloads-a-week baseline. The signal is the SPIKE
+#                      on the current version against that baseline, which is why per-version numbers are kept
+#                      rather than a single total.
+#   release assets     permanent, cumulative, and a real install signal (a tarball download is deliberate).
+#   traffic            EPHEMERAL — the whole reason this exists. Daily arrays are stored, not just the totals,
+#                      so the resolution survives even though the runs overlap.
+#
+# Auth: the traffic endpoints require push access, and `administration` is NOT a permission the workflow's
+# automatic GITHUB_TOKEN can be granted — so traffic needs a fine-grained PAT (Administration: read) in
+# STATS_TOKEN. Releases work with either token. When traffic cannot be read the row records WHY, and the
+# workflow warns: a ledger that silently writes nothing where the numbers should be would read, a year later,
+# exactly like a repo nobody cloned.
+#
+# Usage:
+#   bash packaging/collect-stats.sh                    # token from STATS_TOKEN, else GITHUB_TOKEN, else `gh`
+#   REPO=owner/name bash packaging/collect-stats.sh    # defaults to byerlikaya/claude-starter-kit
+#
+# Exit 0 a row was written (traffic may be absent, and says so) · 1 every source failed — no row, no silent
+# empty entry · 2 a prerequisite is missing (curl / jq).
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"; cd "$ROOT"
+
+REPO="${REPO:-byerlikaya/claude-starter-kit}"
+PKG="@byerlikaya/claude-starter-kit"
+PKG_ENC="%40byerlikaya%2Fclaude-starter-kit"
+
+for tool in curl jq; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "collect-stats: $tool is required" >&2; exit 2; }
+done
+
+# Token: STATS_TOKEN (traffic-capable) is preferred; GITHUB_TOKEN still gets releases; `gh` covers a local run.
+TOKEN="${STATS_TOKEN:-${GITHUB_TOKEN:-}}"
+if [ -z "$TOKEN" ] && command -v gh >/dev/null 2>&1; then TOKEN="$(gh auth token 2>/dev/null || true)"; fi
+
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+VERSION="$(cat VERSION 2>/dev/null || echo unknown)"
+
+# gh_api <path> -> body on stdout, empty on failure (the caller decides whether that is fatal).
+gh_api() {
+  [ -n "$TOKEN" ] || return 1
+  curl -sf -H "Authorization: Bearer $TOKEN" \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "https://api.github.com/repos/$REPO/$1" 2>/dev/null
+}
+npm_api() { curl -sf "https://api.npmjs.org/$1" 2>/dev/null; }
+
+json_or_null() { # a body is only usable if it parses AND is an object
+  jq -e 'type == "object"' >/dev/null 2>&1 <<<"$1" && printf '%s' "$1" || printf 'null'
+}
+
+OK=0
+
+# --- npm ---------------------------------------------------------------------------------------------------
+NPM_POINT="$(json_or_null "$(npm_api "downloads/point/last-week/$PKG")")"
+NPM_RANGE="$(json_or_null "$(npm_api "downloads/range/last-week/$PKG")")"
+NPM_VERS="$(json_or_null "$(npm_api "versions/$PKG_ENC/last-week")")"
+[ "$NPM_POINT" != null ] && OK=1 || echo "collect-stats: npm download point unavailable" >&2
+
+# --- release assets ----------------------------------------------------------------------------------------
+RELEASES="$(gh_api releases)"
+if [ -n "$RELEASES" ] && jq -e 'type == "array"' >/dev/null 2>&1 <<<"$RELEASES"; then
+  RELEASES="$(jq -c '[.[] | {tag: .tag_name, published: .published_at,
+                             assets: [.assets[] | {name, downloads: .download_count}]}]' <<<"$RELEASES")"
+  OK=1
+else
+  RELEASES=null; echo "collect-stats: release list unavailable" >&2
+fi
+
+# --- traffic (the perishable half) ---------------------------------------------------------------------------
+TRAFFIC_ERR=null
+CLONES="$(gh_api traffic/clones)"; VIEWS="$(gh_api traffic/views)"
+if [ -n "$CLONES" ] && [ -n "$VIEWS" ]; then
+  CLONES="$(json_or_null "$CLONES")"; VIEWS="$(json_or_null "$VIEWS")"
+  [ "$CLONES" != null ] && [ "$VIEWS" != null ] && OK=1
+else
+  CLONES=null; VIEWS=null
+  if [ -z "$TOKEN" ]; then
+    TRAFFIC_ERR='"no token: set STATS_TOKEN (fine-grained PAT, Administration: read)"'
+  else
+    TRAFFIC_ERR='"token lacks push/Administration access — the automatic GITHUB_TOKEN cannot read traffic"'
+  fi
+  echo "collect-stats: traffic unavailable — $(jq -r . <<<"$TRAFFIC_ERR")" >&2
+fi
+
+if [ "$OK" -eq 0 ]; then
+  echo "collect-stats: every source failed — writing no row (an empty row is indistinguishable from zero reach)" >&2
+  exit 1
+fi
+
+jq -cn \
+  --arg at "$NOW" --arg version "$VERSION" --arg repo "$REPO" \
+  --argjson point "$NPM_POINT" --argjson range "$NPM_RANGE" --argjson vers "$NPM_VERS" \
+  --argjson releases "$RELEASES" --argjson clones "$CLONES" --argjson views "$VIEWS" \
+  --argjson traffic_error "$TRAFFIC_ERR" \
+  '{
+     captured_at: $at,
+     repo: $repo,
+     kit_version: $version,
+     npm: {
+       window:      (if $point then {start: $point.start, end: $point.end} else null end),
+       total:       (if $point then $point.downloads else null end),
+       daily:       (if $range then $range.downloads else null end),
+       by_version:  (if $vers  then $vers.downloads  else null end),
+       current_version_downloads:
+                    (if $vers then ($vers.downloads[$version] // 0) else null end)
+     },
+     github: {
+       releases: $releases,
+       traffic: (if $clones and $views
+                 then {clones: {count: $clones.count, uniques: $clones.uniques, daily: $clones.clones},
+                       views:  {count: $views.count,  uniques: $views.uniques,  daily: $views.views}}
+                 else null end),
+       traffic_error: $traffic_error
+     }
+   }'


### PR DESCRIPTION
GitHub's traffic API keeps a **fourteen-day window**. Nothing in this repo was writing it down, so every clone count older than two weeks is already unrecoverable. This stops the loss going forward — it cannot recover what is gone.

## What lands

| File | Role |
|---|---|
| `packaging/collect-stats.sh` | Collects npm (weekly total · daily · per-version), release-asset counters and traffic (clones/views **with daily arrays**), emits one JSONL row on stdout |
| `.github/workflows/stats.yml` | Mondays 06:17 UTC + `workflow_dispatch`; appends the row to the ledger |

## Three decisions worth reviewing

**The ledger is not on `main`.** It lives on a root-history `stats` branch holding `stats.jsonl`. A weekly bot commit would bury a release history this project keeps deliberately readable, and `/docs/` is gitignored so the originally planned path could not have worked. The branch is written with git plumbing (`hash-object` / `mktree` / `commit-tree`): no checkout ever touches the working tree, and the branch bootstraps itself on the first run.

**Daily arrays are stored, not just totals.** The point is preserving resolution before deletion. Weekly runs against a fourteen-day window overlap, so days repeat — deduplicate by date when aggregating. The branch README says so.

**Missing traffic is recorded as `null`, never `0`.** Reading traffic requires a fine-grained PAT with `Administration: read` in `STATS_TOKEN`; `administration` is not a permission the automatic `GITHUB_TOKEN` can be granted (verified against GitHub's docs). Without it the row still carries real npm and release numbers, states *why* traffic is absent, and the run annotates itself with a warning. A year from now, "not measured" and "nobody cloned it" must not read the same.

## Verification

Run against the live APIs before commit: npm 391 weekly · 30 releases · 230 clones / 91 unique · 310 views · 14-day daily array. The ledger plumbing was rehearsed in a throwaway repo across two runs — bootstrap and append — confirming an orphan history, a two-entry tree and valid JSON on every line. The degraded path was exercised with no token: `traffic: null` plus a stated reason, exit 0, npm data intact. `smoke-test` and `routing-eval` green; `collect-stats.sh` is already covered by CI's `packaging/*.sh` syntax sweep.

No payload file changes — the kit itself is untouched.