### PR TITLE
A skill required a tool its agent did not have

### DIFF
--- a/claude-starter/agents/privacy-agent-csk.md
+++ b/claude-starter/agents/privacy-agent-csk.md
@@ -5,7 +5,7 @@ description: |
   KVKK/GDPR privacy auditor. Use proactively when personal data, legal basis/consent, data minimisation,
   retention, transparency, data-subject rights, or cross-border transfer are touched. Findings + fixes via
   `privacy-compliance`; writes no code.
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, WebFetch
 # No `model` pin — see security-expert-csk. Omitted means inherit; pinning could only run the mandatory
 # privacy audit below the model that wrote the code it is auditing.
 ---

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -160,6 +160,33 @@ for f in "$AGENTS"/*.md; do
 done
 pass "every skill & agent is routed (no idle components)"
 
+echo "== 3b2) Capability: a skill cannot demand a tool its agent does not have =="
+# A rule an agent physically cannot obey is worse than no rule: it does not fail, it degrades quietly into the
+# thing it forbids. `privacy-compliance` told its agent to CHECK THE OFFICIAL SOURCE rather than decide from
+# memory, and privacy-agent-csk shipped with Read/Grep/Glob — no WebFetch. Nothing flagged it. It surfaced in a
+# real regulatory audit, where the routing had to split the work by hand to get around a gap in the kit.
+#
+# So the requirement is declared in the skill (`<!-- Requires-tool: X -->`) and checked here against every agent
+# that applies it. Declaration rather than guesswork: inferring "this skill probably needs the web" from prose
+# would be a heuristic, and a gate built on a heuristic is a gate nobody trusts when it fires.
+CAPFAIL=""
+for d in "$SKILLS"/*/; do
+  sname="$(basename "$d")"
+  req="$(sed -n 's/.*Requires-tool:[[:space:]]*\([A-Za-z]*\).*/\1/p' "$d/SKILL.md" 2>/dev/null | head -1)"
+  [ -n "$req" ] || continue
+  found=0
+  for af in "$AGENTS"/*.md; do
+    [ -e "$af" ] || continue
+    grep -qE "[^a-z0-9-]$sname([^a-z0-9-]|$)" "$af" 2>/dev/null || continue   # this agent applies the skill
+    found=1
+    grep -m1 '^tools:' "$af" | grep -q "$req" \
+      || CAPFAIL="$CAPFAIL $(basename "$af" .md)(needs $req for $sname)"
+  done
+  [ "$found" = 1 ] || note "skill '$sname' declares Requires-tool: $req but no agent applies it"
+done
+[ -z "$CAPFAIL" ] && pass "every skill's declared tool requirement is met by the agents that apply it" \
+                  || fail "an agent applies a skill it cannot obey:$CAPFAIL"
+
 echo "== 3c) Backend variant parity: a --generic install must not lose routing =="
 # On a non-.NET stack the installer REPLACES backend-expert-csk with agents-optional/backend-expert-generic.
 # Every skill routed only from the .NET variant then silently stops being reached on that stack — §3b cannot see

--- a/claude-starter/skills/privacy-compliance/SKILL.md
+++ b/claude-starter/skills/privacy-compliance/SKILL.md
@@ -12,6 +12,13 @@ description: |
      truncated or dropped, which strips the very keywords a match depends on. -->
 Trigger phrases: "kvkk", "gdpr", "privacy", "consent", "data retention", "minimization"
 
+<!-- Requires-tool: WebFetch -->
+<!-- Machine-readable, and smoke-test enforces it: every agent that applies this skill must carry WebFetch.
+     Without it the instruction below is one an agent physically cannot obey — it would either decide from
+     memory, which this skill forbids in the same breath, or quietly skip the check. That is exactly what
+     happened: the skill said "check the official source", privacy-agent-csk shipped with Read/Grep/Glob, and
+     the gap only surfaced during a real regulatory audit when the routing had to work around it by hand. -->
+
 ## Official sources (authority — always defer to these)
 The **primary, official** sources this skill rests on; rules are always interpreted against these:
 - **KVKK** (Turkey): https://www.kvkk.gov.tr/ — the law, regulations, principle decisions, guidelines.

--- a/plugin/agents/privacy-agent-csk.md
+++ b/plugin/agents/privacy-agent-csk.md
@@ -5,7 +5,7 @@ description: |
   KVKK/GDPR privacy auditor. Use proactively when personal data, legal basis/consent, data minimisation,
   retention, transparency, data-subject rights, or cross-border transfer are touched. Findings + fixes via
   `privacy-compliance`; writes no code.
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, WebFetch
 # No `model` pin — see security-expert-csk. Omitted means inherit; pinning could only run the mandatory
 # privacy audit below the model that wrote the code it is auditing.
 ---

--- a/plugin/skills/privacy-compliance/SKILL.md
+++ b/plugin/skills/privacy-compliance/SKILL.md
@@ -12,6 +12,13 @@ description: |
      truncated or dropped, which strips the very keywords a match depends on. -->
 Trigger phrases: "kvkk", "gdpr", "privacy", "consent", "data retention", "minimization"
 
+<!-- Requires-tool: WebFetch -->
+<!-- Machine-readable, and smoke-test enforces it: every agent that applies this skill must carry WebFetch.
+     Without it the instruction below is one an agent physically cannot obey — it would either decide from
+     memory, which this skill forbids in the same breath, or quietly skip the check. That is exactly what
+     happened: the skill said "check the official source", privacy-agent-csk shipped with Read/Grep/Glob, and
+     the gap only surfaced during a real regulatory audit when the routing had to work around it by hand. -->
+
 ## Official sources (authority — always defer to these)
 The **primary, official** sources this skill rests on; rules are always interpreted against these:
 - **KVKK** (Turkey): https://www.kvkk.gov.tr/ — the law, regulations, principle decisions, guidelines.


### PR DESCRIPTION
Found during a real KVKK/BDDK audit, not by a test.

`privacy-compliance` tells its agent to **check the official source** rather than decide from memory, and gives the KVKK/GDPR URLs. `privacy-agent-csk` shipped with `Read, Grep, Glob` — no `WebFetch`.

A rule an agent cannot obey does not fail loudly; it degrades into the thing the rule forbids. The audit only came out right because the routing split the work by hand — code review to the specialist, legislation to `general-purpose` — and a human noticed and asked why. That is the kit compensating for its own defect.

**Scoped by evidence, not symmetry.** The security skills were checked too: they do not need it. Their authority is a tool they can already run (`npm audit`, `pip-audit` via Bash), not a document to retrieve. Adding a capability no skill asks for would be an idle component.

**The class is gated now.** A skill declares what it needs — `<!-- Requires-tool: X -->` — and `smoke-test` checks it against every agent that applies that skill. Declared rather than inferred: guessing "this skill probably needs the web" from prose would make it a heuristic, and a heuristic gate is one nobody believes when it fires.

Asserted both ways: green as shipped, and red — naming the agent, the tool and the skill — when `WebFetch` is removed again.