### PR TITLE
The version lives in four files — check them together, before the tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 12 specialist agents plan the work, build it, put it through security and test review, then close it
 
-![Version](https://img.shields.io/badge/version-2.2.1-2563eb?style=flat-square)
+![Version](https://img.shields.io/badge/version-2.2.2-2563eb?style=flat-square)
 ![License](https://img.shields.io/badge/license-MIT-16a34a?style=flat-square)
 ![Agents](https://img.shields.io/badge/agents-12-f59e0b?style=flat-square)
 ![Skills](https://img.shields.io/badge/skills-38-f59e0b?style=flat-square)

--- a/README.tr.md
+++ b/README.tr.md
@@ -6,7 +6,7 @@
 
 12 uzman agent işi planlar, üretir, güvenlik ve test denetiminden geçirir, sonra kapatır.
 
-![Sürüm](https://img.shields.io/badge/version-2.2.1-2563eb?style=flat-square)
+![Sürüm](https://img.shields.io/badge/version-2.2.2-2563eb?style=flat-square)
 ![Lisans](https://img.shields.io/badge/license-MIT-16a34a?style=flat-square)
 ![Ajanlar](https://img.shields.io/badge/agents-12-f59e0b?style=flat-square)
 ![Skiller](https://img.shields.io/badge/skills-38-f59e0b?style=flat-square)

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -642,11 +642,28 @@ if [ "$IS_KIT" = 1 ]; then
   # is far too late: it caught it on a tag that was already pushed, after the site had already been updated to
   # the new number. The full sync check needs a build and belongs there; THIS one is the specific drift that
   # actually happens, it costs one grep, and it fails on the laptop where it can still be fixed cheaply.
-  if [ -f "$KR/VERSION" ] && [ -f "$KR/plugin/.claude-plugin/plugin.json" ]; then
+  # The version does not live in one place, it lives in four, and a release stops at whichever one was missed —
+  # one at a time, after a tag has been pushed. 2.2.2 proved it twice in a row: the plugin manifest still said
+  # 2.2.1 and the workflow stopped before publishing; that was fixed, re-tagged, and it stopped AGAIN at npm,
+  # because npm publishes package.json's version and nothing had compared it to anything. Both failures are the
+  # same failure. So every carrier is checked together, here, where the fix costs nothing.
+  if [ -f "$KR/VERSION" ]; then
     KV="$(tr -d ' \n\r' < "$KR/VERSION")"
-    PV="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$KR/plugin/.claude-plugin/plugin.json" | head -1)"
-    [ "$KV" = "$PV" ] && pass "plugin manifest version matches VERSION ($KV)" \
-      || fail "plugin manifest says '$PV' but VERSION is '$KV' — run packaging/build-plugin.sh and commit plugin/"
+    verfile(){ # verfile <label> <file> <extractor-output>
+      local label="$1" got="$3"
+      [ -n "$got" ] || return 0                      # carrier absent in this checkout -> nothing to compare
+      [ "$got" = "$KV" ] && pass "$label version matches VERSION ($KV)" \
+        || fail "$label says '$got' but VERSION is '$KV' — every carrier moves together or the release stops at the one that did not"
+    }
+    jsonver(){ sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$1" 2>/dev/null | head -1; }
+    verfile "plugin manifest" "" "$(jsonver "$KR/plugin/.claude-plugin/plugin.json")"
+    # npm publishes THIS number, not VERSION. Nothing else in the pipeline reads it, which is exactly why it
+    # went unnoticed until the registry refused the upload.
+    verfile "package.json"    "" "$(jsonver "$KR/package.json")"
+    for rf in README.md README.tr.md; do
+      [ -f "$KR/$rf" ] || continue
+      verfile "$rf badge" "" "$(sed -n 's|.*badge/version-\([0-9][0-9.]*\)-.*|\1|p' "$KR/$rf" | head -1)"
+    done
   fi
   # The DIAGRAMS make a claim too, and it is the one a reader takes at face value because nobody counts nodes in
   # a picture. The hand-drawn pipeline shipped with eleven of twelve agents — performance-expert-csk was simply

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@byerlikaya/claude-starter-kit",
-  "version": "2.2.1",
-  "description": "Agentic working kit for Claude Code — disciplined project scaffolding with agents, skills, and tool-level gates.",
+  "version": "2.2.2",
+  "description": "Agentic working kit for Claude Code \u2014 disciplined project scaffolding with agents, skills, and tool-level gates.",
   "bin": {
     "claude-starter-kit": "bin/cli.js"
   },
@@ -38,7 +38,7 @@
     "code-review",
     "git-hooks"
   ],
-  "author": "Barış Yerlikaya",
+  "author": "Bar\u0131\u015f Yerlikaya",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/byerlikaya/claude-starter-kit.git"


### PR DESCRIPTION
2.2.2 failed twice and both failures were the same failure.

1. The plugin manifest still said 2.2.1 → the workflow stopped before publishing. Fixed, re-tagged.
2. It stopped again at npm, which publishes **package.json**'s version, not `VERSION`. package.json still said 2.2.1, the registry refused to overwrite a published version — and by then the GitHub release had already been created. **A partial publish**, which is the worst of the three outcomes.

Patching the one that broke, twice, is how a third gets found the same way. The carriers are `VERSION`, `package.json`, `plugin/.claude-plugin/plugin.json` and the badge in both READMEs — and nothing compared them to each other.

`smoke-test` now does, together, on the laptop:

```
✅ plugin manifest version matches VERSION (2.2.2)
✅ package.json version matches VERSION (2.2.2)
✅ README.md badge version matches VERSION (2.2.2)
✅ README.tr.md badge version matches VERSION (2.2.2)
```

Each asserted by planting the previous version in it one at a time and checking the suite goes red — four separate sabotages, because a check only ever watched passing has not been watched working.

Also fixed here: `package.json` and both badges move to 2.2.2.