### PR TITLE
Record refusals — they were the lock's only evidence and it left none

### DIFF
--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -325,6 +325,20 @@ else
     pass "claiming leaves the worktree and branch untouched (dirty file and branch survive)"
   else fail "claiming disturbed the worktree/branch (status='$ST' branch='$BR')"; fi
 
+  # 5a-ii. A REFUSAL IS THE ONLY EVIDENCE THE LOCK EVER FIRED — and it used to leave none. The message went to
+  # stderr and nowhere else, so "how often did this actually stop a collision?" could not be answered, and would
+  # still not be answerable after a trial because the data would never have existed. An instrument cannot be
+  # fitted after the experiment. Both refusal reasons are asserted, and that the record is on the BOARD rather
+  # than in one clone — a count only its author can see answers nothing about a team.
+  ( cd "$BD/ayse" && bash ../board.sh sync ) >/dev/null 2>&1
+  ( cd "$BD/ayse" && bash ../board.sh claim 001 ) >/dev/null 2>&1     # held by ali -> refused
+  ( cd "$BD/ali"  && bash ../board.sh sync ) >/dev/null 2>&1
+  RLOG="$(git -C "$BD/ali" cat-file -p refs/csk/board:refusals.log 2>/dev/null)"
+  case "$RLOG" in
+    *"|001|held|"*) pass "a refused claim is recorded on the board, where the whole team can count it" ;;
+    *) fail "the refusal left no trace — the lock's only evidence is unrecorded: [$RLOG]" ;;
+  esac
+
   # 5b-ii. THE CLOCK MUST NOT RESTART. Re-claiming an item you already hold used to rewrite `since`, so an item
   # held all morning read as freshly started — which destroys the two things age is for: telling a teammate how
   # long it has been held, and letting an abandoned claim go stale. Found by reading a real session where the

--- a/claude-starter/hooks/board.sh
+++ b/claude-starter/hooks/board.sh
@@ -224,11 +224,13 @@ _apply_once(){ # -> 0 ok · 1 refused · 2 race · 3 unshared
       if [ "$status" = done ]; then printf 'board: #%s is already done\n' "$id" >&2; return 1; fi
       if [ -n "$owner" ] && [ "$owner" != "-" ] && [ "$owner" != "$me" ]; then
         printf 'board: #%s belongs to %s since %s. Free: %s\n' "$id" "$owner" "$since" "$(_free_ids)" >&2
+        _log_refusal "$id" held "$owner"
         return 1
       fi
       local blocked; blocked="$(_unmet_deps "$deps")"
       if [ -n "$blocked" ]; then
         printf 'board: #%s is blocked by #%s (not done). Free: %s\n' "$id" "$blocked" "$(_free_ids)" >&2
+        _log_refusal "$id" blocked "#$blocked"
         return 1
       fi
       if [ "$owner" = "$me" ] && [ "$status" = in_progress ]; then
@@ -369,6 +371,33 @@ $(_body "$c" | head -4 | sed 's/^/      /')"
   [ -n "$out" ] && printf 'Connected work — read this before you start, and update it when you finish:%s\n' "$out"
   return 0
 }
+
+# A refusal is the only proof the lock ever did anything, and it was the one event leaving no trace: the message
+# went to stderr and nowhere else. Nothing on the board, nothing in the history — so "how often did this actually
+# stop a collision?" was unanswerable, and would still be unanswerable after a trial, because the data would
+# never have existed. Measurement has to be installed BEFORE the thing it measures.
+#
+# Appended to the board so the count is the TEAM's, not one clone's. Refusals are rare by construction — they
+# happen only on real contention — so a push per refusal costs little, and it rides the same CAS retry as every
+# other write. Failure here is swallowed: a refusal that cannot be logged is still a refusal, and turning it
+# into an error would punish the user for the bookkeeping.
+_log_refusal(){ # _log_refusal <id> <reason> <holder>
+  _enabled || return 0
+  _have_board || return 0
+  local id="$1" reason="$2" holder="$3" attempt=1 prev line blob tree
+  line="$(_now_iso)|$id|$reason|$(_me)|${holder:--}"
+  while [ "$attempt" -le 3 ]; do
+    prev="$(_cat refusals.log 2>/dev/null)"
+    blob="$(printf '%s%s\n' "${prev:+$prev$NLR}" "$line" | _blob)"
+    tree="$(_tree_with refusals.log "$blob")" || return 0
+    _commit_push "$tree" "board: refusal #$id ($reason)" && return 0
+    _fetch >/dev/null 2>&1 || return 0
+    attempt=$((attempt+1))
+  done
+  return 0
+}
+NLR='
+'
 
 cmd_claim(){
   _mutate claim "$1"; local rc=$?

--- a/plugin/hooks/board.sh
+++ b/plugin/hooks/board.sh
@@ -224,11 +224,13 @@ _apply_once(){ # -> 0 ok · 1 refused · 2 race · 3 unshared
       if [ "$status" = done ]; then printf 'board: #%s is already done\n' "$id" >&2; return 1; fi
       if [ -n "$owner" ] && [ "$owner" != "-" ] && [ "$owner" != "$me" ]; then
         printf 'board: #%s belongs to %s since %s. Free: %s\n' "$id" "$owner" "$since" "$(_free_ids)" >&2
+        _log_refusal "$id" held "$owner"
         return 1
       fi
       local blocked; blocked="$(_unmet_deps "$deps")"
       if [ -n "$blocked" ]; then
         printf 'board: #%s is blocked by #%s (not done). Free: %s\n' "$id" "$blocked" "$(_free_ids)" >&2
+        _log_refusal "$id" blocked "#$blocked"
         return 1
       fi
       if [ "$owner" = "$me" ] && [ "$status" = in_progress ]; then
@@ -369,6 +371,33 @@ $(_body "$c" | head -4 | sed 's/^/      /')"
   [ -n "$out" ] && printf 'Connected work — read this before you start, and update it when you finish:%s\n' "$out"
   return 0
 }
+
+# A refusal is the only proof the lock ever did anything, and it was the one event leaving no trace: the message
+# went to stderr and nowhere else. Nothing on the board, nothing in the history — so "how often did this actually
+# stop a collision?" was unanswerable, and would still be unanswerable after a trial, because the data would
+# never have existed. Measurement has to be installed BEFORE the thing it measures.
+#
+# Appended to the board so the count is the TEAM's, not one clone's. Refusals are rare by construction — they
+# happen only on real contention — so a push per refusal costs little, and it rides the same CAS retry as every
+# other write. Failure here is swallowed: a refusal that cannot be logged is still a refusal, and turning it
+# into an error would punish the user for the bookkeeping.
+_log_refusal(){ # _log_refusal <id> <reason> <holder>
+  _enabled || return 0
+  _have_board || return 0
+  local id="$1" reason="$2" holder="$3" attempt=1 prev line blob tree
+  line="$(_now_iso)|$id|$reason|$(_me)|${holder:--}"
+  while [ "$attempt" -le 3 ]; do
+    prev="$(_cat refusals.log 2>/dev/null)"
+    blob="$(printf '%s%s\n' "${prev:+$prev$NLR}" "$line" | _blob)"
+    tree="$(_tree_with refusals.log "$blob")" || return 0
+    _commit_push "$tree" "board: refusal #$id ($reason)" && return 0
+    _fetch >/dev/null 2>&1 || return 0
+    attempt=$((attempt+1))
+  done
+  return 0
+}
+NLR='
+'
 
 cmd_claim(){
   _mutate claim "$1"; local rc=$?


### PR DESCRIPTION
A refused claim printed a message to stderr and stopped there. Nothing on the board, nothing in the history.

So the question the whole team-board experiment exists to answer — **how often did this actually stop two people starting the same work?** — was unanswerable, and would have stayed unanswerable *after* a trial, because the data would never have been created.

An instrument cannot be fitted after the experiment. Everything else the trial needs is computable from durable history afterwards (decisions recorded, how long items were held, the `[chore]` ratio); this one is not. That is why it is the only part built now.

Each refusal appends a line to the board:

```
2026-08-19T11:13:27Z|001|held|ayse@x|ali@x
2026-08-19T11:13:27Z|002|blocked|ayse@x|#001
```

On the **board** rather than in a local counter — a number only its author can see says nothing about a team, and the team is the unit of the question.

Three properties that were choices, not defaults:
- Refusals are rare by construction — only real contention produces one — so a push each costs little, and it rides the same fast-forward CAS retry as every other write to the ref.
- **Failure is swallowed.** A refusal that cannot be logged is still a refusal; turning bookkeeping into an error would punish the user for our measurement.
- **Nothing reads it yet, deliberately.** The stats reader can be written after the trial from durable history; writing it now would be building a dial for a machine nobody has run.

**Gated both ways:** a real two-clone refusal (held, and blocked-by-dependency) must appear on the board, and disabling the recorder must turn the suite red. A check only ever seen passing has not been seen working.