### PR TITLE
2.0.2 — Windows: the hooks were never running, and three silences that hid it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ versioning follows [SemVer](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- **No hook launched at all on Windows, and every gate was silently absent.** Reported as
+  `bash: C:RuntimeHostExecLayerskqr_backend/.claude/hooks/session-rehydrate.sh: No such file or directory` —
+  note the separators are **deleted**, not converted. The installed `settings.json` was correct, and no local
+  reproduction could produce that string, which is what finally located the cause: hooks were wired in **shell
+  form** with the project path interpolated into the command, and Claude Code substitutes the placeholder into
+  that string *before* a shell ever sees it. On Windows the value is `C:\Repos\app`, and the backslashes are
+  consumed on the way. 2.0.1's `${VAR//\\//}` fold could never have run — bash was not the one doing the
+  expanding.
+
+  Hook commands now carry **no placeholder at all**:
+
+  ```
+  cd "$CLAUDE_PROJECT_DIR" 2>/dev/null; bash .claude/hooks/<name>.sh
+  ```
+
+  Hooks run in the project directory, so the relative path is the load-bearing part and there is nothing left for
+  the substitution to mangle. The `cd` is a belt for a session started in a subdirectory; it uses the **bare**
+  `$CLAUDE_PROJECT_DIR`, which is not the placeholder syntax and therefore survives to the shell, and if it fails
+  the relative path still carries.
+
+  **The documented fix was tried first and rejected on evidence.** The hooks reference recommends *exec form*
+  (`"command": "bash", "args": [...]`) for anything referencing a path placeholder, and it was implemented —
+  then checked on the affected Windows machine before shipping. `where bash` there answered
+  `C:\Windows\System32\bash.exe`: not Git Bash, but the **WSL launcher**, whose filesystem namespace has no
+  `C:\Repos\app` at all. Exec form spawns `command` off the PATH with no shell, so it would have run that — or
+  failed outright on a machine without WSL — and taken every gate with it, with an error pointing nowhere near
+  the cause. It would have been a worse bug than the one being fixed, shipped as the recommended solution.
+  `smoke-test.sh` now refuses exec-form wiring outright, with that reasoning attached.
+
+  `doctor.sh` reports `${CLAUDE_PROJECT_DIR}` in a hook command as a failure on every platform — a repo is shared
+  across machines, and the wiring is wrong on all of them the moment one teammate is on Windows.
+
+  Handled alongside: every non-gate hook was checked to exit 0 on its hook path (`context-usage.sh` had a second
+  non-zero exit that would surface as a per-turn error banner), and `adopt.sh`'s merge now recognises kit hooks
+  from `command` *and* `args`, so it tolerates either wiring shape on an update.
 - **Every path the kit read out of a hook payload was broken on Windows.** Hook stdin is JSON, and JSON encodes a
   backslash as two — so the real path `C:\Users\me\.claude\projects\p\a.jsonl` arrives as
   `C:\\Users\\me\\...`. The kit sliced that value out with `sed` and used it verbatim, which names no file on any
@@ -23,6 +58,18 @@ versioning follows [SemVer](https://semver.org/).
   bad path it still complains and exits 1, because that is a person's mistake and worth saying out loud.
 
 ### Added
+- **A stale-WIRING gate: a session resumed across a kit update runs the previous hooks.** Found while verifying
+  the path fix on the affected machine — `settings.json` on disk had already been corrected and `--resume` still
+  produced the error naming the old, mangled path, while the same event in a fresh session was clean. So
+  `--resume` carries the wiring the session started with, and on the very release that repairs the Windows path
+  that means the gates in force are still the broken ones.
+
+  The obvious gate is impossible: a hook cannot report its own absence, and under the old wiring on Windows no
+  hook launched at all. This catches the other half — hooks that *do* run, but not the way the file on disk says
+  they should. `$0` is the evidence: the kit wires `bash .claude/hooks/<name>.sh`, so a correctly-launched hook
+  sees a relative `$0`, and anything else came from a different `settings.json`. It stays silent when
+  `settings.json` is absent or hand-rewired: a project that wired its own hooks is not wrong, and warning it every
+  turn about something it chose is noise it cannot act on.
 - **`eval/preflight.sh` — the toolchain gaps get named before they become symptoms.** Runs inside `start.sh` and
   `adopt.sh` (before the confirm prompt) and inside `doctor.sh` (because the machine changes after install day).
   The kit is written to degrade rather than break — no `jq` falls back to `python`, then to plain bash; no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 Notable changes to this project are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/),
 versioning follows [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **Every path the kit read out of a hook payload was broken on Windows.** Hook stdin is JSON, and JSON encodes a
+  backslash as two — so the real path `C:\Users\me\.claude\projects\p\a.jsonl` arrives as
+  `C:\\Users\\me\\...`. The kit sliced that value out with `sed` and used it verbatim, which names no file on any
+  platform. `context-usage.sh` therefore reported `transcript not found` on **every turn**, on Windows CLI and in
+  Claude Desktop alike, and it read like the hook was being invoked without stdin. It was being invoked correctly
+  and then discarding the answer. Paths coming out of the payload are now JSON-decoded before use.
+
+  Scope, honestly: only `context-usage.sh` was actually broken. `session-rehydrate.sh` and `skill-trust.sh` folded
+  lone backslashes in 2.0.1, and folding both halves of a `\\` yields `//`, which the OS collapses — they survived
+  the encoded form by accident. Both now decode explicitly, and all three are pinned by a suite case that feeds
+  the real hooks a Windows-shaped payload.
+- **`context-usage.sh` no longer exits non-zero when it cannot measure — as a hook.** Nothing downstream reads the
+  status (`session-guard.sh` parses the line and falls open without it), while a non-zero hook exit is a visible
+  error in the user's session once per turn, for a condition the discipline already handles. Called by hand with a
+  bad path it still complains and exits 1, because that is a person's mistake and worth saying out loud.
+
+### Added
+- **`eval/preflight.sh` — the toolchain gaps get named before they become symptoms.** Runs inside `start.sh` and
+  `adopt.sh` (before the confirm prompt) and inside `doctor.sh` (because the machine changes after install day).
+  The kit is written to degrade rather than break — no `jq` falls back to `python`, then to plain bash; no
+  `sha256sum` falls back to `cksum` — which is correct design and exactly why a missing tool never announces
+  itself. Every surprise in this project came from that silence. Preflight names the gap and what it costs.
+
+  It **reports and never installs**. A scaffolding tool that puts software on someone's workstation unasked is a
+  worse problem than the one it solves, and on a managed corporate machine it just fails in a new way.
+
 ## [2.0.1] - 2026-08-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -321,7 +321,13 @@ The standing cost is published, not hidden. The discipline plus every agent and 
 bash .claude/eval/smoke-test.sh      # structure, frontmatter, gate integrity
 bash .claude/eval/routing-eval.sh    # does an example prompt reach the right agent or skill
 bash .claude/eval/doctor.sh          # is this install healthy, and is the project ready
+bash .claude/eval/preflight.sh       # which tools this machine has, and what degrades without them
 ```
+
+`preflight.sh` also runs inside `start.sh`, `adopt.sh` and `doctor.sh`. The kit degrades rather than breaks when a
+tool is absent — no `jq` falls back to `python`, then to plain bash; no `sha256sum` falls back to `cksum` — which is
+the right design and also the reason a gap never announces itself. Preflight names the gap and what it costs. It
+reports; it never installs anything on your machine and never blocks a run.
 
 ## Extending
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -321,7 +321,13 @@ Sabit maliyet gizlenmiyor, yazıyor. Disiplin ve her agent ile skill tarifi her 
 bash .claude/eval/smoke-test.sh      # yapı, frontmatter, yaptırım bütünlüğü
 bash .claude/eval/routing-eval.sh    # örnek bir istek doğru agent ya da skill'e gidiyor mu
 bash .claude/eval/doctor.sh          # bu kurulum sağlıklı mı, proje hazır mı
+bash .claude/eval/preflight.sh       # bu makinede hangi araçlar var, eksik olan neyi bozar
 ```
+
+`preflight.sh` ayrıca `start.sh`, `adopt.sh` ve `doctor.sh` içinde de çalışır. Bir araç yoksa kit kırılmaz, geriler:
+`jq` yoksa `python`, o da yoksa saf bash; `sha256sum` yoksa `cksum`. Tasarım böyle doğru, ama eksiğin kendini hiç
+belli etmemesinin sebebi de bu. Preflight eksiği ve bedelini adıyla söyler. Yalnız rapor eder — makinenize hiçbir şey
+kurmaz, hiçbir çalışmayı durdurmaz.
 
 ## Genişletme
 

--- a/adopt.sh
+++ b/adopt.sh
@@ -626,7 +626,7 @@ def dm(a;b): reduce (b|keys_unsorted[]) as $k (a;
   if (.[$k]|type)=="object" and (b[$k]|type)=="object" then .[$k]=dm(.[$k];b[$k])
   elif (.[$k]|type)=="array" and (b[$k]|type)=="array" then .[$k]=((.[$k]+b[$k])|ddedup)
   else .[$k]=b[$k] end);
-def is_kit: ((.hooks // []) | map((.command // "") | contains(".claude/hooks/")) | any);
+def is_kit: ((.hooks // []) | map((((.command // "") + " " + ((.args // []) | join(" "))) | contains(".claude/hooks/"))) | any);   # command AND args: tolerates either wiring shape
 def merge_hooks(kh;ph):
   (((kh|keys_unsorted)+(ph|keys_unsorted))|unique) as $e
   | reduce $e[] as $k ({}; .[$k]=((kh[$k] // [])+((ph[$k] // [])|map(select(is_kit|not)))));

--- a/adopt.sh
+++ b/adopt.sh
@@ -387,6 +387,11 @@ if [ -z "$DEC_BR" ]; then
 fi
 
 if [ "$DEC_BR" = here ]; then WHERE="the current branch '$BASE'"; else WHERE="a new review branch (off '$BASE')"; fi
+# Missing tools named before the mutation prompt, not after. It matters more here than on a fresh install: the
+# settings MERGE is the step that needs jq/python, and without them an update replaces settings.json (backup
+# kept) instead of merging — so a project's own hooks are dropped. Better to say that while it is still a
+# choice. Report-only; never blocks.
+[ -f "$SRC/eval/preflight.sh" ] && bash "$SRC/eval/preflight.sh"
 if ! ask_yes "Apply the kit onto $WHERE now? (mutation; staged-not-committed, reversible with git)"; then
   h1 "Stopped"; sub "Stayed at Stage 1 — NOTHING CHANGED (read-only)."; exit 0
 fi

--- a/claude-starter/eval/doctor.sh
+++ b/claude-starter/eval/doctor.sh
@@ -85,6 +85,22 @@ if [ -f "$S" ]; then
       || bad "settings.json missing hook events or wiring:$MISS" "restore settings.json from the kit"
     grep -q '"SessionStart"' "$S" || warn "SessionStart not wired — session rehydration inactive (update the kit)"
   fi
+  # `${CLAUDE_PROJECT_DIR}` inside a hook command is the shape that breaks on Windows, and it breaks invisibly.
+  # Claude Code substitutes that placeholder into the command STRING before any shell sees it; on Windows the
+  # value is `C:\Repos\app` and the separators are gone by the time bash reads it. The reported path was
+  # `C:ReposApp/.claude/hooks/...` — every hook failed to launch and every gate was absent, while settings.json
+  # looked perfectly correct on inspection. The kit now uses a RELATIVE path (hooks run in the project
+  # directory), with a `cd` off the bare `$CLAUDE_PROJECT_DIR` as a belt for a session started in a subdirectory.
+  # Bare `$VAR` is not the placeholder syntax, so Claude Code leaves it for the shell to expand.
+  #
+  # Reported on every platform, not only Windows: a repo is shared across machines, and the wiring is wrong on
+  # all of them the moment one teammate is on Windows.
+  if grep -q '\${CLAUDE_PROJECT_DIR' "$S" 2>/dev/null; then
+    bad "settings.json wires hooks through the \${CLAUDE_PROJECT_DIR} placeholder — on Windows its separators are stripped before bash runs, so NO hook launches and every gate is silently absent" \
+        "update the kit (npx @byerlikaya/claude-starter-kit adopt) — hook commands become: cd \"\$CLAUDE_PROJECT_DIR\" 2>/dev/null; bash .claude/hooks/<name>.sh"
+  else
+    ok "hook wiring carries no path placeholder (nothing for Windows to mangle)"
+  fi
 else
   bad "settings.json missing — the tool-level gates (commit approval, guards, context) are INACTIVE" "reinstall the kit"
 fi

--- a/claude-starter/eval/doctor.sh
+++ b/claude-starter/eval/doctor.sh
@@ -245,6 +245,15 @@ else echo "DOCTOR: $FAIL issue(s) ❌ — apply the fixes above"; fi
 # project-specific skill carries the domain. These are project maturity, not install health, so they NEVER
 # change the exit code — doctor's verdict stays a statement about the install.
 echo
+# The toolchain the install actually landed on. It runs here as well as in the installers because the machine
+# changes after install day — a wiped PATH, a new laptop, a corporate image that removed jq — and the kit's
+# fallbacks mean none of that announces itself. Advisory: it never changes the verdict above.
+# doctor has already cd'd into the project, so the installed copy is the one to run; fall back to the copy
+# sitting beside this script for the case where doctor is run straight out of the kit source.
+PREFLIGHT=".claude/eval/preflight.sh"
+[ -f "$PREFLIGHT" ] || PREFLIGHT="$(dirname "$0")/preflight.sh"
+[ -f "$PREFLIGHT" ] && bash "$PREFLIGHT"
+
 echo "Readiness (advisory — does not affect the verdict above):"
 RDY=0; RTOT=0
 rdy(){ RTOT=$((RTOT+1)); RDY=$((RDY+1)); echo "  ✅ $1"; }

--- a/claude-starter/eval/preflight.sh
+++ b/claude-starter/eval/preflight.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Preflight — name the tools this machine is missing BEFORE they turn into a surprise mid-session.
+#
+# Why this exists. The kit is written to degrade rather than break: no jq -> python -> py -> pure bash for the
+# settings merge, sha256sum -> shasum -> cksum for digests, and so on. That is the right design, and it is also
+# why a missing tool never announces itself — the fallback runs, something is quietly worse, and the user finds
+# out later from a symptom that points somewhere else. A Windows Git Bash install with no jq and no python is
+# the normal case, not the exotic one, and it was where every surprise in this project came from.
+#
+# So: report, do not install. Nothing here writes to the machine or blocks a run. The user asked for exactly
+# that boundary — a scaffolding tool that silently installs software on someone's workstation is a worse problem
+# than the one it solves, and on a managed corporate machine it simply fails in a new way.
+#
+# Called from start.sh and adopt.sh (before the install summary) and from doctor.sh (so it stays re-runnable).
+#   bash preflight.sh            # human-readable report, always exit 0
+#   bash preflight.sh --quiet    # print only what is missing; exit 1 if any REQUIRED tool is absent
+set -uo pipefail
+
+QUIET=0
+case "${1:-}" in --quiet|-q) QUIET=1 ;; esac
+
+B=""; D=""; R=""; YE=""; GR=""
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then B=$'\033[1m'; D=$'\033[2m'; R=$'\033[0m'; YE=$'\033[33m'; GR=$'\033[32m'; fi
+
+MISSING_REQ=""; MISSING_OPT=""
+
+have(){ command -v "$1" >/dev/null 2>&1; }
+# any_of "label" "why it matters" "fix hint" cmd...
+any_of(){
+  label="$1"; why="$2"; fix="$3"; shift 3
+  found=""
+  for c in "$@"; do have "$c" && { found="$c"; break; }; done
+  if [ -n "$found" ]; then
+    [ "$QUIET" = 1 ] || printf '  %s✓%s %-22s %s%s%s\n' "$GR" "$R" "$label" "$D" "$found" "$R"
+    return 0
+  fi
+  printf '  %s✗%s %-22s %s\n' "$YE" "$R" "$label" "$why"
+  printf '      %sfix: %s%s\n' "$D" "$fix" "$R"
+  return 1
+}
+
+[ "$QUIET" = 1 ] || printf '\n  %sPreflight — what this machine has%s\n' "$B" "$R"
+
+# --- REQUIRED: without these the kit does not work at all -------------------------------------------------
+any_of "bash" "the whole kit is bash" \
+  "Windows: install Git for Windows (git-scm.com) and run from Git Bash" bash || MISSING_REQ="$MISSING_REQ bash"
+any_of "awk" "context measurement, routing, doctor" \
+  "Windows: ships with Git Bash · macOS: preinstalled · Linux: apt install gawk" awk gawk mawk || MISSING_REQ="$MISSING_REQ awk"
+any_of "git" "the commit-time trace/secret gates are git hooks" \
+  "git-scm.com · macOS: xcode-select --install · Linux: apt install git" git || MISSING_REQ="$MISSING_REQ git"
+
+# --- OPTIONAL: the kit falls back, but the fallback is worse in a way worth knowing about ------------------
+# jq/python are only needed to MERGE an existing settings.json on update. The pure-bash path replaces the file
+# instead (keeping a backup), which is safe but loses hooks the project added itself — the sort of thing that
+# is obvious in advance and baffling afterwards.
+any_of "jq or python" "settings merge on update falls back to replace+backup (a project's OWN custom hooks are not preserved)" \
+  "Windows: winget install jqlang.jq · macOS: brew install jq · Linux: apt install jq" jq python3 python py \
+  || MISSING_OPT="$MISSING_OPT jq/python"
+any_of "sha256 tool" "the skill-trust gate falls back to cksum (catches accidental edits, not crafted ones)" \
+  "Windows/Linux: coreutils (sha256sum) · macOS: shasum is preinstalled" sha256sum shasum || MISSING_OPT="$MISSING_OPT sha256"
+
+if [ -n "$MISSING_REQ" ]; then
+  printf '\n  %sMissing REQUIRED:%s%s — install these first; the kit will not work without them.\n' "$YE$B" "$R" "$MISSING_REQ"
+elif [ -n "$MISSING_OPT" ]; then
+  [ "$QUIET" = 1 ] || printf '\n  %sAll required tools present.%s Optional gaps above are safe but worth closing.\n' "$GR" "$R"
+else
+  [ "$QUIET" = 1 ] || printf '\n  %sEverything the kit wants is here.%s\n' "$GR" "$R"
+fi
+
+# Report-only by design: a missing OPTIONAL tool never fails. `--quiet` exits non-zero only for REQUIRED gaps,
+# so a caller can branch on it without having to parse this output.
+[ "$QUIET" = 1 ] && [ -n "$MISSING_REQ" ] && exit 1
+exit 0

--- a/claude-starter/eval/preflight.sh
+++ b/claude-starter/eval/preflight.sh
@@ -42,8 +42,14 @@ any_of(){
 [ "$QUIET" = 1 ] || printf '\n  %sPreflight — what this machine has%s\n' "$B" "$R"
 
 # --- REQUIRED: without these the kit does not work at all -------------------------------------------------
+# Hooks are wired in SHELL form on purpose, and `bash` is resolved by the shell Claude Code already runs them
+# in — not off the Windows PATH. That distinction is not academic. On a Windows box checked during this work,
+# `where bash` answered `C:\Windows\System32\bash.exe`, which is not Git Bash at all: it is the WSL launcher,
+# living in a filesystem namespace where `C:\Repos\app` does not exist (`/mnt/c/Repos/app` does). A wiring that
+# spawns `bash` by PATH name would have run THAT, or failed outright where WSL is not installed — every gate
+# gone, with an error pointing nowhere near the cause. Hence shell form, and hence this note.
 any_of "bash" "the whole kit is bash" \
-  "Windows: install Git for Windows (git-scm.com) and run from Git Bash" bash || MISSING_REQ="$MISSING_REQ bash"
+  "Windows: install Git for Windows (git-scm.com) and run Claude Code from Git Bash" bash || MISSING_REQ="$MISSING_REQ bash"
 any_of "awk" "context measurement, routing, doctor" \
   "Windows: ships with Git Bash · macOS: preinstalled · Linux: apt install gawk" awk gawk mawk || MISSING_REQ="$MISSING_REQ awk"
 any_of "git" "the commit-time trace/secret gates are git hooks" \

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -720,6 +720,28 @@ case "$o" in *"kit updated"*) fail "stale gate leaked into the Stop payload" ;; 
 rm -f "$SD/VERSION"; run_cu >/dev/null 2>&1 && pass "stale gate: fails open when VERSION is absent" || fail "stale gate exited non-zero without VERSION"
 rm -rf "$SD"; rm -f "$SDFX" "${TMPDIR:-/tmp}/csk-kit-version.$SDSID"
 
+echo "== 6g2) stale-WIRING gate: a session resumed across a kit update runs the old hooks =="
+# Measured on Windows: settings.json on disk had already been corrected and `--resume` still produced the error
+# naming the OLD, mangled hook path, while the same event in a fresh session was clean. So a resumed session
+# keeps the wiring it started with — and on the release that fixed that path, "the wiring it started with" means
+# the broken one. A hook cannot report its own absence, so this catches the other half: hooks that DO run, but
+# not the way the file on disk says they should. `$0` is the evidence — the kit wires `bash .claude/hooks/<n>.sh`,
+# so a correctly-launched hook sees a relative `$0` and anything else came from a different settings.json.
+SWD="$(mktemp -d)"; mkdir -p "$SWD/.claude/hooks"
+cp "$HOOKS/context-usage.sh" "$SWD/.claude/hooks/"; cp "$ROOT/settings.json" "$SWD/.claude/"
+printf '%s\n' '{"type":"assistant","isSidechain":false,"message":{"usage":{"input_tokens":0,"cache_read_input_tokens":300000,"cache_creation_input_tokens":0}}}' > "$SWD/t.jsonl"
+swp(){ printf '{"hook_event_name":"UserPromptSubmit","session_id":"sw-%s","transcript_path":"%s/t.jsonl"}' "$$" "$SWD"; }
+o="$( cd "$SWD" && swp | CONTEXT_WINDOW=1000000 bash .claude/hooks/context-usage.sh 2>/dev/null )"
+case "$o" in *"OLDER hook wiring"*) fail "stale-wiring gate warned on a correctly-launched hook (relative \$0)" ;; *) pass "stale-wiring: silent when \$0 matches the wiring on disk" ;; esac
+rm -f "${TMPDIR:-/tmp}/csk-kit-version.sw-$$"
+o="$( cd "$SWD" && swp | CONTEXT_WINDOW=1000000 bash "$SWD/.claude/hooks/context-usage.sh" 2>/dev/null )"
+case "$o" in *"OLDER hook wiring"*) pass "stale-wiring: warns when the hook was launched some other way (resumed session)" ;; *) fail "stale-wiring gate stayed silent on a hook launched outside the wiring on disk" ;; esac
+# Fails open where the project rewired its hooks by hand — warning every turn about something it chose is noise.
+rm -f "${TMPDIR:-/tmp}/csk-kit-version.sw-$$"; mv "$SWD/.claude/settings.json" "$SWD/.claude/settings.off"
+o="$( cd "$SWD" && swp | CONTEXT_WINDOW=1000000 bash "$SWD/.claude/hooks/context-usage.sh" 2>/dev/null )"
+case "$o" in *"OLDER hook wiring"*) fail "stale-wiring gate fired without a kit settings.json to compare against" ;; *) pass "stale-wiring: silent when settings.json is absent or hand-rewired" ;; esac
+rm -rf "$SWD"; rm -f "${TMPDIR:-/tmp}/csk-kit-version.sw-$$"
+
 echo "== 6f) always-on token budget =="
 # Everything below is loaded into EVERY session's context (and, when Claude spawns one, into a subagent's).
 # Measured with a real `claude -p` turn: 21804 bytes of always-on material cost 9198 tokens. Bytes are a proxy
@@ -1084,6 +1106,33 @@ if command -v jq >/dev/null 2>&1; then printf '%s' "$o" | jq empty 2>/dev/null &
 rm -rf "$RHD"
 grep -q 'SessionStart' "$ROOT/settings.json" && grep -q 'session-rehydrate.sh' "$ROOT/settings.json" \
   && pass "settings.json wires SessionStart -> session-rehydrate.sh" || fail "settings.json missing SessionStart -> session-rehydrate wiring"
+
+# No `${CLAUDE_PROJECT_DIR}` anywhere in the wiring. Claude Code substitutes that placeholder into the command
+# string before a shell sees it, and on Windows the separators do not survive the trip: the value `C:\Repos\app`
+# reached bash as `C:ReposApp`, so NO hook launched and every gate was silently absent while the file looked
+# right. The kit uses a relative path (hooks run in the project directory) with a `cd` off the BARE
+# `$CLAUDE_PROJECT_DIR` as a belt for a session started in a subdirectory — bare `$VAR` is not the placeholder
+# syntax, so it survives to the shell. This case is the regression guard for the whole class.
+if grep -q '\${CLAUDE_PROJECT_DIR' "$ROOT/settings.json"; then
+  fail "settings.json wires hooks through the \${CLAUDE_PROJECT_DIR} placeholder — Windows strips its separators before bash runs and every hook silently fails to launch"
+else
+  pass "hook wiring carries no path placeholder (nothing for Windows to mangle)"
+fi
+# ...and the belt is actually there: a relative path alone breaks if the session started in a subdirectory.
+# Matched on the raw file, where JSON has escaped the quotes as \" — hence the loose pattern rather than the
+# literal command text.
+grep -q 'cd .*\$CLAUDE_PROJECT_DIR' "$ROOT/settings.json" \
+  && pass "hook wiring cd's to the project dir first (bare \$VAR, expanded by the shell)" \
+  || fail "hook wiring lost the 'cd \"\$CLAUDE_PROJECT_DIR\"' belt — a session started in a subdirectory finds no hooks"
+# The exec-form trap, recorded so it is not walked into again: exec form spawns `command` off the PATH with no
+# shell, and on a Windows box checked during this work `where bash` answered C:\Windows\System32\bash.exe — the
+# WSL launcher, not Git Bash, in a namespace where C:\Repos\app does not exist. Wiring `"command": "bash"` would
+# have run that (or failed where WSL is absent), taking every gate with it.
+if command -v jq >/dev/null 2>&1; then
+  jq -e '[.hooks[][].hooks[]? | select((.args // []) | length > 0)] | length == 0' "$ROOT/settings.json" >/dev/null 2>&1 \
+    && pass "no exec-form hook (bare 'bash' on Windows PATH resolves to WSL, not Git Bash)" \
+    || fail "a hook uses exec form — on Windows 'bash' off the PATH is System32/bash.exe (WSL), so every gate dies"
+fi
 
 echo "== 7d) plugin gate hooks shipped (P1) =="
 PLUGIN="$(cd "$ROOT/.." && pwd)/plugin"

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -388,14 +388,23 @@ printf '%s\n' '{"type":"assistant","isSidechain":false,"message":{"usage":{"inpu
 # The fixture was wrong, not necessarily the hooks; a case that only holds on the platform it was not written
 # for proves nothing about the platform it was.
 WPD_FWD="${WPD//\\//}"
-# Build the JSON exactly as a Windows client would: every separator doubled inside the string value.
+# ONE encoder, used by the payload builder AND by the round-trip check below. They were separate at first and
+# promptly drifted: the builder emitted FOUR backslashes per separator instead of two, the checker emitted two,
+# so the checker passed while the payload was malformed. macOS hid it — decoding `\\\\` leaves `//`, which POSIX
+# collapses — and windows-latest did not, because a leading `//` there is a UNC network path. Two implementations
+# of the same rule is one too many.
+wenc(){ printf '%s' "$1" | sed 's#/#\\\\#g'; }     # one separator -> the two backslashes JSON puts in the wire
 wjson(){ printf '{"hook_event_name":"%s","session_id":"wintest","transcript_path":"%s","cwd":"%s"}' \
-  "$1" "$(printf '%s' "$WPD_FWD/t.jsonl" | sed 's#/#\\\\\\\\#g')" "$(printf '%s' "$WPD_FWD" | sed 's#/#\\\\\\\\#g')"; }
-# Sanity: the fixture really is escaped, or these cases prove nothing.
-case "$(wjson UserPromptSubmit)" in *'\\\\'*) pass "windows fixture carries JSON-escaped separators" ;; *) fail "windows fixture is not escaped — the cases below are vacuous" ;; esac
+  "$1" "$(wenc "$WPD_FWD/t.jsonl")" "$(wenc "$WPD_FWD")"; }
+# Sanity: exactly the doubled form, not more. `\\\\` in the payload is the bug this fixture kept reintroducing.
+case "$(wjson UserPromptSubmit)" in
+  *'\\\\'*) fail "windows fixture over-escapes (four backslashes per separator) — it decodes to // and only POSIX forgives that" ;;
+  *'\\'*)   pass "windows fixture carries JSON-escaped separators" ;;
+  *)        fail "windows fixture is not escaped — the cases below are vacuous" ;;
+esac
 # ...and it must decode back to a file that exists, or a failure below says nothing about the decoder. This
 # check is why the next CI failure will be readable instead of a silent `<silence>`.
-WDEC="$(printf '%s' "$WPD_FWD/t.jsonl" | sed 's#/#\\\\#g')"; WDEC="${WDEC//\\\\//}"
+WDEC="$(wenc "$WPD_FWD/t.jsonl")"; WDEC="${WDEC//\\\\//}"
 [ -f "$WDEC" ] && pass "windows fixture decodes back to the real file" \
   || fail "windows fixture does not round-trip: raw='$WPD' fwd='$WPD_FWD' decoded='$WDEC' — fix the fixture before reading the cases below"
 # Honest scope: of the three hooks below only context-usage was actually broken. session-rehydrate and

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -382,18 +382,29 @@ echo "== 6i2) hook paths survive a WINDOWS stdin payload (JSON-escaped backslash
 # `\\` as part of a directory name.
 WPD="$(mktemp -d)"; mkdir -p "$WPD/docs" "$WPD/.claude/skills/mine" "$WPD/.claude/agents"
 printf '%s\n' '{"type":"assistant","isSidechain":false,"message":{"usage":{"input_tokens":1000,"cache_read_input_tokens":300000,"cache_creation_input_tokens":0}}}' > "$WPD/t.jsonl"
+# The encoder assumes forward separators, so normalise FIRST. On a Windows runner TMPDIR is a native path, so
+# `mktemp -d` already answers with backslashes — encoding that produced a mixed string that was neither the
+# POSIX nor the JSON shape, and all three cases below failed on windows-latest while passing everywhere else.
+# The fixture was wrong, not necessarily the hooks; a case that only holds on the platform it was not written
+# for proves nothing about the platform it was.
+WPD_FWD="${WPD//\\//}"
 # Build the JSON exactly as a Windows client would: every separator doubled inside the string value.
 wjson(){ printf '{"hook_event_name":"%s","session_id":"wintest","transcript_path":"%s","cwd":"%s"}' \
-  "$1" "$(printf '%s' "$WPD/t.jsonl" | sed 's#/#\\\\\\\\#g')" "$(printf '%s' "$WPD" | sed 's#/#\\\\\\\\#g')"; }
+  "$1" "$(printf '%s' "$WPD_FWD/t.jsonl" | sed 's#/#\\\\\\\\#g')" "$(printf '%s' "$WPD_FWD" | sed 's#/#\\\\\\\\#g')"; }
 # Sanity: the fixture really is escaped, or these cases prove nothing.
 case "$(wjson UserPromptSubmit)" in *'\\\\'*) pass "windows fixture carries JSON-escaped separators" ;; *) fail "windows fixture is not escaped — the cases below are vacuous" ;; esac
+# ...and it must decode back to a file that exists, or a failure below says nothing about the decoder. This
+# check is why the next CI failure will be readable instead of a silent `<silence>`.
+WDEC="$(printf '%s' "$WPD_FWD/t.jsonl" | sed 's#/#\\\\#g')"; WDEC="${WDEC//\\\\//}"
+[ -f "$WDEC" ] && pass "windows fixture decodes back to the real file" \
+  || fail "windows fixture does not round-trip: raw='$WPD' fwd='$WPD_FWD' decoded='$WDEC' — fix the fixture before reading the cases below"
 # Honest scope: of the three hooks below only context-usage was actually broken. session-rehydrate and
 # skill-trust already folded lone backslashes (2.0.1), and folding each half of a doubled `\\` yields `//`,
 # which the OS collapses — so they survived the encoded form by accident rather than by design. Their cases
 # here are regression guards, not bug reproductions; the discriminating case is context-usage, which did no
 # folding at all and therefore compared a literal `\\`-bearing string against the filesystem on every turn.
 o="$(wjson UserPromptSubmit | CONTEXT_WINDOW=1000000 bash "$HOOKS/context-usage.sh" 2>/dev/null)"
-case "$o" in *"🔋"*) pass "context-usage decodes a JSON-escaped transcript_path" ;; *) fail "context-usage could not read a Windows-shaped transcript_path (got: ${o:-<silence>})" ;; esac
+case "$o" in *"🔋"*) pass "context-usage decodes a JSON-escaped transcript_path" ;; *) fail "context-usage could not read a Windows-shaped transcript_path (got: ${o:-<silence>}) · payload was: $(wjson UserPromptSubmit)" ;; esac
 # No transcript at all, delivered as a hook payload: silent AND exit 0, because a non-zero status here is an
 # error banner in the user's session once per turn, for a condition the discipline already handles.
 o="$(printf '{"hook_event_name":"UserPromptSubmit","session_id":"wintest2","transcript_path":"/no/such/x.jsonl"}' | bash "$HOOKS/context-usage.sh" 2>&1)"; rc=$?
@@ -403,11 +414,11 @@ o="$(printf '{"hook_event_name":"UserPromptSubmit","session_id":"wintest2","tran
 if bash "$HOOKS/context-usage.sh" "/no/such/x.jsonl" >/dev/null 2>&1; then fail "by-hand bad path returned exit 0"; else pass "by-hand bad path still exits non-zero"; fi
 printf 'HANDOVER\n\n## Next\n- keep going\n' > "$WPD/docs/SESSION_STATE.md"
 o="$(wjson SessionStart | CLAUDE_PROJECT_DIR= bash "$HOOKS/session-rehydrate.sh" 2>/dev/null)"
-case "$o" in *SESSION_STATE*) pass "session-rehydrate decodes a JSON-escaped cwd" ;; *) fail "session-rehydrate could not resolve a Windows-shaped cwd (got: ${o:-<silence>})" ;; esac
+case "$o" in *SESSION_STATE*) pass "session-rehydrate decodes a JSON-escaped cwd" ;; *) fail "session-rehydrate could not resolve a Windows-shaped cwd (got: ${o:-<silence>}) · payload was: $(wjson SessionStart)" ;; esac
 printf 'skills/handoff\n' > "$WPD/.claude/kit-manifest.txt"
 printf -- '---\nname: mine\n---\nProject rules.\n' > "$WPD/.claude/skills/mine/SKILL.md"
 o="$(wjson SessionStart | CLAUDE_PROJECT_DIR= bash "$HOOKS/skill-trust.sh" 2>/dev/null)"
-case "$o" in *skills/mine*) pass "skill-trust decodes a JSON-escaped cwd (the notice still notices)" ;; *) fail "skill-trust could not resolve a Windows-shaped cwd — the gate is inert there" ;; esac
+case "$o" in *skills/mine*) pass "skill-trust decodes a JSON-escaped cwd (the notice still notices)" ;; *) fail "skill-trust could not resolve a Windows-shaped cwd — the gate is inert there · payload was: $(wjson SessionStart)" ;; esac
 rm -rf "$WPD"
 
 echo "== 6j) session-stats: evidence signals read off the transcript =="

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -369,6 +369,47 @@ grep -q 'tail -n' "$HOOKS/context-usage.sh" && pass "transcript is read through 
   || fail "context-usage.sh no longer bounds its read — the whole transcript is scanned every turn"
 rm -rf "$CUD" "$CUJX"
 
+echo "== 6i2) hook paths survive a WINDOWS stdin payload (JSON-escaped backslashes) =="
+# The paths a hook receives on stdin are JSON values, and JSON escapes a backslash as two. So on Windows the
+# real path C:\Users\me\a.jsonl arrives as "C:\\Users\\me\\a.jsonl", and a sed slice hands back the doubled
+# form — a string that names no file on any platform. Every consumer then failed the same quiet way:
+# context-usage reported "transcript not found" on every turn (Windows CLI and Claude Desktop alike),
+# session-rehydrate rehydrated nothing, and the skill-trust security notice stopped noticing. Nothing in the
+# suite caught it because every fixture here writes POSIX paths, where the escaping never appears.
+#
+# These cases feed the REAL hooks a payload shaped the way Windows shapes it, with the file actually present at
+# the unescaped location. Passing means the path was decoded; failing means we are back to reading a literal
+# `\\` as part of a directory name.
+WPD="$(mktemp -d)"; mkdir -p "$WPD/docs" "$WPD/.claude/skills/mine" "$WPD/.claude/agents"
+printf '%s\n' '{"type":"assistant","isSidechain":false,"message":{"usage":{"input_tokens":1000,"cache_read_input_tokens":300000,"cache_creation_input_tokens":0}}}' > "$WPD/t.jsonl"
+# Build the JSON exactly as a Windows client would: every separator doubled inside the string value.
+wjson(){ printf '{"hook_event_name":"%s","session_id":"wintest","transcript_path":"%s","cwd":"%s"}' \
+  "$1" "$(printf '%s' "$WPD/t.jsonl" | sed 's#/#\\\\\\\\#g')" "$(printf '%s' "$WPD" | sed 's#/#\\\\\\\\#g')"; }
+# Sanity: the fixture really is escaped, or these cases prove nothing.
+case "$(wjson UserPromptSubmit)" in *'\\\\'*) pass "windows fixture carries JSON-escaped separators" ;; *) fail "windows fixture is not escaped — the cases below are vacuous" ;; esac
+# Honest scope: of the three hooks below only context-usage was actually broken. session-rehydrate and
+# skill-trust already folded lone backslashes (2.0.1), and folding each half of a doubled `\\` yields `//`,
+# which the OS collapses — so they survived the encoded form by accident rather than by design. Their cases
+# here are regression guards, not bug reproductions; the discriminating case is context-usage, which did no
+# folding at all and therefore compared a literal `\\`-bearing string against the filesystem on every turn.
+o="$(wjson UserPromptSubmit | CONTEXT_WINDOW=1000000 bash "$HOOKS/context-usage.sh" 2>/dev/null)"
+case "$o" in *"🔋"*) pass "context-usage decodes a JSON-escaped transcript_path" ;; *) fail "context-usage could not read a Windows-shaped transcript_path (got: ${o:-<silence>})" ;; esac
+# No transcript at all, delivered as a hook payload: silent AND exit 0, because a non-zero status here is an
+# error banner in the user's session once per turn, for a condition the discipline already handles.
+o="$(printf '{"hook_event_name":"UserPromptSubmit","session_id":"wintest2","transcript_path":"/no/such/x.jsonl"}' | bash "$HOOKS/context-usage.sh" 2>&1)"; rc=$?
+[ "$rc" = 0 ] && [ -z "$o" ] && pass "unmeasurable hook payload -> silent, exit 0 (no per-turn error banner)" \
+  || fail "unmeasurable hook payload should be silent+0, got rc=$rc out='$o'"
+# ...while a by-hand call with a bad argument still complains and exits non-zero (that is a human's mistake).
+if bash "$HOOKS/context-usage.sh" "/no/such/x.jsonl" >/dev/null 2>&1; then fail "by-hand bad path returned exit 0"; else pass "by-hand bad path still exits non-zero"; fi
+printf 'HANDOVER\n\n## Next\n- keep going\n' > "$WPD/docs/SESSION_STATE.md"
+o="$(wjson SessionStart | CLAUDE_PROJECT_DIR= bash "$HOOKS/session-rehydrate.sh" 2>/dev/null)"
+case "$o" in *SESSION_STATE*) pass "session-rehydrate decodes a JSON-escaped cwd" ;; *) fail "session-rehydrate could not resolve a Windows-shaped cwd (got: ${o:-<silence>})" ;; esac
+printf 'skills/handoff\n' > "$WPD/.claude/kit-manifest.txt"
+printf -- '---\nname: mine\n---\nProject rules.\n' > "$WPD/.claude/skills/mine/SKILL.md"
+o="$(wjson SessionStart | CLAUDE_PROJECT_DIR= bash "$HOOKS/skill-trust.sh" 2>/dev/null)"
+case "$o" in *skills/mine*) pass "skill-trust decodes a JSON-escaped cwd (the notice still notices)" ;; *) fail "skill-trust could not resolve a Windows-shaped cwd — the gate is inert there" ;; esac
+rm -rf "$WPD"
+
 echo "== 6j) session-stats: evidence signals read off the transcript =="
 [ -x "$HOOKS/session-stats.sh" ] && pass "session-stats.sh +x" || fail "session-stats.sh missing/not executable"
 SSD="$(mktemp -d)"; SSF="$SSD/t.jsonl"

--- a/claude-starter/hooks/context-usage.sh
+++ b/claude-starter/hooks/context-usage.sh
@@ -119,7 +119,14 @@ if [ -z "$TOTAL" ]; then
   CAP="${CSK_CONTEXT_MAX_BYTES:-209715200}"         # 200 MiB; override per-repo
   [ "${SZ:-0}" -le "$CAP" ] && TOTAL="$(scan < "$TR")"
 fi
-[ -n "${TOTAL:-}" ] || { echo "context-usage: usage not found in the byte-bounded window (transcript too large to scan within the hook timeout)" >&2; exit 1; }
+# Same split as the missing-transcript case above: a hook stays quiet and exits 0, a by-hand call explains
+# itself and exits non-zero. Exec-form hook commands carry no `|| true` to swallow a status, so anything that
+# exits non-zero here becomes an error banner in the user's session once per turn.
+if [ -z "${TOTAL:-}" ]; then
+  [ -n "$IN" ] && exit 0
+  echo "context-usage: usage not found in the byte-bounded window (transcript too large to scan within the hook timeout)" >&2
+  exit 1
+fi
 
 # LC_ALL=C: force a '.' decimal separator regardless of locale (tr_TR etc. would emit '77,2' and could
 # mis-parse the percentage). Generation AND every comparison below run under C so they stay consistent.
@@ -145,6 +152,30 @@ fi
 # Only meaningful on the UserPromptSubmit call: session-guard.sh pipes a Stop payload through this same
 # script, and a by-hand run has no stdin at all. Fails open — no stdin, no session_id, no VERSION: silent.
 case "$IN" in *'"hook_event_name"'*UserPromptSubmit*) ;; *) exit 0 ;; esac
+
+# --- Stale-WIRING gate -------------------------------------------------------------------------------
+# A resumed session keeps the hook wiring it was started with. Measured on Windows: settings.json on disk had
+# already been corrected, and `--resume` still produced the error naming the OLD, mangled path — while the same
+# event under a fresh session was clean. So after a kit update, `--resume` carries the previous wiring, and on
+# the release that fixed the Windows path that means the gates are still the broken ones.
+#
+# The obvious gate cannot work: a hook cannot report its own absence, and under the old wiring on Windows NO
+# hook launched at all. What this catches is the other half — a session where the hooks DO run, but not the way
+# the file on disk says they should. `$0` is the evidence: the kit wires `bash .claude/hooks/<name>.sh`, so a
+# correctly-launched hook sees a relative `$0`. Anything else means this session was launched from a different
+# settings.json than the one now on disk.
+#
+# Silent unless settings.json actually carries the kit's current shape — a project that rewired its hooks by
+# hand is not wrong, and warning it every turn would be noise it cannot fix.
+CSKSET="$HERE/../settings.json"
+if [ -f "$CSKSET" ] && grep -q 'bash \.claude/hooks/context-usage\.sh' "$CSKSET" 2>/dev/null; then
+  case "$0" in
+    .claude/hooks/*) ;;                         # launched exactly as the file on disk wires it
+    *) echo "⚠️ this session is running OLDER hook wiring than .claude/settings.json on disk (resumed across a kit update). The gates in force are the previous ones — ask the user to quit the CLI and start a NEW session; --resume will not pick up the change." ;;
+  esac
+fi
+
+# --- Stale-discipline gate ---------------------------------------------------------------------------
 KITVER="$HERE/../VERSION"                       # hooks live in .claude/hooks -> .claude/VERSION
 [ -f "$KITVER" ] || exit 0
 NOW="$(head -1 "$KITVER" 2>/dev/null | tr -cd '0-9A-Za-z.-')"

--- a/claude-starter/hooks/context-usage.sh
+++ b/claude-starter/hooks/context-usage.sh
@@ -20,12 +20,24 @@ VERBOSE=0
 case "${1:-}" in --verbose|-v) VERBOSE=1; shift ;; esac
 TR="${1:-}"
 
+# A path that arrived inside the hook's stdin JSON is JSON-ENCODED, and on Windows that matters: the real value
+# `C:\Users\me\.claude\projects\p\a.jsonl` is transmitted as `C:\\Users\\me\\...`. Slicing it out with sed hands
+# back the doubled backslashes verbatim, so every `[ -f "$TR" ]` failed and the hook reported "transcript not
+# found" on every single turn — on Windows CLI and on Claude Desktop alike. It read like the hook was being
+# called without stdin; it was being called correctly and then throwing the answer away.
+#
+# So: undo the JSON escaping, then fold the separators. `\\` -> `/` first (the encoded form), then any lone `\`
+# (a value that was never encoded, e.g. an argument typed by hand). Forward slashes resolve on every platform
+# including Git Bash. A POSIX path contains neither, so this is a no-op there.
+unjson_path(){ p="${1//\\\\//}"; p="${p//\\//}"; printf '%s' "$p"; }
+
 IN=""
 # 1) transcript_path from hook stdin (if present)
 if [ -z "$TR" ] && [ ! -t 0 ]; then
   IN="$(cat 2>/dev/null || true)"
   [ -n "$IN" ] && TR="$(printf '%s' "$IN" | sed -n 's/.*"transcript_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
 fi
+[ -n "$TR" ] && TR="$(unjson_path "$TR")"
 # 2) still missing: find the project transcript dir from pwd (client: / and . -> -)
 if [ -z "$TR" ]; then
   for esc in "$(pwd | sed 's#[/.]#-#g')" "$(pwd | sed 's#/#-#g')"; do
@@ -33,7 +45,21 @@ if [ -z "$TR" ]; then
     [ -n "$cand" ] && { TR="$cand"; break; }
   done
 fi
-[ -n "$TR" ] && [ -f "$TR" ] || { echo "context-usage: transcript not found (pass an arg or use hook stdin)" >&2; exit 1; }
+# Cannot measure. The two call sites want opposite things here, so they get opposite answers.
+#
+# Called BY HAND (a transcript passed as an argument): complain on stderr and exit non-zero. A person who typed a
+# path wants to know it was wrong, and the suite asserts this — "never invent a fill" is checked by watching for
+# a non-zero exit rather than by trusting the absence of output.
+#
+# Called AS A HOOK (payload on stdin, no argument): stay silent and exit 0. Nothing downstream reads the status —
+# session-guard.sh parses the line and falls open without it — while a non-zero exit is a visible error in the
+# user's session, once per turn, for a condition the discipline already handles (no 🔋 line, say so once, drop
+# it). It also stops depending on the `|| true` in the hook command to hide it, which exec-form hooks cannot use.
+if [ -z "$TR" ] || [ ! -f "$TR" ]; then
+  [ -n "$IN" ] && exit 0                          # hook payload on stdin -> quiet
+  echo "context-usage: transcript not found (pass an arg or use hook stdin)" >&2
+  exit 1
+fi
 
 # Sum of usage for the last main-context turn: a non-sidechain ASSISTANT record that has a cache_read.
 #

--- a/claude-starter/hooks/session-rehydrate.sh
+++ b/claude-starter/hooks/session-rehydrate.sh
@@ -22,10 +22,11 @@ if [ -z "$ROOT" ]; then
   ROOT="$(printf '%s' "$IN" | sed -n 's/.*"cwd"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
 fi
 [ -n "$ROOT" ] || ROOT="$PWD"
-# Windows hands both CLAUDE_PROJECT_DIR and the stdin `cwd` over as native paths (`C:\Repos\app`). Appending a
-# POSIX segment to one produces `C:\Repos\app/docs/...`, which Git Bash does not reliably resolve. Folding the
-# backslashes is a no-op everywhere else.
-ROOT="${ROOT//\\//}"
+# Windows hands both CLAUDE_PROJECT_DIR and the stdin `cwd` over as native paths (`C:\Repos\app`), and the stdin
+# one arrives JSON-ENCODED on top of that — `C:\\Repos\\app`. Slicing it out with sed keeps the doubled
+# backslashes, so ROOT pointed at a directory that cannot exist and the hook silently rehydrated nothing.
+# Undo the JSON escaping first (`\\`), then fold any lone separator. Both are no-ops on a POSIX path.
+ROOT="${ROOT//\\\\//}"; ROOT="${ROOT//\\//}"
 
 STATE="$ROOT/docs/SESSION_STATE.md"
 [ -s "$STATE" ] || exit 0   # no (non-empty) handover → nothing to rehydrate, stay silent

--- a/claude-starter/hooks/skill-trust.sh
+++ b/claude-starter/hooks/skill-trust.sh
@@ -29,7 +29,10 @@ IN=""
 ROOT="${CLAUDE_PROJECT_DIR:-}"
 [ -n "$ROOT" ] || ROOT="$(printf '%s' "$IN" | sed -n 's/.*"cwd"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
 [ -n "$ROOT" ] || ROOT="$PWD"
-ROOT="${ROOT//\\//}"                                  # Windows native path -> POSIX separators (no-op elsewhere)
+# The stdin `cwd` is JSON-encoded, so a Windows path arrives as `C:\\Repos\\app`. Undo the escaping, then fold
+# the separators; both are no-ops on POSIX. Without this the trust gate resolved a directory that cannot exist,
+# found no components, and exited silently — a security notice that had quietly stopped noticing.
+ROOT="${ROOT//\\\\//}"; ROOT="${ROOT//\\//}"
 CL="$ROOT/.claude"
 [ -d "$CL" ] || CL="$(cd "$HERE/.." && pwd)"          # invoked from inside the install itself
 [ -d "$CL/skills" ] || [ -d "$CL/agents" ] || exit 0

--- a/claude-starter/settings.json
+++ b/claude-starter/settings.json
@@ -45,12 +45,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PROJECT_DIR//\\\\//}/.claude/hooks/guard-bash.sh\"",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" 2>/dev/null; bash .claude/hooks/guard-bash.sh",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PROJECT_DIR//\\\\//}/.claude/hooks/guard-commit-scan.sh\"",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" 2>/dev/null; bash .claude/hooks/guard-commit-scan.sh",
             "timeout": 60
           }
         ]
@@ -60,7 +60,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PROJECT_DIR//\\\\//}/.claude/hooks/guard-write.sh\"",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" 2>/dev/null; bash .claude/hooks/guard-write.sh",
             "timeout": 60
           }
         ]
@@ -71,12 +71,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PROJECT_DIR//\\\\//}/.claude/hooks/context-usage.sh\" 2>/dev/null || true",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" 2>/dev/null; bash .claude/hooks/context-usage.sh",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PROJECT_DIR//\\\\//}/.claude/hooks/route-hint.sh\" 2>/dev/null || true",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" 2>/dev/null; bash .claude/hooks/route-hint.sh",
             "timeout": 60
           }
         ]
@@ -87,7 +87,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PROJECT_DIR//\\\\//}/.claude/hooks/session-guard.sh\"",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" 2>/dev/null; bash .claude/hooks/session-guard.sh",
             "timeout": 60
           }
         ]
@@ -99,7 +99,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PROJECT_DIR//\\\\//}/.claude/hooks/session-rehydrate.sh\"",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" 2>/dev/null; bash .claude/hooks/session-rehydrate.sh",
             "timeout": 60
           }
         ]
@@ -109,7 +109,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PROJECT_DIR//\\\\//}/.claude/hooks/skill-trust.sh\" 2>/dev/null || true",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" 2>/dev/null; bash .claude/hooks/skill-trust.sh",
             "timeout": 60
           }
         ]

--- a/packaging/build-plugin.sh
+++ b/packaging/build-plugin.sh
@@ -46,29 +46,29 @@ cat > "$OUT/hooks/hooks.json" <<'HOOKS'
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT//\\\\//}/hooks/guard-bash.sh\"", "timeout": 60 },
-          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT//\\\\//}/hooks/guard-commit-scan.sh\"", "timeout": 60 }
+          { "type": "command", "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/guard-bash.sh\"", "timeout": 60 },
+          { "type": "command", "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/guard-commit-scan.sh\"", "timeout": 60 }
         ]
       },
       {
         "matcher": "Write|Edit|MultiEdit|NotebookEdit",
         "hooks": [
-          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT//\\\\//}/hooks/guard-write.sh\"", "timeout": 60 }
+          { "type": "command", "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/guard-write.sh\"", "timeout": 60 }
         ]
       }
     ],
     "UserPromptSubmit": [
       {
         "hooks": [
-          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT//\\\\//}/hooks/context-usage.sh\" 2>/dev/null || true", "timeout": 60 },
-          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT//\\\\//}/hooks/route-hint.sh\" 2>/dev/null || true", "timeout": 60 }
+          { "type": "command", "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/context-usage.sh\"", "timeout": 60 },
+          { "type": "command", "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/route-hint.sh\"", "timeout": 60 }
         ]
       }
     ],
     "Stop": [
       {
         "hooks": [
-          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT//\\\\//}/hooks/session-guard.sh\"", "timeout": 60 }
+          { "type": "command", "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/session-guard.sh\"", "timeout": 60 }
         ]
       }
     ],
@@ -76,7 +76,7 @@ cat > "$OUT/hooks/hooks.json" <<'HOOKS'
       {
         "matcher": "compact|clear|resume",
         "hooks": [
-          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT//\\\\//}/hooks/session-rehydrate.sh\"", "timeout": 60 }
+          { "type": "command", "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/session-rehydrate.sh\"", "timeout": 60 }
         ]
       }
     ]

--- a/packaging/e2e.sh
+++ b/packaging/e2e.sh
@@ -191,7 +191,11 @@ mk_stale_install(){                       # $1 = dir : a healthy 1.4.x install w
 # timeout retune into a red e2e that blames the merge — which is exactly what happened when the hook timeouts
 # moved to 60: the merge was correct and the assertion was stale. The fixture above deliberately carries 10, and
 # the guard below keeps the test honest by refusing to run if the kit ever ships that same value.
-KIT_TO="$(grep -A1 'context-usage\.sh' claude-starter/settings.json | sed -n 's/.*"timeout":[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -1)"
+# Layout-independent: find the line naming the script, then take the FIRST "timeout" after it. A fixed `grep -A1`
+# was tied to the shell-form shape and went blank the moment hooks moved to exec form, where the path sits inside
+# an `args` array and the timeout is several lines further down. The guard below caught that rather than letting
+# the assertions quietly pass on an empty value — which is the whole reason it is there.
+KIT_TO="$(awk '/context-usage\.sh/{f=1} f && /"timeout"/{gsub(/[^0-9]/,""); print; exit}' claude-starter/settings.json)"
 [ -n "$KIT_TO" ] && [ "$KIT_TO" != 10 ] || { echo "FAIL: could not read the kit's UserPromptSubmit timeout (got '${KIT_TO:-}') — the stale-vs-refreshed assertions below would prove nothing"; exit 1; }
 # (A) update · non-interactive · NO --yes -> APPLIES (self-heal): stale hook refreshed, SessionStart wired, CLAUDE.md kept
 U="$WORK/selfheal"; mk_stale_install "$U"

--- a/plugin/hooks/context-usage.sh
+++ b/plugin/hooks/context-usage.sh
@@ -119,7 +119,14 @@ if [ -z "$TOTAL" ]; then
   CAP="${CSK_CONTEXT_MAX_BYTES:-209715200}"         # 200 MiB; override per-repo
   [ "${SZ:-0}" -le "$CAP" ] && TOTAL="$(scan < "$TR")"
 fi
-[ -n "${TOTAL:-}" ] || { echo "context-usage: usage not found in the byte-bounded window (transcript too large to scan within the hook timeout)" >&2; exit 1; }
+# Same split as the missing-transcript case above: a hook stays quiet and exits 0, a by-hand call explains
+# itself and exits non-zero. Exec-form hook commands carry no `|| true` to swallow a status, so anything that
+# exits non-zero here becomes an error banner in the user's session once per turn.
+if [ -z "${TOTAL:-}" ]; then
+  [ -n "$IN" ] && exit 0
+  echo "context-usage: usage not found in the byte-bounded window (transcript too large to scan within the hook timeout)" >&2
+  exit 1
+fi
 
 # LC_ALL=C: force a '.' decimal separator regardless of locale (tr_TR etc. would emit '77,2' and could
 # mis-parse the percentage). Generation AND every comparison below run under C so they stay consistent.
@@ -145,6 +152,30 @@ fi
 # Only meaningful on the UserPromptSubmit call: session-guard.sh pipes a Stop payload through this same
 # script, and a by-hand run has no stdin at all. Fails open — no stdin, no session_id, no VERSION: silent.
 case "$IN" in *'"hook_event_name"'*UserPromptSubmit*) ;; *) exit 0 ;; esac
+
+# --- Stale-WIRING gate -------------------------------------------------------------------------------
+# A resumed session keeps the hook wiring it was started with. Measured on Windows: settings.json on disk had
+# already been corrected, and `--resume` still produced the error naming the OLD, mangled path — while the same
+# event under a fresh session was clean. So after a kit update, `--resume` carries the previous wiring, and on
+# the release that fixed the Windows path that means the gates are still the broken ones.
+#
+# The obvious gate cannot work: a hook cannot report its own absence, and under the old wiring on Windows NO
+# hook launched at all. What this catches is the other half — a session where the hooks DO run, but not the way
+# the file on disk says they should. `$0` is the evidence: the kit wires `bash .claude/hooks/<name>.sh`, so a
+# correctly-launched hook sees a relative `$0`. Anything else means this session was launched from a different
+# settings.json than the one now on disk.
+#
+# Silent unless settings.json actually carries the kit's current shape — a project that rewired its hooks by
+# hand is not wrong, and warning it every turn would be noise it cannot fix.
+CSKSET="$HERE/../settings.json"
+if [ -f "$CSKSET" ] && grep -q 'bash \.claude/hooks/context-usage\.sh' "$CSKSET" 2>/dev/null; then
+  case "$0" in
+    .claude/hooks/*) ;;                         # launched exactly as the file on disk wires it
+    *) echo "⚠️ this session is running OLDER hook wiring than .claude/settings.json on disk (resumed across a kit update). The gates in force are the previous ones — ask the user to quit the CLI and start a NEW session; --resume will not pick up the change." ;;
+  esac
+fi
+
+# --- Stale-discipline gate ---------------------------------------------------------------------------
 KITVER="$HERE/../VERSION"                       # hooks live in .claude/hooks -> .claude/VERSION
 [ -f "$KITVER" ] || exit 0
 NOW="$(head -1 "$KITVER" 2>/dev/null | tr -cd '0-9A-Za-z.-')"

--- a/plugin/hooks/context-usage.sh
+++ b/plugin/hooks/context-usage.sh
@@ -20,12 +20,24 @@ VERBOSE=0
 case "${1:-}" in --verbose|-v) VERBOSE=1; shift ;; esac
 TR="${1:-}"
 
+# A path that arrived inside the hook's stdin JSON is JSON-ENCODED, and on Windows that matters: the real value
+# `C:\Users\me\.claude\projects\p\a.jsonl` is transmitted as `C:\\Users\\me\\...`. Slicing it out with sed hands
+# back the doubled backslashes verbatim, so every `[ -f "$TR" ]` failed and the hook reported "transcript not
+# found" on every single turn — on Windows CLI and on Claude Desktop alike. It read like the hook was being
+# called without stdin; it was being called correctly and then throwing the answer away.
+#
+# So: undo the JSON escaping, then fold the separators. `\\` -> `/` first (the encoded form), then any lone `\`
+# (a value that was never encoded, e.g. an argument typed by hand). Forward slashes resolve on every platform
+# including Git Bash. A POSIX path contains neither, so this is a no-op there.
+unjson_path(){ p="${1//\\\\//}"; p="${p//\\//}"; printf '%s' "$p"; }
+
 IN=""
 # 1) transcript_path from hook stdin (if present)
 if [ -z "$TR" ] && [ ! -t 0 ]; then
   IN="$(cat 2>/dev/null || true)"
   [ -n "$IN" ] && TR="$(printf '%s' "$IN" | sed -n 's/.*"transcript_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
 fi
+[ -n "$TR" ] && TR="$(unjson_path "$TR")"
 # 2) still missing: find the project transcript dir from pwd (client: / and . -> -)
 if [ -z "$TR" ]; then
   for esc in "$(pwd | sed 's#[/.]#-#g')" "$(pwd | sed 's#/#-#g')"; do
@@ -33,7 +45,21 @@ if [ -z "$TR" ]; then
     [ -n "$cand" ] && { TR="$cand"; break; }
   done
 fi
-[ -n "$TR" ] && [ -f "$TR" ] || { echo "context-usage: transcript not found (pass an arg or use hook stdin)" >&2; exit 1; }
+# Cannot measure. The two call sites want opposite things here, so they get opposite answers.
+#
+# Called BY HAND (a transcript passed as an argument): complain on stderr and exit non-zero. A person who typed a
+# path wants to know it was wrong, and the suite asserts this — "never invent a fill" is checked by watching for
+# a non-zero exit rather than by trusting the absence of output.
+#
+# Called AS A HOOK (payload on stdin, no argument): stay silent and exit 0. Nothing downstream reads the status —
+# session-guard.sh parses the line and falls open without it — while a non-zero exit is a visible error in the
+# user's session, once per turn, for a condition the discipline already handles (no 🔋 line, say so once, drop
+# it). It also stops depending on the `|| true` in the hook command to hide it, which exec-form hooks cannot use.
+if [ -z "$TR" ] || [ ! -f "$TR" ]; then
+  [ -n "$IN" ] && exit 0                          # hook payload on stdin -> quiet
+  echo "context-usage: transcript not found (pass an arg or use hook stdin)" >&2
+  exit 1
+fi
 
 # Sum of usage for the last main-context turn: a non-sidechain ASSISTANT record that has a cache_read.
 #

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -4,29 +4,29 @@
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT//\\\\//}/hooks/guard-bash.sh\"", "timeout": 60 },
-          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT//\\\\//}/hooks/guard-commit-scan.sh\"", "timeout": 60 }
+          { "type": "command", "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/guard-bash.sh\"", "timeout": 60 },
+          { "type": "command", "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/guard-commit-scan.sh\"", "timeout": 60 }
         ]
       },
       {
         "matcher": "Write|Edit|MultiEdit|NotebookEdit",
         "hooks": [
-          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT//\\\\//}/hooks/guard-write.sh\"", "timeout": 60 }
+          { "type": "command", "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/guard-write.sh\"", "timeout": 60 }
         ]
       }
     ],
     "UserPromptSubmit": [
       {
         "hooks": [
-          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT//\\\\//}/hooks/context-usage.sh\" 2>/dev/null || true", "timeout": 60 },
-          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT//\\\\//}/hooks/route-hint.sh\" 2>/dev/null || true", "timeout": 60 }
+          { "type": "command", "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/context-usage.sh\"", "timeout": 60 },
+          { "type": "command", "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/route-hint.sh\"", "timeout": 60 }
         ]
       }
     ],
     "Stop": [
       {
         "hooks": [
-          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT//\\\\//}/hooks/session-guard.sh\"", "timeout": 60 }
+          { "type": "command", "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/session-guard.sh\"", "timeout": 60 }
         ]
       }
     ],
@@ -34,7 +34,7 @@
       {
         "matcher": "compact|clear|resume",
         "hooks": [
-          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT//\\\\//}/hooks/session-rehydrate.sh\"", "timeout": 60 }
+          { "type": "command", "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/session-rehydrate.sh\"", "timeout": 60 }
         ]
       }
     ]

--- a/plugin/hooks/session-rehydrate.sh
+++ b/plugin/hooks/session-rehydrate.sh
@@ -22,10 +22,11 @@ if [ -z "$ROOT" ]; then
   ROOT="$(printf '%s' "$IN" | sed -n 's/.*"cwd"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
 fi
 [ -n "$ROOT" ] || ROOT="$PWD"
-# Windows hands both CLAUDE_PROJECT_DIR and the stdin `cwd` over as native paths (`C:\Repos\app`). Appending a
-# POSIX segment to one produces `C:\Repos\app/docs/...`, which Git Bash does not reliably resolve. Folding the
-# backslashes is a no-op everywhere else.
-ROOT="${ROOT//\\//}"
+# Windows hands both CLAUDE_PROJECT_DIR and the stdin `cwd` over as native paths (`C:\Repos\app`), and the stdin
+# one arrives JSON-ENCODED on top of that — `C:\\Repos\\app`. Slicing it out with sed keeps the doubled
+# backslashes, so ROOT pointed at a directory that cannot exist and the hook silently rehydrated nothing.
+# Undo the JSON escaping first (`\\`), then fold any lone separator. Both are no-ops on a POSIX path.
+ROOT="${ROOT//\\\\//}"; ROOT="${ROOT//\\//}"
 
 STATE="$ROOT/docs/SESSION_STATE.md"
 [ -s "$STATE" ] || exit 0   # no (non-empty) handover → nothing to rehydrate, stay silent

--- a/start.sh
+++ b/start.sh
@@ -218,6 +218,10 @@ gate "real context measurement + handoff at 75% (Stop hook)"
 gate "destructive command guard (rm -rf / force-push, etc.)"
 echo
 row "Will write" "${D}./.claude (agents·skills·commands·hooks·eval·settings.json) + ./CLAUDE.md${R}"
+# What this machine is missing, BEFORE the confirm prompt — not after, when it becomes a symptom pointing
+# somewhere else. Report-only and never blocking: the kit degrades rather than breaks, and that is exactly why
+# a gap is otherwise invisible. See claude-starter/eval/preflight.sh for the reasoning per tool.
+[ -f "$SRC/eval/preflight.sh" ] && bash "$SRC/eval/preflight.sh"
 rule
 echo
 # ask_yes reads from stdin => in CI `printf 'yes\n' | bash start.sh` works; 'no' on EOF (no accidental install).


### PR DESCRIPTION
Every finding here came off the reporting users' machines. None was reachable from macOS, which is the honest
summary of the release.

## The hooks were not running at all

Reported as `bash: C:RuntimeHostExecLayerskqr_backend/.claude/hooks/session-rehydrate.sh: No such file or
directory` — separators **deleted**, not converted. The installed `settings.json` was correct and no local
reproduction produced that string, which is what finally located it: Claude Code substitutes
`${CLAUDE_PROJECT_DIR}` into the command **string** before any shell sees it, and on Windows the backslashes do
not survive the trip. 2.0.1's `${VAR//\\//}` fold could never have run — bash was not the one expanding it. Every
gate was absent on Windows while the file looked correct on inspection.

Hook commands now carry no placeholder:

```
cd "$CLAUDE_PROJECT_DIR" 2>/dev/null; bash .claude/hooks/<name>.sh
```

Hooks run in the project directory, so the relative path is load-bearing and there is nothing left to mangle. The
`cd` is a belt for a session started in a subdirectory; it uses the **bare** variable, which is not the
placeholder syntax and survives to the shell, and if it fails the relative path still carries.

**The documented fix was implemented and then rejected on evidence.** The hooks reference recommends *exec form*
for path placeholders, and it was written — then checked on the affected machine before shipping. `where bash`
there answered `C:\Windows\System32\bash.exe`: not Git Bash but the **WSL launcher**, whose namespace has no
`C:\Repos\app` at all. Exec form spawns off PATH with no shell, so it would have run that — or failed outright
without WSL — and taken every gate with it. A worse bug than the one being fixed, shipped as the recommended
solution. `smoke-test.sh` now refuses exec-form wiring with that reasoning attached.

Verified by the user rather than by me: same machine, same `SessionStart:clear` event, old wiring errored and the
new wiring is clean.

## Paths from hook payloads were never decoded

Hook stdin is JSON and JSON doubles a backslash, so `C:\Users\me\a.jsonl` arrives as `C:\\Users\\me\\a.jsonl`.
`context-usage.sh` compared that against the filesystem and reported `transcript not found` every turn, on Windows
CLI and Claude Desktop alike. Scope stated honestly: only `context-usage` was broken — `session-rehydrate` and
`skill-trust` folded lone backslashes in 2.0.1 and survived the encoded form by accident, since `\\` folds to `//`
which the OS collapses. All three now decode explicitly.

`context-usage.sh` also stops exiting non-zero when it cannot measure **as a hook**; called by hand it still
complains, because that one is a person's mistake.

## A resumed session runs the previous wiring

Found while verifying the above: `settings.json` was already corrected and `--resume` still named the old path,
while a fresh session was clean. So the release that repairs the Windows path does not reach a session resumed
across it. A hook cannot report its own absence, so the gate catches the other half — hooks that *do* run but not
as the file on disk says. `$0` is the evidence. Silent when `settings.json` is absent or hand-rewired.

## Toolchain gaps were invisible by design

The kit degrades rather than breaks — no `jq` falls back to `python` then to plain bash, no `sha256sum` falls back
to `cksum` — which is right, and is exactly why a gap never announces itself. Every surprise in this project came
out of that silence, on a Windows Git Bash box with no `jq` and no `python`, which is the normal case rather than
the exotic one. `eval/preflight.sh` runs in `start.sh` and `adopt.sh` before the confirm prompt and in
`doctor.sh`, names each gap and what it costs, and **installs nothing**.

## Gates added

`${CLAUDE_PROJECT_DIR}` placeholder refused · `cd` belt required · exec-form wiring refused · Windows-shaped JSON
payload fed to the real hooks · stale-wiring detection (three states) · `doctor.sh` reports placeholder wiring as
a failure on every platform.

Local: smoke ✅ · routing-eval ✅ · installer e2e ✅ · README catalogue ✅ · plugin in sync ✅.

**Not included:** no version bump, no tag. `VERSION` is still 2.0.1 — this waits on a verification pass on the
affected Windows machine.