### PR TITLE
"Independent" cost a separate context, and we were not paying it

### DIFF
--- a/claude-starter/agents/performance-expert-csk.md
+++ b/claude-starter/agents/performance-expert-csk.md
@@ -68,3 +68,9 @@ a separate, explicitly requested task.
 - A fix proposal states the expected gain and the re-measurement that must confirm it — the fix is not "done"
   until the second measurement exists.
 - Writes no code.
+
+## When you cannot establish it
+Without a measurement you are guessing which line matters, and intuition about hot paths is famously unreliable —
+which is why profilers exist. If you have no number, write **"unmeasured"**, never "slow", and name the
+measurement that would settle it (the command, the workload, what you would compare it against). A ranked
+performance finding with no number attached is a preference.

--- a/claude-starter/agents/privacy-agent-csk.md
+++ b/claude-starter/agents/privacy-agent-csk.md
@@ -59,5 +59,11 @@ On a flow that processes personal data with an unclear legal basis, **stop and r
 - ✅ A new flow that collects/processes personal data
 - ❌ A technical refactor with no personal data
 
+## When you cannot establish it
+Rank by what a real data subject actually loses, not by how arguable the classification is — a report that treats
+a leaked identity number and a locale preference alike stops being usable, and a team that cannot see the
+difference ships both or neither. Cite the article you relied on; if the source did not settle it, say the
+question is open rather than choosing the strictest available reading on its behalf.
+
 ## Prohibitions (absolute)
 CLAUDE.md §4 applies.

--- a/claude-starter/agents/review-agent-csk.md
+++ b/claude-starter/agents/review-agent-csk.md
@@ -61,6 +61,12 @@ On a blocking finding, raise an explicit **stop** marker with rationale; don't c
 - ✅ Reviewing a PR/change set
 - ❌ Writing/fixing code (goes to the author specialist)
 
+## When you cannot establish it
+For any "fixed" / "passes" claim, name the command whose exit code you checked. Re-reading the code is not
+verification and "it looks right now" is not a passing test — if you cannot name the check, downgrade the claim
+instead of restating it. The same applies to severity: a finding you cannot tie to a behaviour is a nit, whatever
+it looks like, and ranking it higher spends the credibility you will need for the next real blocker.
+
 ## Prohibitions (absolute)
 CLAUDE.md §4 applies. In review, additionally catch: §4.1 AI-authorship traces (co-author trailers,
 auto-generation footers, robot emoji, AI-assistant/tool names, the .claude name — see trace-blocklist.txt)

--- a/claude-starter/agents/security-expert-csk.md
+++ b/claude-starter/agents/security-expert-csk.md
@@ -59,6 +59,13 @@ On an exploitable CRITICAL finding, **warn clearly**; don't report a finding you
 - ✅ Auth/secret/IDOR/injection touch
 - ❌ Simple style fix (goes to review-agent-csk)
 
+## When you cannot establish it
+Severity follows the preconditions you could actually demonstrate, not the ones that would make the finding
+matter. If you could not establish reachability from untrusted input, say which precondition is unproven and rank
+it there — an unproven medium is worth more than a confident critical nobody trusts, because the second one
+teaches the reader to discount the next report too. `CANNOT_VERIFY` is a real verdict; use it instead of rounding
+up.
+
 ## Prohibitions (absolute)
 CLAUDE.md §4 applies. In your audit, also flag §4.1 (AI trace) and §4.2 (vendor template name)
 leaks as findings.

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -128,8 +128,18 @@ pass "agent->skill references (applies + Also apply) checked"
 # (c) progressive disclosure: a `references/X.md` pointer in a SKILL.md body must resolve to a real file
 for d in "$SKILLS"/*/; do
   f="$d/SKILL.md"; [ -f "$f" ] || continue
-  for ref in $(grep -oE 'references/[A-Za-z0-9_-]+\.md' "$f" | sort -u); do
-    [ -f "$d/$ref" ] || fail "$(basename "$d"): SKILL.md points to missing $ref"
+  # A pointer may be to this skill's own references/ OR, qualified with a skill name, to another skill's —
+  # `security-scan/references/verify.md`. Cross-skill is legitimate and the kit's single-source-of-truth rule
+  # depends on it: the verifier contract lives in one file and code-review-csk points at it rather than keeping a
+  # second copy to drift. The check stays strict either way — a wrong skill name or a missing file still fails.
+  for ref in $(grep -oE '([a-z0-9-]+/)?references/[A-Za-z0-9_-]+\.md' "$f" | sort -u); do
+    case "$ref" in
+      */references/*.md)
+        case "$ref" in
+          references/*) [ -f "$d/$ref" ] || fail "$(basename "$d"): SKILL.md points to missing $ref" ;;
+          *) [ -f "$SKILLS/$ref" ] || fail "$(basename "$d"): SKILL.md points to missing $ref (cross-skill)" ;;
+        esac ;;
+    esac
   done
 done
 pass "skill references/*.md pointers resolve"

--- a/claude-starter/skills/code-review-csk/SKILL.md
+++ b/claude-starter/skills/code-review-csk/SKILL.md
@@ -85,6 +85,13 @@ Before a finding is reported — especially a **blocker** — run a second, inde
 A finding that survives the disprove pass is a verdict; one that doesn't is dropped or downgraded. This is what kills
 false-positive blockers that stall progress while keeping the review's authority.
 
+**"Independent" costs a separate context.** A second pass in the same context has already read the first one's
+reasoning, so it cannot be blind to it — and its agreement is the first pass nodding at itself. For a **blocker**,
+run the disprove pass as its own subagent, handed the claim and the `file:line` but not your argument. If you did
+not isolate it, label the verdict as a single pass rather than calling it independent. The full contract —
+isolation, one lens per verifier, and why unanimity for the same reason is a monoculture — lives in
+`security-scan/references/verify.md`; it is one discipline, not two.
+
 ## Panel mode (high-stakes decisions only)
 
 For hard-to-reverse calls (architecture, public API, security boundary), run several independent adversarial lenses then synthesize. Full method: **`references/panel-mode.md`**.

--- a/claude-starter/skills/confidence-check/SKILL.md
+++ b/claude-starter/skills/confidence-check/SKILL.md
@@ -66,6 +66,19 @@ Five lines, one per check: `✅ <what was run/read>` or `❌ <what is missing>` 
 "starting" or the single action that unblocks it. Keep it to the main thread; it is a handful of lines, not a
 document.
 
+## Fix the deciding rule before you see the options
+When this check ends in a choice — which approach, which library, which of three designs — write down what would
+make an option **win**, and what would **disqualify** one, *before* generating or evaluating any. A criterion
+chosen after the options exist is a criterion shaped by them: it will quietly favour the one already preferred,
+and nothing in the output will show that it did.
+
+Write the **kill criterion** in the same breath: what would make you abandon the whole approach. An option set
+with no losing condition is a preference wearing an analysis.
+
+> Honest boundary: this one is discipline, not a gate. Nothing can check whether the rule was written before the
+> options or backfilled after them — the value is that the user can see the rule stated first and argue with it,
+> which is impossible when the criterion never leaves your head. Treat it as cheap insurance, not as proof.
+
 ## DoD (this skill's contribution)
 - Every check is answered with a named command, file, or document — never with a recollection.
 - Any "no" was resolved before implementation started, or is recorded as a user-accepted assumption.

--- a/claude-starter/skills/security-scan/references/verify.md
+++ b/claude-starter/skills/security-scan/references/verify.md
@@ -15,6 +15,43 @@ audit). Each verifier:
 - Is stanced **"find any reason this finding is wrong."** Actively hunt for why it is *not* exploitable.
 - Is **blind to the other verifiers' reasoning** — shared context propagates the same blind spot.
 
+### "Independent" means a separate context, or it means nothing
+Three passes inside one context window are not three verifiers. The second pass has already read the first one's
+reasoning; the blindness above is then a wish, not a property, and the agreement it produces is one argument
+counted three times. So:
+- **Each verifier is its own subagent** (`Agent`, one call per verifier, run in parallel). A subagent has its own
+  context window: it cannot see what the others concluded, which is the whole point. Read-only work, so no
+  `worktree` is needed — nothing is being written.
+- **Give it the finding and the file:line, never your reasoning.** Not "I think X is exploitable because Y" —
+  just "claim: X at file:line. Try to refute it."
+- **If you did not isolate, say so.** Write `verifiers: 1 (single pass, not isolated)` in the verdict block. A
+  single honest pass is useful; three passes labelled as independent when they were not is worse than one,
+  because it launders confidence.
+
+**Cost gate, because isolation is not free** — each subagent re-pays for its own context (see `token-budget`), so
+N×findings gets expensive fast. Isolate by stake, not by default:
+- **blocker / high severity, or anything heading for a release** → isolate, N=3 (N=5 for a release audit).
+- **medium** → isolate, N=1. One genuinely independent pass beats three entangled ones.
+- **low / nit** → single inline pass, labelled as such. Do not spend a subagent proving a nit.
+
+### The verifiers must not be three copies of one method
+Independent is still not uncorrelated. Three verifiers running the same four steps fail in the same place, and
+their agreement then reads as confirmation when it is only repetition. Assign each a **different attack**:
+- **Reachability** — can untrusted input actually arrive here? Quote the first call-site as evidence.
+- **Protection** — does something on every path already stop it? Try to break each guard.
+- **Reproduction** — what input, in what state, actually triggers it? If you cannot name one, that is
+  `CANNOT_VERIFY`, not agreement with the others.
+
+At N=5 add **exclusion rules** (does this match a known FALSE_POSITIVE class below?) and **blast radius** (if it
+is real, what does it actually reach?). Record which lens produced which verdict — a verdict whose lens is
+unnamed cannot be weighed.
+
+### Unanimity is a signal to check, not a verdict to trust
+If every verifier returns the same verdict **for the same reason**, that is one argument counted N times. Before
+accepting it, run one counterfactual pass: *"assume this verdict is wrong — what would have to be true, and what
+evidence would show it?"* Record the answer beside the verdict. Unanimity with N distinct reasons is strong;
+unanimity with one reason is a monoculture, and it is exactly how a whole panel misses the same guard.
+
 ## The 4-step verify procedure (each step kills a specific false-positive class)
 1. **Read the cited code yourself** — do not trust the description.
 2. **Trace reachability backward from the sink.** Can untrusted input actually reach it? **Quote the first
@@ -52,10 +89,16 @@ Add project-specific rules as you confirm them.
 ```
 VERDICT: TRUE_POSITIVE | FALSE_POSITIVE | CANNOT_VERIFY
 CONFIDENCE: 0-10
+VERIFIERS: <N, isolated | N, single pass not isolated>
+LENSES: <reachability, protection, reproduction — which ones actually ran>
+AGREEMENT: <unanimous-same-reason | unanimous-distinct-reasons | split N-M>
 REACHABILITY: <first untrusted call-site file:line, or "unreachable">
 EXCLUSION_RULE: <number, or none>
 RATIONALE: <cites concrete file:line, not prose>
 ```
+`VERIFIERS` and `AGREEMENT` exist so the reader can discount the verdict without re-doing the work. "3, single
+pass not isolated" and "unanimous-same-reason" together mean one argument wearing three hats — still worth
+reporting, not worth treating as three. Leaving these fields out is how a weak verdict passes for a strong one.
 
 ## Tally
 Verdict = majority of the N verifiers; confidence = mean of the agreeing votes. **Tie → the operator's noise

--- a/plugin/agents/performance-expert-csk.md
+++ b/plugin/agents/performance-expert-csk.md
@@ -68,3 +68,9 @@ a separate, explicitly requested task.
 - A fix proposal states the expected gain and the re-measurement that must confirm it — the fix is not "done"
   until the second measurement exists.
 - Writes no code.
+
+## When you cannot establish it
+Without a measurement you are guessing which line matters, and intuition about hot paths is famously unreliable —
+which is why profilers exist. If you have no number, write **"unmeasured"**, never "slow", and name the
+measurement that would settle it (the command, the workload, what you would compare it against). A ranked
+performance finding with no number attached is a preference.

--- a/plugin/agents/privacy-agent-csk.md
+++ b/plugin/agents/privacy-agent-csk.md
@@ -59,5 +59,11 @@ On a flow that processes personal data with an unclear legal basis, **stop and r
 - ✅ A new flow that collects/processes personal data
 - ❌ A technical refactor with no personal data
 
+## When you cannot establish it
+Rank by what a real data subject actually loses, not by how arguable the classification is — a report that treats
+a leaked identity number and a locale preference alike stops being usable, and a team that cannot see the
+difference ships both or neither. Cite the article you relied on; if the source did not settle it, say the
+question is open rather than choosing the strictest available reading on its behalf.
+
 ## Prohibitions (absolute)
 CLAUDE.md §4 applies.

--- a/plugin/agents/review-agent-csk.md
+++ b/plugin/agents/review-agent-csk.md
@@ -61,6 +61,12 @@ On a blocking finding, raise an explicit **stop** marker with rationale; don't c
 - ✅ Reviewing a PR/change set
 - ❌ Writing/fixing code (goes to the author specialist)
 
+## When you cannot establish it
+For any "fixed" / "passes" claim, name the command whose exit code you checked. Re-reading the code is not
+verification and "it looks right now" is not a passing test — if you cannot name the check, downgrade the claim
+instead of restating it. The same applies to severity: a finding you cannot tie to a behaviour is a nit, whatever
+it looks like, and ranking it higher spends the credibility you will need for the next real blocker.
+
 ## Prohibitions (absolute)
 CLAUDE.md §4 applies. In review, additionally catch: §4.1 AI-authorship traces (co-author trailers,
 auto-generation footers, robot emoji, AI-assistant/tool names, the .claude name — see trace-blocklist.txt)

--- a/plugin/agents/security-expert-csk.md
+++ b/plugin/agents/security-expert-csk.md
@@ -59,6 +59,13 @@ On an exploitable CRITICAL finding, **warn clearly**; don't report a finding you
 - ✅ Auth/secret/IDOR/injection touch
 - ❌ Simple style fix (goes to review-agent-csk)
 
+## When you cannot establish it
+Severity follows the preconditions you could actually demonstrate, not the ones that would make the finding
+matter. If you could not establish reachability from untrusted input, say which precondition is unproven and rank
+it there — an unproven medium is worth more than a confident critical nobody trusts, because the second one
+teaches the reader to discount the next report too. `CANNOT_VERIFY` is a real verdict; use it instead of rounding
+up.
+
 ## Prohibitions (absolute)
 CLAUDE.md §4 applies. In your audit, also flag §4.1 (AI trace) and §4.2 (vendor template name)
 leaks as findings.

--- a/plugin/skills/code-review-csk/SKILL.md
+++ b/plugin/skills/code-review-csk/SKILL.md
@@ -85,6 +85,13 @@ Before a finding is reported — especially a **blocker** — run a second, inde
 A finding that survives the disprove pass is a verdict; one that doesn't is dropped or downgraded. This is what kills
 false-positive blockers that stall progress while keeping the review's authority.
 
+**"Independent" costs a separate context.** A second pass in the same context has already read the first one's
+reasoning, so it cannot be blind to it — and its agreement is the first pass nodding at itself. For a **blocker**,
+run the disprove pass as its own subagent, handed the claim and the `file:line` but not your argument. If you did
+not isolate it, label the verdict as a single pass rather than calling it independent. The full contract —
+isolation, one lens per verifier, and why unanimity for the same reason is a monoculture — lives in
+`security-scan/references/verify.md`; it is one discipline, not two.
+
 ## Panel mode (high-stakes decisions only)
 
 For hard-to-reverse calls (architecture, public API, security boundary), run several independent adversarial lenses then synthesize. Full method: **`references/panel-mode.md`**.

--- a/plugin/skills/confidence-check/SKILL.md
+++ b/plugin/skills/confidence-check/SKILL.md
@@ -66,6 +66,19 @@ Five lines, one per check: `✅ <what was run/read>` or `❌ <what is missing>` 
 "starting" or the single action that unblocks it. Keep it to the main thread; it is a handful of lines, not a
 document.
 
+## Fix the deciding rule before you see the options
+When this check ends in a choice — which approach, which library, which of three designs — write down what would
+make an option **win**, and what would **disqualify** one, *before* generating or evaluating any. A criterion
+chosen after the options exist is a criterion shaped by them: it will quietly favour the one already preferred,
+and nothing in the output will show that it did.
+
+Write the **kill criterion** in the same breath: what would make you abandon the whole approach. An option set
+with no losing condition is a preference wearing an analysis.
+
+> Honest boundary: this one is discipline, not a gate. Nothing can check whether the rule was written before the
+> options or backfilled after them — the value is that the user can see the rule stated first and argue with it,
+> which is impossible when the criterion never leaves your head. Treat it as cheap insurance, not as proof.
+
 ## DoD (this skill's contribution)
 - Every check is answered with a named command, file, or document — never with a recollection.
 - Any "no" was resolved before implementation started, or is recorded as a user-accepted assumption.

--- a/plugin/skills/security-scan/references/verify.md
+++ b/plugin/skills/security-scan/references/verify.md
@@ -15,6 +15,43 @@ audit). Each verifier:
 - Is stanced **"find any reason this finding is wrong."** Actively hunt for why it is *not* exploitable.
 - Is **blind to the other verifiers' reasoning** — shared context propagates the same blind spot.
 
+### "Independent" means a separate context, or it means nothing
+Three passes inside one context window are not three verifiers. The second pass has already read the first one's
+reasoning; the blindness above is then a wish, not a property, and the agreement it produces is one argument
+counted three times. So:
+- **Each verifier is its own subagent** (`Agent`, one call per verifier, run in parallel). A subagent has its own
+  context window: it cannot see what the others concluded, which is the whole point. Read-only work, so no
+  `worktree` is needed — nothing is being written.
+- **Give it the finding and the file:line, never your reasoning.** Not "I think X is exploitable because Y" —
+  just "claim: X at file:line. Try to refute it."
+- **If you did not isolate, say so.** Write `verifiers: 1 (single pass, not isolated)` in the verdict block. A
+  single honest pass is useful; three passes labelled as independent when they were not is worse than one,
+  because it launders confidence.
+
+**Cost gate, because isolation is not free** — each subagent re-pays for its own context (see `token-budget`), so
+N×findings gets expensive fast. Isolate by stake, not by default:
+- **blocker / high severity, or anything heading for a release** → isolate, N=3 (N=5 for a release audit).
+- **medium** → isolate, N=1. One genuinely independent pass beats three entangled ones.
+- **low / nit** → single inline pass, labelled as such. Do not spend a subagent proving a nit.
+
+### The verifiers must not be three copies of one method
+Independent is still not uncorrelated. Three verifiers running the same four steps fail in the same place, and
+their agreement then reads as confirmation when it is only repetition. Assign each a **different attack**:
+- **Reachability** — can untrusted input actually arrive here? Quote the first call-site as evidence.
+- **Protection** — does something on every path already stop it? Try to break each guard.
+- **Reproduction** — what input, in what state, actually triggers it? If you cannot name one, that is
+  `CANNOT_VERIFY`, not agreement with the others.
+
+At N=5 add **exclusion rules** (does this match a known FALSE_POSITIVE class below?) and **blast radius** (if it
+is real, what does it actually reach?). Record which lens produced which verdict — a verdict whose lens is
+unnamed cannot be weighed.
+
+### Unanimity is a signal to check, not a verdict to trust
+If every verifier returns the same verdict **for the same reason**, that is one argument counted N times. Before
+accepting it, run one counterfactual pass: *"assume this verdict is wrong — what would have to be true, and what
+evidence would show it?"* Record the answer beside the verdict. Unanimity with N distinct reasons is strong;
+unanimity with one reason is a monoculture, and it is exactly how a whole panel misses the same guard.
+
 ## The 4-step verify procedure (each step kills a specific false-positive class)
 1. **Read the cited code yourself** — do not trust the description.
 2. **Trace reachability backward from the sink.** Can untrusted input actually reach it? **Quote the first
@@ -52,10 +89,16 @@ Add project-specific rules as you confirm them.
 ```
 VERDICT: TRUE_POSITIVE | FALSE_POSITIVE | CANNOT_VERIFY
 CONFIDENCE: 0-10
+VERIFIERS: <N, isolated | N, single pass not isolated>
+LENSES: <reachability, protection, reproduction — which ones actually ran>
+AGREEMENT: <unanimous-same-reason | unanimous-distinct-reasons | split N-M>
 REACHABILITY: <first untrusted call-site file:line, or "unreachable">
 EXCLUSION_RULE: <number, or none>
 RATIONALE: <cites concrete file:line, not prose>
 ```
+`VERIFIERS` and `AGREEMENT` exist so the reader can discount the verdict without re-doing the work. "3, single
+pass not isolated" and "unanimous-same-reason" together mean one argument wearing three hats — still worth
+reporting, not worth treating as three. Leaving these fields out is how a weak verdict passes for a strong one.
 
 ## Tally
 Verdict = majority of the N verifiers; confidence = mean of the agreeing votes. **Tie → the operator's noise


### PR DESCRIPTION
Comparing the kit against a deliberation framework turned up a defect in **our** file rather than an idea to borrow.

`verify.md` required N independent verifiers, each "blind to the other verifiers' reasoning" — and never said where they run. Three passes inside one context window have already read the first one's reasoning: the blindness was a wish, not a property, and the unanimity it produced was one argument counted three times.

- Each verifier is now its **own subagent**, handed the claim and the `file:line` but not the finder's argument.
- When isolation did not happen, the verdict says so: `VERIFIERS: 1 (single pass, not isolated)`. One honest pass is useful; three entangled ones labelled independent are worse than one, because they launder confidence.
- **Isolation is not free**, so it is spent by stake: blockers at N=3 (5 for a release audit), medium at N=1, nits get an inline pass and are labelled as such.
- The N verifiers all ran the **same four steps**, so they failed in the same place and called it agreement. Each now takes a different attack — reachability, protection, reproduction (plus exclusion rules and blast radius at N=5) — and the verdict block records which lens produced it.
- **Unanimity for the same reason** now triggers a counterfactual pass before it is accepted, with `AGREEMENT` in the block so a reader can discount a verdict without redoing the work.

Four audit agents gain a calibration rule — what to do when you *cannot* establish something: say which precondition is unproven rather than rounding severity up; write "unmeasured", never "slow"; rank privacy findings by what a subject actually loses and cite the article; name the command whose exit code you checked, or downgrade the claim.

These started as blind-spot **diagnoses**, borrowed in shape from that framework. Asked whether any of it had been observed here, the answer was no — so they were dropped. Not only because it is the assert-without-evidence this repo refuses elsewhere, but because a diagnosis points a direction, and for three of the four the direction pushes toward the **more expensive error**: an under-flagging security auditor misses a vulnerability, a downgrading review lets a real blocker through, a quiet privacy audit has legal consequences.

The reference gate learned a form it had never met — a SKILL.md may point at **another** skill's `references/` file, so the verifier contract lives in one place instead of a copy that drifts. Widened, not weakened: asserted in three states (bogus skill prefix fails, valid skill with missing file fails, correct pointer passes).

**Honest boundary:** of everything here only the isolation rule is *observable* — a transcript shows whether subagents ran. The rest is instruction.