### PR TITLE
Stop re-measuring context fill at the end of every turn

### DIFF
--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -253,6 +253,40 @@ fill 760000
 # (6) emitted payload is valid JSON carrying systemMessage
 if command -v jq >/dev/null 2>&1; then
   fill 800000; sg "${SGPFX}-e" | jq -e '.systemMessage' >/dev/null 2>&1 && pass "stop-hook: stdout is valid JSON with .systemMessage" || fail "stop-hook stdout is not valid systemMessage JSON"
+
+  # --- the fast path -------------------------------------------------------------------------------------
+  # Every assertion above exercises the SLOW path, where this hook measures for itself. It now prefers the
+  # reading context-usage.sh published at the start of the turn, because re-deriving it cost a second shell
+  # startup and a second transcript scan at the end of EVERY turn — ~29 processes down to 14, which on a
+  # corporate Windows machine (measured: ~290ms per process) is about four seconds a turn. A faster path that
+  # reaches a different verdict would be worse than the cost it saves, so both halves are asserted: it must
+  # agree with the slow path, and it must survive a cache it cannot trust.
+  SGC="${TMPDIR:-/tmp}/csk-context.${SGPFX}-fast"
+  fill 800000
+  SLOWOUT="$(sg "${SGPFX}-slow")"                       # no cache for this key -> measures for itself
+  printf '80.0 800000 1000000 handoff+clear\n' > "$SGC"
+  FASTOUT="$(sg "${SGPFX}-fast")"                       # same fill, published reading
+  case "$FASTOUT" in
+    *'"systemMessage"'*'>75%'*) pass "stop-hook fast path: a published reading produces the same 75% verdict" ;;
+    *) fail "stop-hook fast path reached a different verdict from the measured one: $FASTOUT" ;;
+  esac
+  [ -n "$SLOWOUT" ] && [ -n "$FASTOUT" ] \
+    && pass "stop-hook: both paths speak at the same fill (the shortcut did not silence the gate)" \
+    || fail "one path spoke and the other did not (slow='$SLOWOUT' fast='$FASTOUT')"
+  # A truncated or garbled cache must not be believed, and must not silence the warning either: it falls back.
+  printf 'not-a-number junk\n' > "$SGC"
+  case "$(sg "${SGPFX}-fast2")" in
+    *'"systemMessage"'*) pass "stop-hook: an unreadable published reading falls back to measuring, not to silence" ;;
+    *) fail "a corrupt cache silenced the threshold warning — fail-open became fail-quiet" ;;
+  esac
+  rm -f "$SGC"
+  # And the shortcut must actually be taken: no nested shell at the end of a turn is the whole point.
+  printf '80.0 800000 1000000 handoff+clear\n' > "${TMPDIR:-/tmp}/csk-context.${SGPFX}-cnt"
+  mkjson "${SGPFX}-cnt" "$SGFX" false | CONTEXT_WINDOW=1000000 bash -x "$HOOKS/session-guard.sh" >/dev/null 2>"$SGFX.trace"
+  NB="$(grep -cE '^\++ bash ' "$SGFX.trace" 2>/dev/null | tr -cd '0-9')"; NB="${NB:-0}"
+  [ "$NB" -eq 0 ] && pass "stop-hook fast path spawns no nested shell (the cost this removes)" \
+                  || fail "stop-hook still starts $NB nested shell(s) with a published reading available"
+  rm -f "${TMPDIR:-/tmp}/csk-context.${SGPFX}-cnt" "$SGFX.trace"
 else pass "stop-hook JSON check skipped (no jq)"; fi
 # (7) fail-open: unreadable transcript -> exit 0 and silent (never blocks on measurement failure)
 o="$(mkjson "${SGPFX}-f" "/no/such.jsonl" false | bash "$HOOKS/session-guard.sh" 2>/dev/null)"; r=$?

--- a/claude-starter/hooks/context-usage.sh
+++ b/claude-starter/hooks/context-usage.sh
@@ -156,7 +156,19 @@ case "$IN" in *'"hook_event_name"'*UserPromptSubmit*) ;; *) exit 0 ;; esac
 # The session id is used twice below; computing it once is not a tidiness question. Measured on a corporate
 # Windows machine: a process costs ~290ms there against ~2ms on Linux, so every spawn removed from a hook that
 # runs on EVERY turn is a third of a second the user waits before the model has even started.
-SID="$(printf '%s' "$IN" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1 | tr -cd 'A-Za-z0-9._-')"
+SID=""
+case "$IN" in *'"session_id"'*)
+  # Extracted with parameter expansion, not `printf | sed | head | tr`. Four spawns, on every turn, to lift a
+  # UUID out of a string the shell already holds. It reads worse and costs ~1.2s a turn on a machine where a
+  # process is 290ms. Handles both `"session_id":"x"` and `"session_id": "x"` — the cut is at the next quote
+  # after the colon either way.
+  SID="${IN#*\"session_id\"}"; SID="${SID#*:}"; SID="${SID#*\"}"; SID="${SID%%\"*}"
+  # It becomes a filename, so it is VALIDATED rather than trusted. Anything unexpected falls back to the old
+  # scrub — correctness first, and the fallback costs nothing in the normal case because it never runs.
+  case "$SID" in
+    ''|*[!A-Za-z0-9._-]*) SID="$(printf '%s' "$IN" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1 | tr -cd 'A-Za-z0-9._-')" ;;
+  esac ;;
+esac
 
 # --- Publish the measurement so the Stop hook does not have to repeat it ------------------------------
 # session-guard.sh needs the same number, and it used to get it by running THIS script again as a nested

--- a/claude-starter/hooks/context-usage.sh
+++ b/claude-starter/hooks/context-usage.sh
@@ -153,6 +153,25 @@ fi
 # script, and a by-hand run has no stdin at all. Fails open — no stdin, no session_id, no VERSION: silent.
 case "$IN" in *'"hook_event_name"'*UserPromptSubmit*) ;; *) exit 0 ;; esac
 
+# The session id is used twice below; computing it once is not a tidiness question. Measured on a corporate
+# Windows machine: a process costs ~290ms there against ~2ms on Linux, so every spawn removed from a hook that
+# runs on EVERY turn is a third of a second the user waits before the model has even started.
+SID="$(printf '%s' "$IN" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1 | tr -cd 'A-Za-z0-9._-')"
+
+# --- Publish the measurement so the Stop hook does not have to repeat it ------------------------------
+# session-guard.sh needs the same number, and it used to get it by running THIS script again as a nested
+# `bash context-usage.sh --verbose` — a second shell startup plus a second full transcript scan, at the end of
+# every single turn. On the machine above that pair costs seconds per turn, to recompute a figure that was
+# already sitting in memory one hook earlier.
+#
+# The honest cost of sharing it: this reading is taken at the START of the turn, so the Stop hook sees a fill
+# that does not include the turn's own output. It can therefore cross a threshold one turn later than a fresh
+# measurement would. That is acceptable for an advisory warning and is NOT acceptable silently — session-guard
+# falls back to measuring for itself whenever this file is missing, so the accurate path always exists.
+if [ -n "$SID" ]; then
+  printf '%s %s %s %s\n' "$PCT" "$TOTAL" "$WINDOW" "$LEVEL" > "${TMPDIR:-/tmp}/csk-context.${SID}" 2>/dev/null || true
+fi
+
 # --- Stale-WIRING gate -------------------------------------------------------------------------------
 # A resumed session keeps the hook wiring it was started with. Measured on Windows: settings.json on disk had
 # already been corrected, and `--resume` still produced the error naming the OLD, mangled path — while the same
@@ -180,8 +199,7 @@ KITVER="$HERE/../VERSION"                       # hooks live in .claude/hooks ->
 [ -f "$KITVER" ] || exit 0
 NOW="$(head -1 "$KITVER" 2>/dev/null | tr -cd '0-9A-Za-z.-')"
 [ -n "$NOW" ] || exit 0
-SID="$(printf '%s' "$IN" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1 | tr -cd 'A-Za-z0-9._-')"
-[ -n "$SID" ] || exit 0
+[ -n "$SID" ] || exit 0                         # computed once, above
 MARK="${TMPDIR:-/tmp}/csk-kit-version.${SID}"
 if [ ! -e "$MARK" ]; then
   printf '%s' "$NOW" > "$MARK" 2>/dev/null || true   # first turn: remember the version, say nothing

--- a/claude-starter/hooks/session-guard.sh
+++ b/claude-starter/hooks/session-guard.sh
@@ -54,21 +54,45 @@ if [ "${AUTOC:-0}" -gt 0 ] && [ ! -e "$(marker autocompact)" ]; then
   exit 0
 fi
 
-# Real context% — context-usage.sh reads transcript_path from the same stdin JSON. Fail-open on any error.
-# --verbose here: this line reaches the USER at most twice per session, so the raw token counts are free.
-# (The per-turn UserPromptSubmit injection uses the compact form; that one is paid for on every single turn.)
-LINE="$(printf '%s' "$IN" | bash "$HERE/context-usage.sh" --verbose 2>/dev/null | head -1 || true)"
-[ -n "$LINE" ] || exit 0
+# Real context%, from context-usage.sh's measurement. Fail-open on any error.
+#
+# FAST PATH — read the figure context-usage.sh already published this turn. That hook runs on UserPromptSubmit,
+# measures exactly this, and now writes it to a session-keyed file. Re-deriving it here meant a second shell
+# startup plus a second full transcript scan at the end of EVERY turn: measured at ~31 processes per Stop, and
+# on a corporate Windows machine a process costs ~290ms, so the turn ended with seconds of silence.
+#
+# Read with `$(<file)` — a builtin, no `cat`. Parsed by word splitting, no `sed`. What it costs: the reading is
+# from the start of the turn, so it excludes this turn's own output and can cross a threshold one turn late.
+# For a warning that never blocks, one turn of lag is worth seconds a turn, and it is not silent: without the
+# file we measure properly below, so the accurate path is always there when the fast one is not.
+PCT=""; TOTAL=""; WINDOW=""; LEVEL=""; LINE=""
+CACHE="${TMPDIR:-/tmp}/csk-context.${KEY}"
+if [ -f "$CACHE" ]; then
+  read -r PCT TOTAL WINDOW LEVEL < "$CACHE" 2>/dev/null || true
+  case "$PCT" in ''|*[!0-9.]*) PCT="" ;; esac      # anything unexpected -> fall through and measure
+  [ -n "$PCT" ] && LINE="🔋 Session: %$PCT ($TOTAL/$WINDOW token) → $LEVEL"
+fi
 
-# Pull the percentage back out of the "🔋 Session: %77.2 (...)" line. context-usage.sh pins LC_ALL=C, so the
-# decimal separator is always '.' whatever the locale. No number -> cannot classify -> stay silent (fail open).
-PCT="$(printf '%s' "$LINE" | sed -n 's/.*%\([0-9][0-9]*\(\.[0-9][0-9]*\)*\).*/\1/p' | head -1)"
-[ -n "$PCT" ] || exit 0
+if [ -z "$PCT" ]; then
+  # SLOW PATH — no published reading (first turn, a by-hand run, or context-usage silent). Measure for real.
+  # --verbose here: this line reaches the USER at most twice per session, so the raw token counts are free.
+  LINE="$(printf '%s' "$IN" | bash "$HERE/context-usage.sh" --verbose 2>/dev/null | head -1 || true)"
+  [ -n "$LINE" ] || exit 0
+  # Pull the percentage back out of the "🔋 Session: %77.2 (...)" line. context-usage.sh pins LC_ALL=C, so the
+  # decimal separator is always '.' whatever the locale. No number -> cannot classify -> stay silent (fail open).
+  PCT="$(printf '%s' "$LINE" | sed -n 's/.*%\([0-9][0-9]*\(\.[0-9][0-9]*\)*\).*/\1/p' | head -1)"
+  [ -n "$PCT" ] || exit 0
+fi
 
 # Highest threshold crossed. Compared under LC_ALL=C so '77.2' parses identically everywhere.
+# Compared on the integer part with shell arithmetic rather than two `awk` calls. Two spawns at the end of every
+# turn bought nothing here: the thresholds are whole numbers, so truncating is exactly equivalent — 89.9 is below
+# 90 either way — and dropping the decimal also drops the locale hazard the awk calls existed to pin down.
+INT="${PCT%%.*}"; INT="${INT:-0}"
+case "$INT" in ''|*[!0-9]*) exit 0 ;; esac
 TIER=""
-LC_ALL=C awk -v p="$PCT" 'BEGIN{exit !(p+0>=90)}' && TIER=90
-[ -n "$TIER" ] || { LC_ALL=C awk -v p="$PCT" 'BEGIN{exit !(p+0>=75)}' && TIER=75; }
+[ "$INT" -ge 90 ] && TIER=90
+[ -n "$TIER" ] || { [ "$INT" -ge 75 ] && TIER=75; }
 [ -n "$TIER" ] || exit 0
 
 # Already warned at this tier this session? Stay silent — one alert per threshold, not one per turn.

--- a/plugin/hooks/context-usage.sh
+++ b/plugin/hooks/context-usage.sh
@@ -156,7 +156,19 @@ case "$IN" in *'"hook_event_name"'*UserPromptSubmit*) ;; *) exit 0 ;; esac
 # The session id is used twice below; computing it once is not a tidiness question. Measured on a corporate
 # Windows machine: a process costs ~290ms there against ~2ms on Linux, so every spawn removed from a hook that
 # runs on EVERY turn is a third of a second the user waits before the model has even started.
-SID="$(printf '%s' "$IN" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1 | tr -cd 'A-Za-z0-9._-')"
+SID=""
+case "$IN" in *'"session_id"'*)
+  # Extracted with parameter expansion, not `printf | sed | head | tr`. Four spawns, on every turn, to lift a
+  # UUID out of a string the shell already holds. It reads worse and costs ~1.2s a turn on a machine where a
+  # process is 290ms. Handles both `"session_id":"x"` and `"session_id": "x"` — the cut is at the next quote
+  # after the colon either way.
+  SID="${IN#*\"session_id\"}"; SID="${SID#*:}"; SID="${SID#*\"}"; SID="${SID%%\"*}"
+  # It becomes a filename, so it is VALIDATED rather than trusted. Anything unexpected falls back to the old
+  # scrub — correctness first, and the fallback costs nothing in the normal case because it never runs.
+  case "$SID" in
+    ''|*[!A-Za-z0-9._-]*) SID="$(printf '%s' "$IN" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1 | tr -cd 'A-Za-z0-9._-')" ;;
+  esac ;;
+esac
 
 # --- Publish the measurement so the Stop hook does not have to repeat it ------------------------------
 # session-guard.sh needs the same number, and it used to get it by running THIS script again as a nested

--- a/plugin/hooks/context-usage.sh
+++ b/plugin/hooks/context-usage.sh
@@ -153,6 +153,25 @@ fi
 # script, and a by-hand run has no stdin at all. Fails open — no stdin, no session_id, no VERSION: silent.
 case "$IN" in *'"hook_event_name"'*UserPromptSubmit*) ;; *) exit 0 ;; esac
 
+# The session id is used twice below; computing it once is not a tidiness question. Measured on a corporate
+# Windows machine: a process costs ~290ms there against ~2ms on Linux, so every spawn removed from a hook that
+# runs on EVERY turn is a third of a second the user waits before the model has even started.
+SID="$(printf '%s' "$IN" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1 | tr -cd 'A-Za-z0-9._-')"
+
+# --- Publish the measurement so the Stop hook does not have to repeat it ------------------------------
+# session-guard.sh needs the same number, and it used to get it by running THIS script again as a nested
+# `bash context-usage.sh --verbose` — a second shell startup plus a second full transcript scan, at the end of
+# every single turn. On the machine above that pair costs seconds per turn, to recompute a figure that was
+# already sitting in memory one hook earlier.
+#
+# The honest cost of sharing it: this reading is taken at the START of the turn, so the Stop hook sees a fill
+# that does not include the turn's own output. It can therefore cross a threshold one turn later than a fresh
+# measurement would. That is acceptable for an advisory warning and is NOT acceptable silently — session-guard
+# falls back to measuring for itself whenever this file is missing, so the accurate path always exists.
+if [ -n "$SID" ]; then
+  printf '%s %s %s %s\n' "$PCT" "$TOTAL" "$WINDOW" "$LEVEL" > "${TMPDIR:-/tmp}/csk-context.${SID}" 2>/dev/null || true
+fi
+
 # --- Stale-WIRING gate -------------------------------------------------------------------------------
 # A resumed session keeps the hook wiring it was started with. Measured on Windows: settings.json on disk had
 # already been corrected, and `--resume` still produced the error naming the OLD, mangled path — while the same
@@ -180,8 +199,7 @@ KITVER="$HERE/../VERSION"                       # hooks live in .claude/hooks ->
 [ -f "$KITVER" ] || exit 0
 NOW="$(head -1 "$KITVER" 2>/dev/null | tr -cd '0-9A-Za-z.-')"
 [ -n "$NOW" ] || exit 0
-SID="$(printf '%s' "$IN" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1 | tr -cd 'A-Za-z0-9._-')"
-[ -n "$SID" ] || exit 0
+[ -n "$SID" ] || exit 0                         # computed once, above
 MARK="${TMPDIR:-/tmp}/csk-kit-version.${SID}"
 if [ ! -e "$MARK" ]; then
   printf '%s' "$NOW" > "$MARK" 2>/dev/null || true   # first turn: remember the version, say nothing

--- a/plugin/hooks/session-guard.sh
+++ b/plugin/hooks/session-guard.sh
@@ -54,21 +54,45 @@ if [ "${AUTOC:-0}" -gt 0 ] && [ ! -e "$(marker autocompact)" ]; then
   exit 0
 fi
 
-# Real context% — context-usage.sh reads transcript_path from the same stdin JSON. Fail-open on any error.
-# --verbose here: this line reaches the USER at most twice per session, so the raw token counts are free.
-# (The per-turn UserPromptSubmit injection uses the compact form; that one is paid for on every single turn.)
-LINE="$(printf '%s' "$IN" | bash "$HERE/context-usage.sh" --verbose 2>/dev/null | head -1 || true)"
-[ -n "$LINE" ] || exit 0
+# Real context%, from context-usage.sh's measurement. Fail-open on any error.
+#
+# FAST PATH — read the figure context-usage.sh already published this turn. That hook runs on UserPromptSubmit,
+# measures exactly this, and now writes it to a session-keyed file. Re-deriving it here meant a second shell
+# startup plus a second full transcript scan at the end of EVERY turn: measured at ~31 processes per Stop, and
+# on a corporate Windows machine a process costs ~290ms, so the turn ended with seconds of silence.
+#
+# Read with `$(<file)` — a builtin, no `cat`. Parsed by word splitting, no `sed`. What it costs: the reading is
+# from the start of the turn, so it excludes this turn's own output and can cross a threshold one turn late.
+# For a warning that never blocks, one turn of lag is worth seconds a turn, and it is not silent: without the
+# file we measure properly below, so the accurate path is always there when the fast one is not.
+PCT=""; TOTAL=""; WINDOW=""; LEVEL=""; LINE=""
+CACHE="${TMPDIR:-/tmp}/csk-context.${KEY}"
+if [ -f "$CACHE" ]; then
+  read -r PCT TOTAL WINDOW LEVEL < "$CACHE" 2>/dev/null || true
+  case "$PCT" in ''|*[!0-9.]*) PCT="" ;; esac      # anything unexpected -> fall through and measure
+  [ -n "$PCT" ] && LINE="🔋 Session: %$PCT ($TOTAL/$WINDOW token) → $LEVEL"
+fi
 
-# Pull the percentage back out of the "🔋 Session: %77.2 (...)" line. context-usage.sh pins LC_ALL=C, so the
-# decimal separator is always '.' whatever the locale. No number -> cannot classify -> stay silent (fail open).
-PCT="$(printf '%s' "$LINE" | sed -n 's/.*%\([0-9][0-9]*\(\.[0-9][0-9]*\)*\).*/\1/p' | head -1)"
-[ -n "$PCT" ] || exit 0
+if [ -z "$PCT" ]; then
+  # SLOW PATH — no published reading (first turn, a by-hand run, or context-usage silent). Measure for real.
+  # --verbose here: this line reaches the USER at most twice per session, so the raw token counts are free.
+  LINE="$(printf '%s' "$IN" | bash "$HERE/context-usage.sh" --verbose 2>/dev/null | head -1 || true)"
+  [ -n "$LINE" ] || exit 0
+  # Pull the percentage back out of the "🔋 Session: %77.2 (...)" line. context-usage.sh pins LC_ALL=C, so the
+  # decimal separator is always '.' whatever the locale. No number -> cannot classify -> stay silent (fail open).
+  PCT="$(printf '%s' "$LINE" | sed -n 's/.*%\([0-9][0-9]*\(\.[0-9][0-9]*\)*\).*/\1/p' | head -1)"
+  [ -n "$PCT" ] || exit 0
+fi
 
 # Highest threshold crossed. Compared under LC_ALL=C so '77.2' parses identically everywhere.
+# Compared on the integer part with shell arithmetic rather than two `awk` calls. Two spawns at the end of every
+# turn bought nothing here: the thresholds are whole numbers, so truncating is exactly equivalent — 89.9 is below
+# 90 either way — and dropping the decimal also drops the locale hazard the awk calls existed to pin down.
+INT="${PCT%%.*}"; INT="${INT:-0}"
+case "$INT" in ''|*[!0-9]*) exit 0 ;; esac
 TIER=""
-LC_ALL=C awk -v p="$PCT" 'BEGIN{exit !(p+0>=90)}' && TIER=90
-[ -n "$TIER" ] || { LC_ALL=C awk -v p="$PCT" 'BEGIN{exit !(p+0>=75)}' && TIER=75; }
+[ "$INT" -ge 90 ] && TIER=90
+[ -n "$TIER" ] || { [ "$INT" -ge 75 ] && TIER=75; }
 [ -n "$TIER" ] || exit 0
 
 # Already warned at this tier this session? Stay silent — one alert per threshold, not one per turn.


### PR DESCRIPTION
Reported from a corporate Windows machine: clean session, first command, minutes of silence. Measured there, because on macOS a broken hook and a fast one both read 0s.

| measured on the reporting machine | |
|:--|--:|
| empty `bash` startup | 263 ms |
| empty external command | 298 ms |
| `context-usage.sh` (every prompt) | 3100 ms |
| `session-guard.sh` (every turn end) | 6011 ms |

Process creation there is 60-100x slower than normal — an enterprise scanner inspecting every spawn. Nothing in our shell can undo that. What is ours is **how many processes we ask for**, and one stood out: `session-guard.sh` ran `bash context-usage.sh --verbose` as a child at the end of every turn, to recompute a figure the same script had measured one hook earlier in the same turn.

| | before | after |
|:--|--:|--:|
| `session-guard` per turn end | ~29 | **14** |
| `context-usage` per prompt (installed) | 17 | **14** |
| `context-usage` per prompt (plugin edition) | 12 | **12** |

About **18 processes a turn**, ~5 s on that machine.

**The honest cost:** the published reading is taken at the START of the turn, so it excludes that turn's own output and can cross a threshold one turn late. For a warning that never blocks that is a good trade — and it is not silent: a missing or unreadable file falls back to measuring properly.

**Gated:** the 17 existing stop-hook assertions (slow path) still pass, plus 4 new ones — the fast path reaches the same verdict as the measured one, both paths speak at the same fill, a corrupt cache falls back to measuring rather than to silence, and no nested shell starts when a reading is available. The session id parse was checked on three payload shapes, because a mis-parsed id would not crash: it would write the cache under one name, read it under another, and the only symptom would be that the hook quietly stayed slow.

**Still open, larger:** session start runs three separate hooks, the prompt two, each Bash tool call two more — one shell startup each. And the biggest lever on that machine is not ours: an antivirus exclusion for the Git install, the project directory and `~/.claude`.