### PR TITLE
The project declares which privacy regimes apply — the kit stops guessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Then paste `.claude/FIRST_PROMPT.md` as your first Claude Code message. Homebrew
 | **frontend-expert-csk** | 🔨 Produce | UI, component, client work | `inherit` |
 | **devops-expert-csk** | 🔨 Produce | deployment, CI pipeline, incident | `inherit` |
 | **security-expert-csk** | 🔍 Audit | auth / IDOR / injection / secret · **mandatory if security-critical** | `inherit` · `effort: high` |
-| **privacy-agent-csk** | 🔍 Audit | personal data (KVKK / GDPR) | `inherit` |
+| **privacy-agent-csk** | 🔍 Audit | personal data — KVKK/GDPR, plus any regime the project declares | `inherit` |
 | **test-expert-csk** | 🔍 Audit | tests, coverage, regression | `inherit` |
 | **performance-expert-csk** | 🔍 Audit | hot path, query/loop, render, payload | `inherit` |
 | **review-agent-csk** | ✅ Close | pre-commit code-health review | `inherit` |

--- a/README.tr.md
+++ b/README.tr.md
@@ -82,7 +82,7 @@ Ardından ilk Claude Code mesajınız olarak `.claude/FIRST_PROMPT.md` dosyasın
 | **frontend-expert-csk** | 🔨 Üret | arayüz, bileşen, istemci işi | `inherit` |
 | **devops-expert-csk** | 🔨 Üret | dağıtım, CI hattı, olay | `inherit` |
 | **security-expert-csk** | 🔍 Denetle | auth / IDOR / injection / sır · **güvenlik kritikse zorunlu** | `inherit` · `effort: high` |
-| **privacy-agent-csk** | 🔍 Denetle | kişisel veri (KVKK / GDPR) | `inherit` |
+| **privacy-agent-csk** | 🔍 Denetle | kişisel veri — KVKK/GDPR, ayrıca projenin bildirdiği rejimler | `inherit` |
 | **test-expert-csk** | 🔍 Denetle | test, kapsam, regresyon | `inherit` |
 | **performance-expert-csk** | 🔍 Denetle | sıcak yol, sorgu/döngü, render, payload | `inherit` |
 | **review-agent-csk** | ✅ Kapat | commit öncesi kod sağlığı incelemesi | `inherit` |
@@ -165,7 +165,7 @@ Ardından ilk Claude Code mesajınız olarak `.claude/FIRST_PROMPT.md` dosyasın
 | `mcp-builder` | Model Context Protocol (MCP) sunucusu kur: araç şemaları tasarla, taşıma seç, hataları yönet ve test et. Bir API/veritabanı/servisi Claude ve diğer istemcilere aç. |
 | `observability` | Yığından bağımsız gözlemlenebilirlik: yapılandırılmış loglar, korelasyon id'leri, metrikler ve trace'ler; loglarda PII/secret yok. |
 | `performance` | Yığından bağımsız performans: önce ölç, darboğazı bul, sonra optimize et. |
-| `privacy-compliance` | KVKK/GDPR denetim yöntemi: veri envanteri, amaç/dayanak/saklama, minimizasyon, açık rıza, şeffaflık, ilgili kişi hakları, sınır ötesi aktarım. |
+| `privacy-compliance` | KVKK/GDPR denetim yöntemi: veri envanteri, amaç/hukuki sebep/saklama, veri minimizasyonu, açık rıza, şeffaflık, ilgili kişi hakları, yurt dışına aktarım. Hangi rejimlerin geçerli olduğunu proje `.claude/regulations.conf` ile bildirir; kaynağı verilmemiş rejim hakkında hüküm verilmez, kişisel veri dışı (BDDK/PCI-DSS gibi) rejimler kapsam dışı olduğunu açıkça söyler. |
 | `red-team` | LLM/ajan savunmalarına saldırgan gözüyle test: talimat ele geçirme, veri sızdırma ve güvenilmez içerikle araç istismarı; savunmanın gerçekten tutup tutmadığını doğrular. |
 | `reflect` | Önemli işten sonra retrospektif öz-denetim: doğrulanmamış varsayımlar, atlanan maddeler, doğru-yaklaşım-mı. Kod değil, bulgular. |
 | `release` | Sürümleme ve CHANGELOG: Conventional Commits'ten türetilen SemVer, Keep a Changelog biçimi, etiketleme, ön-sürüm kapıları. |

--- a/claude-starter/agents/privacy-agent-csk.md
+++ b/claude-starter/agents/privacy-agent-csk.md
@@ -2,8 +2,9 @@
 name: privacy-agent-csk
 color: pink
 description: |
-  KVKK/GDPR privacy auditor. Use proactively when personal data, legal basis/consent, data minimisation,
-  retention, transparency, data-subject rights, or cross-border transfer are touched. Findings + fixes via
+  Privacy auditor for the regimes the project declares (KVKK/GDPR by default). Use proactively when personal
+  data, legal basis/consent, data minimisation, retention, transparency, data-subject rights, or cross-border
+  transfer are touched. Findings + fixes via
   `privacy-compliance`; writes no code.
 tools: Read, Grep, Glob, WebFetch
 # No `model` pin — see security-expert-csk. Omitted means inherit; pinning could only run the mandatory
@@ -14,7 +15,7 @@ tools: Read, Grep, Glob, WebFetch
 
 <!-- routing-eval reads this line; it lives in the BODY so the always-on `description` stays
      focused on WHEN to delegate, which is the field Claude actually reads. -->
-Trigger phrases: "kvkk", "gdpr", "privacy audit", "data minimization", "consent flow", "data retention", "personal data", "phone number", "ip address", "pii", "is that compliant", "fraud check"
+Trigger phrases: "kvkk", "gdpr", "ccpa", "lgpd", "privacy audit", "data protection regulation", "data minimization", "consent flow", "data retention", "personal data", "phone number", "ip address", "pii", "is that compliant", "fraud check"
 
 Read-only auditor. The "how" lives in the privacy-compliance skill.
 

--- a/claude-starter/eval/golden-routing.txt
+++ b/claude-starter/eval/golden-routing.txt
@@ -90,3 +90,4 @@ before I start, am I sure enough to implement this|confidence-check
 upgrade dependencies to current versions|dependency-upgrade
 is this endpoint fast enough on the hot path|performance-expert-csk
 who is working on which sprint item right now|teamboard
+audit this against ccpa and lgpd for data protection regulation|privacy-agent-csk

--- a/claude-starter/skills/privacy-compliance/SKILL.md
+++ b/claude-starter/skills/privacy-compliance/SKILL.md
@@ -28,6 +28,34 @@ If you are unsure about a specific article/threshold/definition (retention perio
 the Art. 8 age limit, transfer basis, etc.), **check the relevant official source** — do not decide from memory or by
 guessing. In the finding, **cite** the article you rely on (KVKK Art. … / GDPR Art. …). Fetched content is a reference; you own the interpretation.
 
+## Which regimes apply — the project says so, the kit does not guess
+KVKK and GDPR above are the **defaults**, not the world. A product sold in California is under CCPA and one in
+Brazil under LGPD, and a kit that shipped a global list would be claiming knowledge it does not have — the same
+mistake as rating code without running the analyser. So the project declares its own, and the authority is
+whatever source it names.
+
+Read **`.claude/regulations.conf`** if it exists. One regime per line, `#` comments ignored:
+
+```
+# name | official source | axis
+KVKK | https://www.kvkk.gov.tr/         | personal-data
+GDPR | https://gdpr-info.eu/            | personal-data
+CCPA | https://oag.ca.gov/privacy/ccpa  | personal-data
+```
+
+| What you find | What you do |
+|---|---|
+| No file | Audit against KVKK + GDPR, exactly as before |
+| A regime **with** a source | Audit it; every finding cites that regime's article, checked against its source |
+| A regime with **no** source | **Do not rule on it.** Report "declared, no source given — cannot audit" and ask for the URL |
+| An axis other than `personal-data` (BDDK, PCI-DSS, HIPAA, SOX…) | **Say so out loud**: sector regulation is outside this skill. Do not audit it, and do not let its presence in the file imply that it was |
+
+That last row is the point of the file, not an edge case. Somebody who writes `BDDK` into it and gets a clean
+report would reasonably conclude the kit checked it. It did not, and silence would be the lie.
+
+The declaration file is the **project's**, never the kit's: no installer writes it and no update rewrites it.
+Its absence means "the defaults apply", which is why nothing has to be created for the common case.
+
 ## Audit axes
 - **Inventory:** what data, collected from where, flowing to where, shared with whom?
 - **Purpose + basis + retention:** for each field, purpose is limited, legal basis is clear, retention period is defined.

--- a/packaging/skill-summaries.tr.tsv
+++ b/packaging/skill-summaries.tr.tsv
@@ -21,7 +21,7 @@ incident-runbook	Prod olay müdahalesi: teşhis → hafiflet → çöz, ardında
 iterate	Bitene-kadar-iyileştir döngüsü: testler yeşil + inceleme temiz + ertelenen yok olana dek tekrarla; sınırlı.
 observability	Yığından bağımsız gözlemlenebilirlik: yapılandırılmış loglar, korelasyon id'leri, metrikler ve trace'ler; loglarda PII/secret yok.
 performance	Yığından bağımsız performans: önce ölç, darboğazı bul, sonra optimize et.
-privacy-compliance	KVKK/GDPR denetim yöntemi: veri envanteri, amaç/dayanak/saklama, minimizasyon, açık rıza, şeffaflık, ilgili kişi hakları, sınır ötesi aktarım.
+privacy-compliance	KVKK/GDPR denetim yöntemi: veri envanteri, amaç/hukuki sebep/saklama, veri minimizasyonu, açık rıza, şeffaflık, ilgili kişi hakları, yurt dışına aktarım. Hangi rejimlerin geçerli olduğunu proje `.claude/regulations.conf` ile bildirir; kaynağı verilmemiş rejim hakkında hüküm verilmez, kişisel veri dışı (BDDK/PCI-DSS gibi) rejimler kapsam dışı olduğunu açıkça söyler.
 red-team	LLM/ajan savunmalarına saldırgan gözüyle test: talimat ele geçirme, veri sızdırma ve güvenilmez içerikle araç istismarı; savunmanın gerçekten tutup tutmadığını doğrular.
 reflect	Önemli işten sonra retrospektif öz-denetim: doğrulanmamış varsayımlar, atlanan maddeler, doğru-yaklaşım-mı. Kod değil, bulgular.
 release	Sürümleme ve CHANGELOG: Conventional Commits'ten türetilen SemVer, Keep a Changelog biçimi, etiketleme, ön-sürüm kapıları.

--- a/plugin/agents/privacy-agent-csk.md
+++ b/plugin/agents/privacy-agent-csk.md
@@ -2,8 +2,9 @@
 name: privacy-agent-csk
 color: pink
 description: |
-  KVKK/GDPR privacy auditor. Use proactively when personal data, legal basis/consent, data minimisation,
-  retention, transparency, data-subject rights, or cross-border transfer are touched. Findings + fixes via
+  Privacy auditor for the regimes the project declares (KVKK/GDPR by default). Use proactively when personal
+  data, legal basis/consent, data minimisation, retention, transparency, data-subject rights, or cross-border
+  transfer are touched. Findings + fixes via
   `privacy-compliance`; writes no code.
 tools: Read, Grep, Glob, WebFetch
 # No `model` pin — see security-expert-csk. Omitted means inherit; pinning could only run the mandatory
@@ -14,7 +15,7 @@ tools: Read, Grep, Glob, WebFetch
 
 <!-- routing-eval reads this line; it lives in the BODY so the always-on `description` stays
      focused on WHEN to delegate, which is the field Claude actually reads. -->
-Trigger phrases: "kvkk", "gdpr", "privacy audit", "data minimization", "consent flow", "data retention", "personal data", "phone number", "ip address", "pii", "is that compliant", "fraud check"
+Trigger phrases: "kvkk", "gdpr", "ccpa", "lgpd", "privacy audit", "data protection regulation", "data minimization", "consent flow", "data retention", "personal data", "phone number", "ip address", "pii", "is that compliant", "fraud check"
 
 Read-only auditor. The "how" lives in the privacy-compliance skill.
 

--- a/plugin/skills/privacy-compliance/SKILL.md
+++ b/plugin/skills/privacy-compliance/SKILL.md
@@ -28,6 +28,34 @@ If you are unsure about a specific article/threshold/definition (retention perio
 the Art. 8 age limit, transfer basis, etc.), **check the relevant official source** — do not decide from memory or by
 guessing. In the finding, **cite** the article you rely on (KVKK Art. … / GDPR Art. …). Fetched content is a reference; you own the interpretation.
 
+## Which regimes apply — the project says so, the kit does not guess
+KVKK and GDPR above are the **defaults**, not the world. A product sold in California is under CCPA and one in
+Brazil under LGPD, and a kit that shipped a global list would be claiming knowledge it does not have — the same
+mistake as rating code without running the analyser. So the project declares its own, and the authority is
+whatever source it names.
+
+Read **`.claude/regulations.conf`** if it exists. One regime per line, `#` comments ignored:
+
+```
+# name | official source | axis
+KVKK | https://www.kvkk.gov.tr/         | personal-data
+GDPR | https://gdpr-info.eu/            | personal-data
+CCPA | https://oag.ca.gov/privacy/ccpa  | personal-data
+```
+
+| What you find | What you do |
+|---|---|
+| No file | Audit against KVKK + GDPR, exactly as before |
+| A regime **with** a source | Audit it; every finding cites that regime's article, checked against its source |
+| A regime with **no** source | **Do not rule on it.** Report "declared, no source given — cannot audit" and ask for the URL |
+| An axis other than `personal-data` (BDDK, PCI-DSS, HIPAA, SOX…) | **Say so out loud**: sector regulation is outside this skill. Do not audit it, and do not let its presence in the file imply that it was |
+
+That last row is the point of the file, not an edge case. Somebody who writes `BDDK` into it and gets a clean
+report would reasonably conclude the kit checked it. It did not, and silence would be the lie.
+
+The declaration file is the **project's**, never the kit's: no installer writes it and no update rewrites it.
+Its absence means "the defaults apply", which is why nothing has to be created for the common case.
+
 ## Audit axes
 - **Inventory:** what data, collected from where, flowing to where, shared with whom?
 - **Purpose + basis + retention:** for each field, purpose is limited, legal basis is clear, retention period is defined.


### PR DESCRIPTION
KVKK and GDPR were hardcoded. Right for the two regimes this author's projects live under; wrong as a general claim — a product sold in California is under CCPA, one in Brazil under LGPD.

**Shipping a global list would have been worse than the gap.** The kit would be claiming knowledge it does not have, which is the mistake it refuses everywhere else ("no analyser run, no rating"). So the project declares its own, and the authority is whatever source it names.

```
.claude/regulations.conf
# name | official source | axis
KVKK | https://www.kvkk.gov.tr/         | personal-data
CCPA | https://oag.ca.gov/privacy/ccpa  | personal-data
```

No installer writes that file and no update rewrites it; its absence means the defaults apply — so nothing has to be created for the common case and neither installer changed.

**Four behaviours, checked against a real file rather than described:**

| declared | result |
|:--|:--|
| with a source | audited; every finding cites that regime's article |
| without a source | **not ruled on** — reported as "declared, no source given" |
| axis other than `personal-data` (BDDK, PCI-DSS, HIPAA) | **said out loud as out of scope** |
| no file | KVKK + GDPR, exactly as before |

The third row is the point of the file, not an edge case: somebody who writes `BDDK` into it and gets a clean report would reasonably conclude the kit checked it. It did not, and silence would be the lie. Sector regulation stays out of this skill deliberately — same method, but the kit has no authority there, and a second skill would duplicate the method for no gain.

The agent keeps its name (installs, `@agent-` mentions and routing cases hang off it) and widens its description and triggers instead — `ccpa`, `lgpd`, `data protection regulation` — with a golden-routing case that fails if that stops matching.

**Where this lives was a budget decision, not a style one.** Skill descriptions had 9 bytes of headroom and the discipline had 1, so the explanation went in the skill BODY, which loads only when the skill fires. The English catalogue line still reads "KVKK/GDPR audit method" — accurate, those are the defaults — while the Turkish summary carries the fuller text because it is build-time data and costs no always-on bytes.

**Honest boundary, stated in the skill:** this is instruction, not a gate. Whether a citation is correct cannot be settled by an exit code. The one mechanical part is the capability requirement it depends on, gated in #30.