### PR TITLE
Plugin manifest kept 2.2.1 — catch it on the laptop, not on the tag

### DIFF
--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -637,6 +637,17 @@ if [ "$IS_KIT" = 1 ]; then
       fail "plugin/settings hook sets diverged — only in settings: '${ONLY_SET:-none}' (expected exactly skill-trust.sh)"
     fi
   fi
+  # The plugin manifest carries the version, and build-plugin.sh is what writes it — so bumping VERSION without
+  # re-running the build leaves the plugin edition claiming the previous release. release.yml catches that, which
+  # is far too late: it caught it on a tag that was already pushed, after the site had already been updated to
+  # the new number. The full sync check needs a build and belongs there; THIS one is the specific drift that
+  # actually happens, it costs one grep, and it fails on the laptop where it can still be fixed cheaply.
+  if [ -f "$KR/VERSION" ] && [ -f "$KR/plugin/.claude-plugin/plugin.json" ]; then
+    KV="$(tr -d ' \n\r' < "$KR/VERSION")"
+    PV="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$KR/plugin/.claude-plugin/plugin.json" | head -1)"
+    [ "$KV" = "$PV" ] && pass "plugin manifest version matches VERSION ($KV)" \
+      || fail "plugin manifest says '$PV' but VERSION is '$KV' — run packaging/build-plugin.sh and commit plugin/"
+  fi
   # The DIAGRAMS make a claim too, and it is the one a reader takes at face value because nobody counts nodes in
   # a picture. The hand-drawn pipeline shipped with eleven of twelve agents — performance-expert-csk was simply
   # never drawn — and every gate stayed green because none of them looked at an SVG. Both diagrams are generated

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "claude-starter-kit",
   "displayName": "Claude Starter Kit",
   "description": "Agentic Working Kit — disciplined agents, skills, slash commands, and tool-level gate hooks (commit/push approval, destructive-op & write guards, context-fill measurement, session rehydration) for Claude Code. The git-commit trace/secret/bloat scan needs the full install (start.sh / adopt.sh).",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "author": { "name": "Barış Yerlikaya" },
   "homepage": "https://github.com/byerlikaya/claude-starter-kit",
   "repository": "https://github.com/byerlikaya/claude-starter-kit",


### PR DESCRIPTION
The 2.2.2 release stopped at its third step. `build-plugin.sh` writes the version into `plugin/.claude-plugin/plugin.json`; VERSION was bumped without re-running it, so the plugin edition still claimed 2.2.1.

**Nothing shipped.** No GitHub release, npm still 2.2.1, every publish step `skipped` — the release workflow runs a full verify before publishing, and that is exactly why. The gate worked.

It worked too late, though: by then the tag was pushed and the published site had already been moved to 2.2.2. Two outward-facing steps taken for a release that could not complete.

So this adds the cheap half locally: `smoke-test` compares the plugin manifest's version against `VERSION`. One grep, no build, fails on the laptop. The full sync check needs a build and stays in `release.yml` where it belongs.

Asserted in both directions — green when they match, red when `plugin.json` is planted with the previous version. A gate seen only passing has not been seen working.