### PR TITLE
fix(hooks): parse the command on the jq-less path, encode the cwd the way the client does, gate private paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 
 # Release artefaktlari (make-release.sh ciktisi) — build ciktisi, repoya gitmez.
 /dist/
+.private-terms.txt
+.private-allowlist.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -341,7 +341,7 @@ versioning follows [SemVer](https://semver.org/).
 
 ### Fixed
 - **No hook launched at all on Windows, and every gate was silently absent.** Reported as
-  `bash: C:RuntimeHostExecLayerskqr_backend/.claude/hooks/session-rehydrate.sh: No such file or directory` —
+  `bash: C:Reposapp/.claude/hooks/session-rehydrate.sh: No such file or directory` —
   note the separators are **deleted**, not converted. The installed `settings.json` was correct, and no local
   reproduction could produce that string, which is what finally located the cause: hooks were wired in **shell
   form** with the project path interpolated into the command, and Claude Code substitutes the placeholder into
@@ -1538,7 +1538,7 @@ from a single observation: **a gate that matches one spelling of a command has p
 ### Fixed
 - **Windows launch made robust (Git Bash + WSL):** the `npx` runner now (a) prefers **Git Bash** if installed —
   it accepts `C:/…` paths natively and avoids WSL's `/mnt/c` and 8.3-name pitfalls; (b) expands 8.3 short paths
-  (`…\BB358~1.YER\…`) before staging; and (c) under WSL translates the Windows path to `/mnt/c/…` inside bash,
+  (`…\LONGNA~1.DEV\…`) before staging; and (c) under WSL translates the Windows path to `/mnt/c/…` inside bash,
   dispatched by shell flavour. If the staged script still can't be read it now fails with an actionable message
   instead of a cryptic "No such file or directory". macOS/Linux run unchanged (no path rewriting).
 - Shell scripts pinned to LF via `.gitattributes` so a Windows checkout can't flip them to CRLF.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -65,7 +65,7 @@ if (probe.error) {
   process.exit(1);
 }
 
-// Expand 8.3 short names (e.g. C:\Users\BB358~1.YER) to their real long form before staging — WSL's drvfs
+// Expand 8.3 short names (e.g. C:\Users\LONGNA~1.DEV) to their real long form before staging — WSL's drvfs
 // exposes only long names, so an unexpanded short path yields a "correct-looking" /mnt/c/... that still ENOENTs.
 // No-op / safe on macOS & Linux.
 const realpath = (p) => { try { return fs.realpathSync.native(p); } catch (_) { return p; } };

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -597,6 +597,32 @@ else
 fi
 
 
+echo "== 5e) executable bit on every shipped script =="
+# A hook that loses +x does not fail loudly: Claude Code invokes it through `bash <path>`, so it keeps working
+# in the installed tree while the repo carries a broken mode, and start.sh chmods on install which hides it
+# again. The only place it is visible is the git index — so that is where it is checked. This gate exists
+# because the very commit that added it dropped 755 to 644 on this file, twice in one session, with nothing
+# noticing: rewriting a file in place creates a NEW file, and a new file does not inherit the old one's mode.
+csk_exec_check(){    # $1 = human label, $2.. = paths that must be executable on disk
+  local lbl="$1"; shift; local p bad=""
+  for p in "$@"; do [ -e "$p" ] || continue; [ -x "$p" ] || bad="$bad $(basename "$p")"; done
+  [ -z "$bad" ] && pass "on disk, every $lbl is executable" || fail "not executable ($lbl):$bad"
+}
+csk_exec_check "hook" "$HOOKS"/*.sh "$HOOKS/pre-commit" "$HOOKS/commit-msg"
+csk_exec_check "eval script" "$HERE"/*.sh
+# The index is the half that actually regresses, and it only exists where these files are tracked — in an
+# installed project .claude/ is usually gitignored, so a miss there is silence, not a failure.
+if command -v git >/dev/null 2>&1 && git -C "$ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  IDX="$(git -C "$ROOT" ls-files -s -- "$HOOKS" "$HERE" 2>/dev/null \
+         | awk '$1=="100644" && ($4 ~ /\.sh$/ || $4 ~ /\/(pre-commit|commit-msg)$/) {print $4}')"
+  if [ -z "$(git -C "$ROOT" ls-files -- "$HOOKS" "$HERE" 2>/dev/null)" ]; then
+    note "index mode check skipped (these files are not tracked in this layout)"
+  elif [ -z "$IDX" ]; then
+    pass "in the git index, every shipped script is mode 100755"
+  else
+    fail "tracked with mode 100644 (the +x bit was lost in a commit): $(printf '%s ' $IDX)"
+  fi
+fi
 echo "== 6) Context-usage threshold logic (fixture) + hook integrity =="
 FX="$(mktemp)"
 printf '%s\n' '{"type":"assistant","isSidechain":false,"message":{"usage":{"input_tokens":1000,"cache_read_input_tokens":800000,"cache_creation_input_tokens":0}}}' > "$FX"
@@ -861,6 +887,44 @@ printf -- '---\nname: mine\n---\nProject rules.\n' > "$WPD/.claude/skills/mine/S
 o="$(wjson SessionStart | CLAUDE_PROJECT_DIR= bash "$HOOKS/skill-trust.sh" 2>/dev/null)"
 case "$o" in *skills/mine*) pass "skill-trust decodes a JSON-escaped cwd (the notice still notices)" ;; *) fail "skill-trust could not resolve a Windows-shaped cwd — the gate is inert there · payload was: $(wjson SessionStart)" ;; esac
 rm -rf "$WPD"
+
+echo "== 6i3) transcript directory encoding (the BY-HAND call, no hook payload) =="
+# With a hook payload on stdin the transcript path is handed over; called by hand there is none, so the hook has
+# to reproduce how Claude Code encodes a cwd into $HOME/.claude/projects/<name>. Getting that wrong is not
+# cosmetic: `context-usage.sh --verbose` and `session-stats.sh` then find nothing, the 🔋 line disappears, and
+# the session reports "could not measure" — which is exactly what one Windows machine reported three times.
+# Ground truth, observed on a Windows install: a cwd of the shape `C:\Repos\team\report_api` is stored as
+# `C--Repos-team-report-api`, i.e. : \ / . and _ all fold to '-'.
+# The expression is READ OUT OF THE HOOK, never restated here. A copy in the test asserts what the test author
+# believed, not what ships: the hook could quietly lose the underscore again and every case below would still
+# pass. This is the same failure the no-jq section carried for months, so it does not get repeated.
+CSK_ENC_SED="$(grep -o "s#\[[^]]*\]#-#g" "$HOOKS/context-usage.sh" | head -1)"
+[ -n "$CSK_ENC_SED" ] && pass "the cwd encoder expression was found in context-usage.sh" \
+                      || fail "no cwd-encoder expression in context-usage.sh (the resolver was rewritten or removed)"
+enc_csk(){ printf '%s' "$1" | sed "${CSK_ENC_SED:-s#x#x#}"; }
+[ "$(enc_csk '/Users/x/Projects/claude-starter-kit')" = '-Users-x-Projects-claude-starter-kit' ] \
+  && pass "encode: POSIX path" || fail "encode: POSIX path -> $(enc_csk '/Users/x/Projects/claude-starter-kit')"
+[ "$(enc_csk 'C:\Repos\team\report_api')" = 'C--Repos-team-report-api' ] \
+  && pass "encode: Windows native path (drive letter + backslashes)" \
+  || fail "encode: Windows native -> $(enc_csk 'C:\Repos\team\report_api')"
+[ "$(enc_csk '/Users/x/my_app')" = '-Users-x-my-app' ] \
+  && pass "encode: underscore folds to '-' (misses every such project otherwise)" \
+  || fail "encode: underscore NOT folded -> $(enc_csk '/Users/x/my_app')"
+# The encoder is written out twice, once per hook, because a shared file would have to be added to
+# build-plugin.sh's explicit copy list and a miss there breaks the plugin channel silently. Two copies are only
+# safe while they cannot drift, so that is enforced here rather than trusted.
+cu_blk="$(sed -n '/---- CSK-TRANSCRIPT-DIR/,/---- \/CSK-TRANSCRIPT-DIR/p' "$HOOKS/context-usage.sh")"
+ss_blk="$(sed -n '/---- CSK-TRANSCRIPT-DIR/,/---- \/CSK-TRANSCRIPT-DIR/p' "$HOOKS/session-stats.sh")"
+[ -n "$cu_blk" ] && [ "$cu_blk" = "$ss_blk" ] \
+  && pass "the duplicated resolver is byte-identical in both hooks" \
+  || fail "context-usage.sh and session-stats.sh resolvers have DRIFTED (or the markers are missing)"
+# End to end: called by hand from this repo, the hook must produce a reading rather than "transcript not found".
+cu_hand="$(cd "$ROOT/.." && bash "$HOOKS/context-usage.sh" 2>&1)"
+case "$cu_hand" in
+  *"transcript not found"*) note "by-hand reading unavailable here (no transcript for this cwd) — encoding still pinned above" ;;
+  *%*)                      pass "by-hand call resolves its own transcript and reports a fill" ;;
+  *)                        note "by-hand call produced no reading (out=${cu_hand:-empty})" ;;
+esac
 
 echo "== 6j) session-stats: evidence signals read off the transcript =="
 [ -x "$HOOKS/session-stats.sh" ] && pass "session-stats.sh +x" || fail "session-stats.sh missing/not executable"
@@ -1151,6 +1215,22 @@ if command -v git >/dev/null 2>&1; then
 
   pcreset; printf 'const a = 1;\n' > "$PR/src.js"
   pc && pass "a clean staged diff commits" || { fail "clean diff blocked"; sed -n 1,2p "$PCLOG"; }
+
+  # (C2) private-path gate — a path that exists only on the committing machine must not reach a shared artifact.
+  # This is not a hypothetical class: a work project's absolute path, pasted from a terminal into a CHANGELOG
+  # entry, shipped in eight consecutive releases of THIS repo before anyone read it back. The gate therefore
+  # has to hold in three directions at once — catch the real thing, leave placeholders alone, and stay
+  # overridable — because a gate that flags `/Users/me` in a README gets switched off within a week.
+  pcreset; printf 'see %s/Projects/x\n' "$HOME" > "$PR/src.js"
+  pc && fail "private-path scan let this machine's \$HOME through (§4.3)" || pass "private-path scan blocks the machine's own \$HOME"
+  pcreset; printf 'see /Users/me/Projects/x and C:\\Users\\me\\x\n' > "$PR/src.js"
+  pc && pass "private-path scan leaves documentation placeholders alone" || { fail "private-path scan flagged a placeholder"; sed -n 1,2p "$PCLOG"; }
+  # A term the repo owner adds by hand: the kit cannot know an internal project's code name, only its owner can.
+  pcreset; printf 'AcmeCore\n' > "$PR/.private-terms.txt"; printf 'fix the AcmeCore import\n' > "$PR/src.js"
+  pc && fail "private-path scan ignored .private-terms.txt" || pass "private-path scan honours .private-terms.txt"
+  printf 'AcmeCore\n' > "$PR/.private-allowlist.txt"
+  pc && pass "private-path scan is overridable via .private-allowlist.txt" || { fail "no escape from a private-term false positive"; sed -n 1,2p "$PCLOG"; }
+  rm -f "$PR/.private-terms.txt" "$PR/.private-allowlist.txt"
 
   # (D) repo-bloat gate — vendored/build path blocked; oversized blob blocked (binaries emit no '+' line, so this
   # must fire off the file list, not the added-text scan).
@@ -1537,15 +1617,92 @@ o="$(gj auto 'eval \"git commit -m x\"' | bash "$HOOKS/guard-bash.sh" 2>/dev/nul
 # Precision: a commit whose MESSAGE contains 'reset --hard' (no git-before-reset) ASKs as a commit, is not blocked.
 o="$(gj auto 'git commit -m \"reset --hard bug\"' | bash "$HOOKS/guard-bash.sh" 2>/dev/null)"; echo "$o" | grep -q '"permissionDecision":"ask"' && pass "commit msg with 'reset --hard' NOT over-blocked" || fail "commit msg 'reset --hard' wrongly blocked: $o"
 # Fallback (no jq AND no python3 — stock Git Bash on Windows): the matchers must still fire on the raw JSON blob (M1).
-GBX="$(mktemp -d)"; GBOK=1; GBBASH="$(command -v bash 2>/dev/null || echo bash)"
-for t in awk sed grep head cat tr git cut; do tp="$(command -v "$t" 2>/dev/null)" && ln -s "$tp" "$GBX/$t" 2>/dev/null || GBOK=0; done
-[ "$GBOK" = 1 ] && [ ! -L "$GBX/awk" ] && GBOK=0   # Windows Git-Bash copies instead of symlinking -> not a faithful jq-less PATH; skip
-if [ "$GBOK" = 1 ] && ! PATH="$GBX" command -v jq >/dev/null 2>&1 && ! PATH="$GBX" command -v python3 >/dev/null 2>&1; then
+GBBASH="$(type -P bash 2>/dev/null || echo bash)"
+# Build a jq/python3-free PATH. `type -P` NOT `command -v`: command -v answers with the bare NAME when a shell
+# function or alias shadows the tool, and `ln -s grep "$GBX/grep"` then creates a symlink pointing at ITSELF.
+# That is not a hypothetical — it is what this harness did on a developer Mac whose profile defines a `grep`
+# function, so every hook invocation inside the "sandbox" died with `grep: command not found` and the section
+# reported a skip. The gate looked measured for months and was not. `type -P` resolves the real PATH binary.
+GB_WHYF="$(mktemp)"
+# The reason a sandbox could not be built has to travel OUT of a command substitution, which is a subshell —
+# a plain variable assignment inside it is discarded, so the caller would only ever see "unknown".
+gb_why(){ printf '%s' "$1" > "$GB_WHYF"; }
+gb_sandbox(){   # echoes a working sandbox dir, or nothing when one cannot be built here; $GB_WHYF says why not
+  local d t tp; : > "$GB_WHYF"; d="$(mktemp -d)" || { gb_why "mktemp failed"; return 1; }
+  for t in awk sed grep head cat tr git cut; do
+    tp="$(type -P "$t" 2>/dev/null)"
+    [ -n "$tp" ] || { gb_why "no PATH binary for '$t'"; rm -rf "$d"; return 1; }
+    ln -s "$tp" "$d/$t" 2>/dev/null || { gb_why "ln -s failed for '$t'"; rm -rf "$d"; return 1; }
+  done
+  # Windows Git-Bash copies instead of symlinking -> not a faithful jq-less PATH.
+  [ -L "$d/awk" ] || { gb_why "symlinks unsupported (Git-Bash copies)"; rm -rf "$d"; return 1; }
+  # jq/python3 must really be invisible, or the branch under test is not the branch that runs.
+  # Checked in a FRESH bash, not with `command -v` in this one. A shell caches resolved binaries in its hash
+  # table and consults it BEFORE PATH, so once any earlier section of this suite has run jq, `PATH="$d" command
+  # -v jq` keeps answering with the cached absolute path and the sandbox is rejected as "jq still visible" —
+  # which is exactly why this whole section silently skipped in a full run while passing in isolation. The hook
+  # under test is a fresh process with an empty hash table, so the check must be one too.
+  PATH="$d" "$GBBASH" -c 'command -v jq'      >/dev/null 2>&1 && { gb_why "jq still visible inside the sandbox"; rm -rf "$d"; return 1; }
+  PATH="$d" "$GBBASH" -c 'command -v python3' >/dev/null 2>&1 && { gb_why "python3 still visible inside the sandbox"; rm -rf "$d"; return 1; }
+  # CANARY: prove the sandbox can actually run the tools the hook needs. Without this a broken sandbox is
+  # indistinguishable from a broken gate, and every assertion below becomes noise pointing at the wrong file.
+  PATH="$d" "$GBBASH" -c 'printf x | grep -q x && printf y | sed -n "s/y/z/p" >/dev/null' 2>/dev/null \
+    || { gb_why "canary failed: grep/sed unusable inside the sandbox"; rm -rf "$d"; return 1; }
+  printf '%s' "$d"
+}
+GBX="$(gb_sandbox)"
+
+
+if [ -n "$GBX" ]; then
   o="$(gj auto 'git commit -m x' | PATH="$GBX" "$GBBASH" "$HOOKS/guard-bash.sh" 2>/dev/null)"
   echo "$o" | grep -q '"permissionDecision":"ask"' && pass "no-jq/py: commit still ASKs (M1 fallback closed)" || fail "no-jq/py: commit gate FAILS OPEN (M1): $o"
   gj auto 'git reset --hard' | PATH="$GBX" CLAUDE_GIT_OK=1 "$GBBASH" "$HOOKS/guard-bash.sh" >/dev/null 2>&1; [ "$?" = 2 ] && pass "no-jq/py: reset --hard still BLOCKED" || fail "no-jq/py: reset --hard PASSED (§4.5 fallback hole)"
 else
-  pass "no-jq/py fallback test skipped (jq/python3-less PATH not buildable here)"
+  fail "no-jq/py fallback tests DID NOT RUN — the Windows branch is unmeasured here ($(cat "$GB_WHYF" 2>/dev/null || echo unknown))"
+fi
+rm -rf "$GBX"
+
+# --- The fallback assertions above are NOT sufficient, and that is the lesson, not a footnote. -------------
+# `git commit` ASKing and `git reset --hard` BLOCKing were BOTH true while the fallback was `CMD="$INPUT"` —
+# the raw hook payload fed to the matchers — because the payload contains the command as a substring, so a
+# blob match and a real parse produce the identical verdict. The gate was measured, the measurement was blind,
+# and a stock Windows install (Git Bash ships neither jq nor python3) ran the broken branch for months.
+# What the blob CANNOT survive is the payload's own metadata leaking into the rules, so that is what is pinned
+# here: a session_id containing `-f8` made every innocent `git push` hard-block as "push --force", and the §4.4
+# prompt rendered the whole JSON instead of the command the human was being asked to approve.
+GBX="$(gb_sandbox)"
+
+
+# session_id chosen deliberately: `-f872` is the exact shape that matched the §4.5 `-f([^a-z]|$)` force rule.
+gjs(){ printf '{"session_id":"5d3e9c10-f872-4a21-9b07-2c6ea4d1b3f5","tool_name":"Bash","permission_mode":"%s","tool_input":{"command":"%s","description":"d"}}' "$1" "$2"; }
+if [ -n "$GBX" ]; then
+  # 1) FALSE POSITIVE: an ordinary push must not inherit `-f` from the session id.
+  o="$(gjs default 'git push origin feature/x' | PATH="$GBX" "$GBBASH" "$HOOKS/guard-bash.sh" 2>/dev/null)"; r=$?
+  { [ "$r" != 2 ] && printf '%s' "$o" | grep -q '"permissionDecision":"ask"'; } \
+    && pass "no-jq/py: plain push ASKs, not force-blocked by the session id" \
+    || fail "no-jq/py: plain push mis-blocked as force (rc=$r) — the fallback is matching the payload, not the command"
+  # 2) APPROVAL INTEGRITY: §4.4 must show the command. A prompt quoting the payload is consent theatre.
+  o="$(gjs default 'git push origin feature/x' | PATH="$GBX" "$GBBASH" "$HOOKS/guard-bash.sh" 2>/dev/null)"
+  { printf '%s' "$o" | grep -q 'git push origin feature/x' && ! printf '%s' "$o" | grep -q 'session_id'; } \
+    && pass "no-jq/py: the §4.4 prompt shows the command, not the raw payload" \
+    || fail "no-jq/py: the §4.4 prompt leaked the payload (the human cannot read what they approve)"
+  # 3) NO NEW HOLE: the slice takes the FIRST \"command\" key, so a decoy inside the command cannot relocate it.
+  gjs auto 'git push --force # \"command\":\"ls\"' | PATH="$GBX" CLAUDE_GIT_OK=1 "$GBBASH" "$HOOKS/guard-bash.sh" >/dev/null 2>&1
+  [ "$?" = 2 ] && pass "no-jq/py: decoy \"command\" key inside the command does NOT relocate the parse" \
+                || fail "no-jq/py: decoy \"command\" key walked a force-push past §4.5"
+  # 4) ESCAPES: JSON-escaped quotes and Windows backslash paths must decode, not derail the rules.
+  gjs auto 'git commit -m \"x\" --no-verify' | PATH="$GBX" CLAUDE_GIT_OK=1 "$GBBASH" "$HOOKS/guard-bash.sh" >/dev/null 2>&1
+  [ "$?" = 2 ] && pass "no-jq/py: --no-verify inside an escaped-quote command still BLOCKED" \
+                || fail "no-jq/py: escaped quotes hid --no-verify from §4.5"
+  o="$(gjs default 'git commit -F C:\\\\Users\\\\b\\\\msg.txt' | PATH="$GBX" "$GBBASH" "$HOOKS/guard-bash.sh" 2>/dev/null)"
+  printf '%s' "$o" | grep -q '"permissionDecision":"ask"' \
+    && pass "no-jq/py: a Windows backslash path still reaches the §4.4 ask" \
+    || fail "no-jq/py: backslash path derailed the parse (out=$o)"
+  # 5) NOT OVER-BLOCKING: an ordinary command stays allowed even with the dirty session id.
+  gjs default 'ls -la' | PATH="$GBX" "$GBBASH" "$HOOKS/guard-bash.sh" >/dev/null 2>&1
+  [ "$?" = 0 ] && pass "no-jq/py: 'ls -la' still allowed" || fail "no-jq/py: 'ls -la' blocked (fallback over-blocks)"
+else
+  fail "no-jq/py discriminating tests DID NOT RUN — the Windows branch is unmeasured here ($(cat "$GB_WHYF" 2>/dev/null || echo unknown))"
 fi
 rm -rf "$GBX"
 # C2 / M5: gate-tamper by an interpreter, a variable-indirected redirect, or .git/hooks — the "rewrite the guard"

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -612,6 +612,15 @@ csk_exec_check "hook" "$HOOKS"/*.sh "$HOOKS/pre-commit" "$HOOKS/commit-msg"
 csk_exec_check "eval script" "$HERE"/*.sh
 # The index is the half that actually regresses, and it only exists where these files are tracked — in an
 # installed project .claude/ is usually gitignored, so a miss there is silence, not a failure.
+# ...and only where git TRACKS the bit at all. Windows filesystems carry no exec bit, so git sets
+# core.fileMode=false there and records 100644 for every file it has ever seen — all 19 shipped scripts at
+# once. An index check under that setting is not a strict check, it is a guaranteed false alarm, and it took
+# out the Windows job on a change that had nothing wrong with it. Where the bit is untracked the index holds
+# no information about it, so there is nothing to assert; the POSIX runners are where this gate has teeth.
+CSK_FILEMODE="$(git -C "$ROOT" config --get core.fileMode 2>/dev/null || echo true)"
+case "${CSK_FILEMODE:-true}" in
+  false|0|no) note "index mode check skipped (core.fileMode=$CSK_FILEMODE — this platform does not track the bit)" ;;
+  *)
 if command -v git >/dev/null 2>&1 && git -C "$ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   IDX="$(git -C "$ROOT" ls-files -s -- "$HOOKS" "$HERE" 2>/dev/null \
          | awk '$1=="100644" && ($4 ~ /\.sh$/ || $4 ~ /\/(pre-commit|commit-msg)$/) {print $4}')"
@@ -623,6 +632,8 @@ if command -v git >/dev/null 2>&1 && git -C "$ROOT" rev-parse --is-inside-work-t
     fail "tracked with mode 100644 (the +x bit was lost in a commit): $(printf '%s ' $IDX)"
   fi
 fi
+ ;;
+esac
 echo "== 6) Context-usage threshold logic (fixture) + hook integrity =="
 FX="$(mktemp)"
 printf '%s\n' '{"type":"assistant","isSidechain":false,"message":{"usage":{"input_tokens":1000,"cache_read_input_tokens":800000,"cache_creation_input_tokens":0}}}' > "$FX"

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -1618,6 +1618,19 @@ o="$(gj auto 'eval \"git commit -m x\"' | bash "$HOOKS/guard-bash.sh" 2>/dev/nul
 o="$(gj auto 'git commit -m \"reset --hard bug\"' | bash "$HOOKS/guard-bash.sh" 2>/dev/null)"; echo "$o" | grep -q '"permissionDecision":"ask"' && pass "commit msg with 'reset --hard' NOT over-blocked" || fail "commit msg 'reset --hard' wrongly blocked: $o"
 # Fallback (no jq AND no python3 — stock Git Bash on Windows): the matchers must still fire on the raw JSON blob (M1).
 GBBASH="$(type -P bash 2>/dev/null || echo bash)"
+gb_unbuildable(){   # $1 = which block, for the message
+  local why; why="$(cat "$GB_WHYF" 2>/dev/null || echo unknown)"
+  case "$why" in
+    "symlinks unsupported"*)
+      # Git Bash copies rather than symlinks, so a jq-less PATH cannot be assembled ON Windows. That is a
+      # property of the platform, not a regression, and the branch it would exercise is the one Windows takes
+      # natively anyway — the POSIX runners cover it. Anything else means a sandbox that SHOULD have built did
+      # not, and a silent skip there is how this whole section stayed unmeasured for months.
+      note "$1 skipped: this platform cannot host a jq-less PATH ($why)" ;;
+    *)
+      fail "$1 DID NOT RUN — the jq-less branch is unmeasured here ($why)" ;;
+  esac
+}
 # Build a jq/python3-free PATH. `type -P` NOT `command -v`: command -v answers with the bare NAME when a shell
 # function or alias shadows the tool, and `ln -s grep "$GBX/grep"` then creates a symlink pointing at ITSELF.
 # That is not a hypothetical — it is what this harness did on a developer Mac whose profile defines a `grep`
@@ -1658,7 +1671,7 @@ if [ -n "$GBX" ]; then
   echo "$o" | grep -q '"permissionDecision":"ask"' && pass "no-jq/py: commit still ASKs (M1 fallback closed)" || fail "no-jq/py: commit gate FAILS OPEN (M1): $o"
   gj auto 'git reset --hard' | PATH="$GBX" CLAUDE_GIT_OK=1 "$GBBASH" "$HOOKS/guard-bash.sh" >/dev/null 2>&1; [ "$?" = 2 ] && pass "no-jq/py: reset --hard still BLOCKED" || fail "no-jq/py: reset --hard PASSED (§4.5 fallback hole)"
 else
-  fail "no-jq/py fallback tests DID NOT RUN — the Windows branch is unmeasured here ($(cat "$GB_WHYF" 2>/dev/null || echo unknown))"
+  gb_unbuildable "no-jq/py fallback tests"
 fi
 rm -rf "$GBX"
 
@@ -1702,7 +1715,7 @@ if [ -n "$GBX" ]; then
   gjs default 'ls -la' | PATH="$GBX" "$GBBASH" "$HOOKS/guard-bash.sh" >/dev/null 2>&1
   [ "$?" = 0 ] && pass "no-jq/py: 'ls -la' still allowed" || fail "no-jq/py: 'ls -la' blocked (fallback over-blocks)"
 else
-  fail "no-jq/py discriminating tests DID NOT RUN — the Windows branch is unmeasured here ($(cat "$GB_WHYF" 2>/dev/null || echo unknown))"
+  gb_unbuildable "no-jq/py discriminating tests"
 fi
 rm -rf "$GBX"
 # C2 / M5: gate-tamper by an interpreter, a variable-indirected redirect, or .git/hooks — the "rewrite the guard"

--- a/claude-starter/hooks/context-usage.sh
+++ b/claude-starter/hooks/context-usage.sh
@@ -38,13 +38,36 @@ if [ -z "$TR" ] && [ ! -t 0 ]; then
   [ -n "$IN" ] && TR="$(printf '%s' "$IN" | sed -n 's/.*"transcript_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
 fi
 [ -n "$TR" ] && TR="$(unjson_path "$TR")"
-# 2) still missing: find the project transcript dir from pwd (client: / and . -> -)
+# 2) still missing: derive the project dir from pwd.
+# ---- CSK-TRANSCRIPT-DIR (kept byte-identical in context-usage.sh and session-stats.sh; smoke-test §6i3 pins it)
+# Claude Code stores a session under $HOME/.claude/projects/<cwd encoded as a directory name>. Reproducing that
+# encoding is the ONLY way a by-hand call (no hook payload on stdin) can find its own transcript.
+csk_project_dirs(){   # candidate directory names for the current cwd, best first, one per line
+  local w p
+  # Windows first. Claude Code sees the NATIVE cwd (C:\repo\app) while Git Bash's `pwd` reports /c/repo/app, so
+  # the drive letter never matched and the by-hand call could not resolve a transcript on Windows AT ALL — the
+  # same "transcript not found" was reported from that machine three separate times before the cause was found.
+  # `pwd -W` is the MSYS builtin that returns the native form; elsewhere it just fails and is discarded.
+  w="$(pwd -W 2>/dev/null || true)"
+  # The encoder folds : \ / . AND _ to '-'. The underscore is the one that hides: a project named `report_api`
+  # lands in `...-report-api`, so folding only slashes and dots misses every path containing an underscore — on
+  # every platform, not just Windows.
+  for p in "$w" "$(pwd)"; do
+    [ -n "$p" ] && printf '%s\n' "$(printf '%s' "$p" | sed 's#[:\\/._]#-#g')"
+  done
+  # Legacy shapes, kept so a directory written by an older client still resolves.
+  printf '%s\n' "$(pwd | sed 's#[/.]#-#g')" "$(pwd | sed 's#/#-#g')"
+}
 if [ -z "$TR" ]; then
-  for esc in "$(pwd | sed 's#[/.]#-#g')" "$(pwd | sed 's#/#-#g')"; do
+  while IFS= read -r esc; do
+    [ -n "$esc" ] || continue
     cand="$(ls -t "$HOME/.claude/projects/$esc"/*.jsonl 2>/dev/null | head -1)"
     [ -n "$cand" ] && { TR="$cand"; break; }
-  done
+  done <<CSKEOF
+$(csk_project_dirs)
+CSKEOF
 fi
+# ---- /CSK-TRANSCRIPT-DIR
 # Cannot measure. The two call sites want opposite things here, so they get opposite answers.
 #
 # Called BY HAND (a transcript passed as an argument): complain on stderr and exit non-zero. A person who typed a

--- a/claude-starter/hooks/guard-bash.sh
+++ b/claude-starter/hooks/guard-bash.sh
@@ -33,7 +33,63 @@
 set -uo pipefail
 INPUT="$(cat)"
 
-# Extract the command + the permission mode (jq > python3 > raw text fallback).
+# Extract the command + the permission mode: jq > python3 > pure-bash JSON slice.
+#
+# THE THIRD TIER IS NOT A DEGRADED MODE, it is the Windows default. Git Bash ships neither jq nor python3, so
+# on a stock Windows install this is THE path every gate decision takes. It used to read `CMD="$INPUT"` — the
+# whole hook payload handed to the rules as though it were the command — and that is not a weaker gate, it is
+# a WRONG one, in both directions:
+#   * False positive, measured: session_id `...-f872-...` (any session id whose second group starts `f8`) contains `-f8`, the §4.5 force-push rule matches
+#     `-f([^a-z]|$)`, and so EVERY `git push` was hard-blocked as "push --force" no matter what was typed.
+#     A gate that blocks the innocent teaches the user to reach for --no-verify, which disarms all of §4.
+#   * Broken approval, measured: when it did not misfire, the §4.4 prompt rendered the raw JSON blob as "the
+#     command Claude wants to run". §4.4's entire purpose is to show the human what they are approving; an
+#     unreadable prompt is consent theatre.
+# CI never caught it because GitHub's windows-latest image HAS jq preinstalled — the verification ran on a path
+# no Windows user is on. smoke-test §7b pins the fallback branch itself for exactly that reason.
+#
+# The slice is pure parameter expansion: zero forks, so it is CHEAPER than the sed it replaces (Git Bash charges
+# 20-50ms per process, and this hook runs on every Bash call). `${INPUT#*"command"}` is shortest-match, so it
+# takes the FIRST occurrence — greedy matching would let a command containing the literal text `"command":"`
+# relocate the parse and walk a payload straight past the rules.
+_json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) string value, "" if absent
+  local rest="${1#*\"$2\"}" seg tail out bs
+  [ "$rest" != "$1" ] || return 0          # key absent: emit nothing
+  rest="${rest#*\"}"                       # skip `: "` up to the value's opening quote
+  out=""; tail="$rest"
+  # Walk to the closing quote that is NOT escaped. A `"` preceded by an odd number of backslashes is content.
+  while :; do
+    seg="${tail%%\"*}"
+    [ "$seg" != "$tail" ] || { out="$out$seg"; break; }   # no closing quote at all: take the rest
+    out="$out$seg"
+    bs="${seg##*[!\\]}"                    # trailing backslash run ("" when the last char is not a backslash)
+    case "$seg" in *[!\\]*) ;; *) bs="$seg" ;; esac       # all-backslash segment: the run is the whole segment
+    if [ $(( ${#bs} % 2 )) -eq 1 ]; then out="$out\""; tail="${tail#"$seg"\"}"; else break; fi
+  done
+  printf '%s' "$out"
+}
+_json_unescape(){  # single left-to-right pass; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
+  local s="$1" out="" c
+  case "$s" in *\\*) ;; *) printf '%s' "$s"; return 0 ;; esac   # no escapes: the common case pays nothing
+  while [ -n "$s" ]; do
+    c="${s%"${s#?}"}"; s="${s#?}"
+    if [ "$c" = "\\" ] && [ -n "$s" ]; then
+      c="${s%"${s#?}"}"; s="${s#?}"
+      case "$c" in
+        n) out="$out
+" ;;
+        t) out="$out	" ;;
+        r) ;;
+        b|f) out="$out " ;;
+        u) s="${s#????}"; out="$out?" ;;
+        *) out="$out$c" ;;
+      esac
+    else
+      out="$out$c"
+    fi
+  done
+  printf '%s' "$out"
+}
 if command -v jq >/dev/null 2>&1; then
   CMD="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)"
   PERM_MODE="$(printf '%s' "$INPUT" | jq -r '.permission_mode // empty' 2>/dev/null)"
@@ -41,8 +97,8 @@ elif command -v python3 >/dev/null 2>&1; then
   CMD="$(printf '%s' "$INPUT" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(d.get("tool_input",{}).get("command",""))' 2>/dev/null)"
   PERM_MODE="$(printf '%s' "$INPUT" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(d.get("permission_mode",""))' 2>/dev/null)"
 else
-  CMD="$INPUT"
-  PERM_MODE="$(printf '%s' "$INPUT" | sed -n 's/.*"permission_mode"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+  CMD="$(_json_unescape "$(_json_slice "$INPUT" command)")"
+  PERM_MODE="$(_json_slice "$INPUT" permission_mode)"
 fi
 PERM_MODE="${PERM_MODE:-}"
 [ -z "$CMD" ] && exit 0

--- a/claude-starter/hooks/pre-commit
+++ b/claude-starter/hooks/pre-commit
@@ -2,6 +2,7 @@
 # Pre-commit gate on staged ADDED lines:
 #  (1) §4.1/§4.2 trace scanner — AI-authorship traces / vendor names (trace-blocklist.txt)
 #  (2) secret scanner        — API keys / tokens / private keys       (secret-blocklist.txt)
+#  (3) private-path scanner  — this machine's $HOME + .private-terms.txt (§4.3)
 # Skipping requires an explicit request per §4.5 (git commit --no-verify).
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -123,10 +124,60 @@ if [ -f "$SL" ] && [ -s "$SECRET_F" ]; then
   done < "$SL"
 fi
 
+# (3) private-path scan — a path that only exists on THIS machine has no business in a shared artifact.
+#
+# Why this is not a blocklist regex: "is this path private?" cannot be answered by a pattern. `/Users/me` is a
+# placeholder every README wants, `/Users/ada` is a real person's home, and no ERE separates them (and ERE has
+# no negative lookahead to spell "not a placeholder"). So the terms are derived from the machine doing the
+# commit — where the answer is knowable exactly — plus whatever the repo owner adds by hand.
+#
+# It exists because this failure is not hypothetical: a work project's absolute path, pasted from a terminal
+# into a CHANGELOG entry, shipped in eight consecutive releases before anyone noticed. The paste is the vector,
+# so the gate has to sit where pasted text becomes a commit.
+#
+#   automatic  : $HOME, in the three spellings the same directory gets written as on Windows
+#                (/c/Users/x · C:/Users/x · C:\Users\x) — case-insensitively, since that filesystem is.
+#   by hand    : .private-terms.txt at the repo root, one literal term per line ('#' comments). Put internal
+#                project names, client names, and host names there. GITIGNORE IT — it is a list of the very
+#                strings you do not want published.
+#   escape     : .private-allowlist.txt, a term per full line, for the rare case a term is legitimately public.
+PRIV_F="$(mktemp)"; PTERM_F="$(mktemp)"
+trap 'rm -f "$TRACE_F" "$SECRET_F" "$PRIV_F" "$PTERM_F"' EXIT INT TERM
+PTF="";  [ -n "$GITROOT" ] && [ -f "$GITROOT/.private-terms.txt" ]     && PTF="$GITROOT/.private-terms.txt"
+PAL="";  [ -n "$GITROOT" ] && [ -f "$GITROOT/.private-allowlist.txt" ] && PAL="$GITROOT/.private-allowlist.txt"
+{
+  # A home path shorter than this cannot be distinguishing (`/root`, `/`), and matching it would flag everything.
+  if [ -n "${HOME:-}" ] && [ "${#HOME}" -ge 8 ]; then
+    printf '%s\n' "$HOME"
+    # Git Bash reports /c/Users/x for what Windows itself calls C:\Users\x — both spellings reach a file.
+    case "$HOME" in
+      /[a-zA-Z]/?*)
+        d="$(printf '%s' "${HOME:1:1}" | tr 'a-z' 'A-Z')"; r="${HOME:3}"
+        printf '%s\n' "$d:/$r" "$d:\\${r//\//\\}" ;;
+    esac
+  fi
+  [ -n "$PTF" ] && sed -e 's/[[:space:]]*$//' -e '/^#/d' -e '/^$/d' "$PTF"
+} > "$PTERM_F" 2>/dev/null || true
+if [ -s "$PTERM_F" ] && [ -s "$SECRET_F" ]; then
+  while IFS= read -r term || [ -n "$term" ]; do
+    term="${term%$'\r'}"
+    [ -n "$term" ] || continue
+    if [ -n "$PAL" ] && grep -qxF -- "$term" "$PAL"; then continue; fi
+    if grep -qiF -- "$term" "$SECRET_F"; then
+      # The term is echoed back deliberately: unlike a secret, the author has to see WHICH private string to
+      # replace, and it is already sitting in their own working tree.
+      echo "PRIVATE-PATH SCANNER: a staged line contains a machine-private string -> '$term' (§4.3)"
+      HIT=1
+    fi
+  done < "$PTERM_F"
+fi
+rm -f "$PRIV_F"
+
 if [ "$HIT" -ne 0 ]; then
   echo "-----------------------------------------------------------"
   echo "Commit stopped. Remove the AI-authorship trace / vendor name / secret / bloated file from the staged changes."
   echo "False positive (trace/secret)? add the EXACT pattern line to .trace-allowlist.txt or .secret-allowlist.txt at the repo root."
+  echo "Private path flagged but genuinely public? add that exact term to .private-allowlist.txt at the repo root."
   echo "Large file is intentional? raise CSK_MAX_FILE_BYTES, use Git LFS, or gitignore the build/vendored path."
   echo "Deliberate exception: 'git commit --no-verify' — only on an EXPLICIT request (§4.5)."
   exit 1

--- a/claude-starter/hooks/session-stats.sh
+++ b/claude-starter/hooks/session-stats.sh
@@ -26,12 +26,35 @@ if [ -z "$TR" ] && [ ! -t 0 ]; then
   IN="$(cat 2>/dev/null || true)"
   [ -n "$IN" ] && TR="$(printf '%s' "$IN" | sed -n 's/.*"transcript_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
 fi
+# ---- CSK-TRANSCRIPT-DIR (kept byte-identical in context-usage.sh and session-stats.sh; smoke-test §6i3 pins it)
+# Claude Code stores a session under $HOME/.claude/projects/<cwd encoded as a directory name>. Reproducing that
+# encoding is the ONLY way a by-hand call (no hook payload on stdin) can find its own transcript.
+csk_project_dirs(){   # candidate directory names for the current cwd, best first, one per line
+  local w p
+  # Windows first. Claude Code sees the NATIVE cwd (C:\repo\app) while Git Bash's `pwd` reports /c/repo/app, so
+  # the drive letter never matched and the by-hand call could not resolve a transcript on Windows AT ALL — the
+  # same "transcript not found" was reported from that machine three separate times before the cause was found.
+  # `pwd -W` is the MSYS builtin that returns the native form; elsewhere it just fails and is discarded.
+  w="$(pwd -W 2>/dev/null || true)"
+  # The encoder folds : \ / . AND _ to '-'. The underscore is the one that hides: a project named `report_api`
+  # lands in `...-report-api`, so folding only slashes and dots misses every path containing an underscore — on
+  # every platform, not just Windows.
+  for p in "$w" "$(pwd)"; do
+    [ -n "$p" ] && printf '%s\n' "$(printf '%s' "$p" | sed 's#[:\\/._]#-#g')"
+  done
+  # Legacy shapes, kept so a directory written by an older client still resolves.
+  printf '%s\n' "$(pwd | sed 's#[/.]#-#g')" "$(pwd | sed 's#/#-#g')"
+}
 if [ -z "$TR" ]; then
-  for esc in "$(pwd | sed 's#[/.]#-#g')" "$(pwd | sed 's#/#-#g')"; do
+  while IFS= read -r esc; do
+    [ -n "$esc" ] || continue
     cand="$(ls -t "$HOME/.claude/projects/$esc"/*.jsonl 2>/dev/null | head -1)"
     [ -n "$cand" ] && { TR="$cand"; break; }
-  done
+  done <<CSKEOF
+$(csk_project_dirs)
+CSKEOF
 fi
+# ---- /CSK-TRANSCRIPT-DIR
 [ -n "$TR" ] && [ -f "$TR" ] || { echo "session-stats: transcript not found (pass an arg or use hook stdin)" >&2; exit 1; }
 
 # Whole-file scan, unlike context-usage.sh's byte-bounded tail: that one runs on EVERY turn inside a hook

--- a/plugin/hooks/context-usage.sh
+++ b/plugin/hooks/context-usage.sh
@@ -38,13 +38,36 @@ if [ -z "$TR" ] && [ ! -t 0 ]; then
   [ -n "$IN" ] && TR="$(printf '%s' "$IN" | sed -n 's/.*"transcript_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
 fi
 [ -n "$TR" ] && TR="$(unjson_path "$TR")"
-# 2) still missing: find the project transcript dir from pwd (client: / and . -> -)
+# 2) still missing: derive the project dir from pwd.
+# ---- CSK-TRANSCRIPT-DIR (kept byte-identical in context-usage.sh and session-stats.sh; smoke-test §6i3 pins it)
+# Claude Code stores a session under $HOME/.claude/projects/<cwd encoded as a directory name>. Reproducing that
+# encoding is the ONLY way a by-hand call (no hook payload on stdin) can find its own transcript.
+csk_project_dirs(){   # candidate directory names for the current cwd, best first, one per line
+  local w p
+  # Windows first. Claude Code sees the NATIVE cwd (C:\repo\app) while Git Bash's `pwd` reports /c/repo/app, so
+  # the drive letter never matched and the by-hand call could not resolve a transcript on Windows AT ALL — the
+  # same "transcript not found" was reported from that machine three separate times before the cause was found.
+  # `pwd -W` is the MSYS builtin that returns the native form; elsewhere it just fails and is discarded.
+  w="$(pwd -W 2>/dev/null || true)"
+  # The encoder folds : \ / . AND _ to '-'. The underscore is the one that hides: a project named `report_api`
+  # lands in `...-report-api`, so folding only slashes and dots misses every path containing an underscore — on
+  # every platform, not just Windows.
+  for p in "$w" "$(pwd)"; do
+    [ -n "$p" ] && printf '%s\n' "$(printf '%s' "$p" | sed 's#[:\\/._]#-#g')"
+  done
+  # Legacy shapes, kept so a directory written by an older client still resolves.
+  printf '%s\n' "$(pwd | sed 's#[/.]#-#g')" "$(pwd | sed 's#/#-#g')"
+}
 if [ -z "$TR" ]; then
-  for esc in "$(pwd | sed 's#[/.]#-#g')" "$(pwd | sed 's#/#-#g')"; do
+  while IFS= read -r esc; do
+    [ -n "$esc" ] || continue
     cand="$(ls -t "$HOME/.claude/projects/$esc"/*.jsonl 2>/dev/null | head -1)"
     [ -n "$cand" ] && { TR="$cand"; break; }
-  done
+  done <<CSKEOF
+$(csk_project_dirs)
+CSKEOF
 fi
+# ---- /CSK-TRANSCRIPT-DIR
 # Cannot measure. The two call sites want opposite things here, so they get opposite answers.
 #
 # Called BY HAND (a transcript passed as an argument): complain on stderr and exit non-zero. A person who typed a

--- a/plugin/hooks/guard-bash.sh
+++ b/plugin/hooks/guard-bash.sh
@@ -33,7 +33,63 @@
 set -uo pipefail
 INPUT="$(cat)"
 
-# Extract the command + the permission mode (jq > python3 > raw text fallback).
+# Extract the command + the permission mode: jq > python3 > pure-bash JSON slice.
+#
+# THE THIRD TIER IS NOT A DEGRADED MODE, it is the Windows default. Git Bash ships neither jq nor python3, so
+# on a stock Windows install this is THE path every gate decision takes. It used to read `CMD="$INPUT"` — the
+# whole hook payload handed to the rules as though it were the command — and that is not a weaker gate, it is
+# a WRONG one, in both directions:
+#   * False positive, measured: session_id `...-f872-...` (any session id whose second group starts `f8`) contains `-f8`, the §4.5 force-push rule matches
+#     `-f([^a-z]|$)`, and so EVERY `git push` was hard-blocked as "push --force" no matter what was typed.
+#     A gate that blocks the innocent teaches the user to reach for --no-verify, which disarms all of §4.
+#   * Broken approval, measured: when it did not misfire, the §4.4 prompt rendered the raw JSON blob as "the
+#     command Claude wants to run". §4.4's entire purpose is to show the human what they are approving; an
+#     unreadable prompt is consent theatre.
+# CI never caught it because GitHub's windows-latest image HAS jq preinstalled — the verification ran on a path
+# no Windows user is on. smoke-test §7b pins the fallback branch itself for exactly that reason.
+#
+# The slice is pure parameter expansion: zero forks, so it is CHEAPER than the sed it replaces (Git Bash charges
+# 20-50ms per process, and this hook runs on every Bash call). `${INPUT#*"command"}` is shortest-match, so it
+# takes the FIRST occurrence — greedy matching would let a command containing the literal text `"command":"`
+# relocate the parse and walk a payload straight past the rules.
+_json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) string value, "" if absent
+  local rest="${1#*\"$2\"}" seg tail out bs
+  [ "$rest" != "$1" ] || return 0          # key absent: emit nothing
+  rest="${rest#*\"}"                       # skip `: "` up to the value's opening quote
+  out=""; tail="$rest"
+  # Walk to the closing quote that is NOT escaped. A `"` preceded by an odd number of backslashes is content.
+  while :; do
+    seg="${tail%%\"*}"
+    [ "$seg" != "$tail" ] || { out="$out$seg"; break; }   # no closing quote at all: take the rest
+    out="$out$seg"
+    bs="${seg##*[!\\]}"                    # trailing backslash run ("" when the last char is not a backslash)
+    case "$seg" in *[!\\]*) ;; *) bs="$seg" ;; esac       # all-backslash segment: the run is the whole segment
+    if [ $(( ${#bs} % 2 )) -eq 1 ]; then out="$out\""; tail="${tail#"$seg"\"}"; else break; fi
+  done
+  printf '%s' "$out"
+}
+_json_unescape(){  # single left-to-right pass; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
+  local s="$1" out="" c
+  case "$s" in *\\*) ;; *) printf '%s' "$s"; return 0 ;; esac   # no escapes: the common case pays nothing
+  while [ -n "$s" ]; do
+    c="${s%"${s#?}"}"; s="${s#?}"
+    if [ "$c" = "\\" ] && [ -n "$s" ]; then
+      c="${s%"${s#?}"}"; s="${s#?}"
+      case "$c" in
+        n) out="$out
+" ;;
+        t) out="$out	" ;;
+        r) ;;
+        b|f) out="$out " ;;
+        u) s="${s#????}"; out="$out?" ;;
+        *) out="$out$c" ;;
+      esac
+    else
+      out="$out$c"
+    fi
+  done
+  printf '%s' "$out"
+}
 if command -v jq >/dev/null 2>&1; then
   CMD="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)"
   PERM_MODE="$(printf '%s' "$INPUT" | jq -r '.permission_mode // empty' 2>/dev/null)"
@@ -41,8 +97,8 @@ elif command -v python3 >/dev/null 2>&1; then
   CMD="$(printf '%s' "$INPUT" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(d.get("tool_input",{}).get("command",""))' 2>/dev/null)"
   PERM_MODE="$(printf '%s' "$INPUT" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(d.get("permission_mode",""))' 2>/dev/null)"
 else
-  CMD="$INPUT"
-  PERM_MODE="$(printf '%s' "$INPUT" | sed -n 's/.*"permission_mode"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+  CMD="$(_json_unescape "$(_json_slice "$INPUT" command)")"
+  PERM_MODE="$(_json_slice "$INPUT" permission_mode)"
 fi
 PERM_MODE="${PERM_MODE:-}"
 [ -z "$CMD" ] && exit 0

--- a/plugin/hooks/pre-commit
+++ b/plugin/hooks/pre-commit
@@ -2,6 +2,7 @@
 # Pre-commit gate on staged ADDED lines:
 #  (1) §4.1/§4.2 trace scanner — AI-authorship traces / vendor names (trace-blocklist.txt)
 #  (2) secret scanner        — API keys / tokens / private keys       (secret-blocklist.txt)
+#  (3) private-path scanner  — this machine's $HOME + .private-terms.txt (§4.3)
 # Skipping requires an explicit request per §4.5 (git commit --no-verify).
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -123,10 +124,60 @@ if [ -f "$SL" ] && [ -s "$SECRET_F" ]; then
   done < "$SL"
 fi
 
+# (3) private-path scan — a path that only exists on THIS machine has no business in a shared artifact.
+#
+# Why this is not a blocklist regex: "is this path private?" cannot be answered by a pattern. `/Users/me` is a
+# placeholder every README wants, `/Users/ada` is a real person's home, and no ERE separates them (and ERE has
+# no negative lookahead to spell "not a placeholder"). So the terms are derived from the machine doing the
+# commit — where the answer is knowable exactly — plus whatever the repo owner adds by hand.
+#
+# It exists because this failure is not hypothetical: a work project's absolute path, pasted from a terminal
+# into a CHANGELOG entry, shipped in eight consecutive releases before anyone noticed. The paste is the vector,
+# so the gate has to sit where pasted text becomes a commit.
+#
+#   automatic  : $HOME, in the three spellings the same directory gets written as on Windows
+#                (/c/Users/x · C:/Users/x · C:\Users\x) — case-insensitively, since that filesystem is.
+#   by hand    : .private-terms.txt at the repo root, one literal term per line ('#' comments). Put internal
+#                project names, client names, and host names there. GITIGNORE IT — it is a list of the very
+#                strings you do not want published.
+#   escape     : .private-allowlist.txt, a term per full line, for the rare case a term is legitimately public.
+PRIV_F="$(mktemp)"; PTERM_F="$(mktemp)"
+trap 'rm -f "$TRACE_F" "$SECRET_F" "$PRIV_F" "$PTERM_F"' EXIT INT TERM
+PTF="";  [ -n "$GITROOT" ] && [ -f "$GITROOT/.private-terms.txt" ]     && PTF="$GITROOT/.private-terms.txt"
+PAL="";  [ -n "$GITROOT" ] && [ -f "$GITROOT/.private-allowlist.txt" ] && PAL="$GITROOT/.private-allowlist.txt"
+{
+  # A home path shorter than this cannot be distinguishing (`/root`, `/`), and matching it would flag everything.
+  if [ -n "${HOME:-}" ] && [ "${#HOME}" -ge 8 ]; then
+    printf '%s\n' "$HOME"
+    # Git Bash reports /c/Users/x for what Windows itself calls C:\Users\x — both spellings reach a file.
+    case "$HOME" in
+      /[a-zA-Z]/?*)
+        d="$(printf '%s' "${HOME:1:1}" | tr 'a-z' 'A-Z')"; r="${HOME:3}"
+        printf '%s\n' "$d:/$r" "$d:\\${r//\//\\}" ;;
+    esac
+  fi
+  [ -n "$PTF" ] && sed -e 's/[[:space:]]*$//' -e '/^#/d' -e '/^$/d' "$PTF"
+} > "$PTERM_F" 2>/dev/null || true
+if [ -s "$PTERM_F" ] && [ -s "$SECRET_F" ]; then
+  while IFS= read -r term || [ -n "$term" ]; do
+    term="${term%$'\r'}"
+    [ -n "$term" ] || continue
+    if [ -n "$PAL" ] && grep -qxF -- "$term" "$PAL"; then continue; fi
+    if grep -qiF -- "$term" "$SECRET_F"; then
+      # The term is echoed back deliberately: unlike a secret, the author has to see WHICH private string to
+      # replace, and it is already sitting in their own working tree.
+      echo "PRIVATE-PATH SCANNER: a staged line contains a machine-private string -> '$term' (§4.3)"
+      HIT=1
+    fi
+  done < "$PTERM_F"
+fi
+rm -f "$PRIV_F"
+
 if [ "$HIT" -ne 0 ]; then
   echo "-----------------------------------------------------------"
   echo "Commit stopped. Remove the AI-authorship trace / vendor name / secret / bloated file from the staged changes."
   echo "False positive (trace/secret)? add the EXACT pattern line to .trace-allowlist.txt or .secret-allowlist.txt at the repo root."
+  echo "Private path flagged but genuinely public? add that exact term to .private-allowlist.txt at the repo root."
   echo "Large file is intentional? raise CSK_MAX_FILE_BYTES, use Git LFS, or gitignore the build/vendored path."
   echo "Deliberate exception: 'git commit --no-verify' — only on an EXPLICIT request (§4.5)."
   exit 1

--- a/plugin/hooks/session-stats.sh
+++ b/plugin/hooks/session-stats.sh
@@ -26,12 +26,35 @@ if [ -z "$TR" ] && [ ! -t 0 ]; then
   IN="$(cat 2>/dev/null || true)"
   [ -n "$IN" ] && TR="$(printf '%s' "$IN" | sed -n 's/.*"transcript_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
 fi
+# ---- CSK-TRANSCRIPT-DIR (kept byte-identical in context-usage.sh and session-stats.sh; smoke-test §6i3 pins it)
+# Claude Code stores a session under $HOME/.claude/projects/<cwd encoded as a directory name>. Reproducing that
+# encoding is the ONLY way a by-hand call (no hook payload on stdin) can find its own transcript.
+csk_project_dirs(){   # candidate directory names for the current cwd, best first, one per line
+  local w p
+  # Windows first. Claude Code sees the NATIVE cwd (C:\repo\app) while Git Bash's `pwd` reports /c/repo/app, so
+  # the drive letter never matched and the by-hand call could not resolve a transcript on Windows AT ALL — the
+  # same "transcript not found" was reported from that machine three separate times before the cause was found.
+  # `pwd -W` is the MSYS builtin that returns the native form; elsewhere it just fails and is discarded.
+  w="$(pwd -W 2>/dev/null || true)"
+  # The encoder folds : \ / . AND _ to '-'. The underscore is the one that hides: a project named `report_api`
+  # lands in `...-report-api`, so folding only slashes and dots misses every path containing an underscore — on
+  # every platform, not just Windows.
+  for p in "$w" "$(pwd)"; do
+    [ -n "$p" ] && printf '%s\n' "$(printf '%s' "$p" | sed 's#[:\\/._]#-#g')"
+  done
+  # Legacy shapes, kept so a directory written by an older client still resolves.
+  printf '%s\n' "$(pwd | sed 's#[/.]#-#g')" "$(pwd | sed 's#/#-#g')"
+}
 if [ -z "$TR" ]; then
-  for esc in "$(pwd | sed 's#[/.]#-#g')" "$(pwd | sed 's#/#-#g')"; do
+  while IFS= read -r esc; do
+    [ -n "$esc" ] || continue
     cand="$(ls -t "$HOME/.claude/projects/$esc"/*.jsonl 2>/dev/null | head -1)"
     [ -n "$cand" ] && { TR="$cand"; break; }
-  done
+  done <<CSKEOF
+$(csk_project_dirs)
+CSKEOF
 fi
+# ---- /CSK-TRANSCRIPT-DIR
 [ -n "$TR" ] && [ -f "$TR" ] || { echo "session-stats: transcript not found (pass an arg or use hook stdin)" >&2; exit 1; }
 
 # Whole-file scan, unlike context-usage.sh's byte-bounded tail: that one runs on EVERY turn inside a hook

--- a/start.sh
+++ b/start.sh
@@ -327,7 +327,9 @@ else
   echo "  ./CLAUDE.md existed — prepended the discipline @import; your content is untouched."
 fi
 touch .gitignore
-for e in 'docs/' '.claude/' 'CLAUDE.md'; do grep -qxF "$e" .gitignore || echo "$e" >> .gitignore; done
+# .private-terms.txt lists the strings that must never be published (internal project names, client
+# names, host names) — publishing that list would defeat its purpose, so it is ignored from the start.
+for e in 'docs/' '.claude/' 'CLAUDE.md' '.private-terms.txt'; do grep -qxF "$e" .gitignore || echo "$e" >> .gitignore; done
 if [ -d .git ]; then
   git config core.hooksPath .claude/hooks
   echo "  trace scan: core.hooksPath -> .claude/hooks (§4.1/§4.2 commit gate active)"


### PR DESCRIPTION
## Why

Three gates were live but not doing what they claimed on Windows, and the tests that covered them
could not tell the difference.

**`guard-bash.sh` judged the payload, not the command.** With neither `jq` nor `python3` on PATH —
the stock Git Bash state — the fallback assigned the entire hook JSON to `CMD` and ran the §4.4/§4.5
matchers over it. A session id whose second group starts `f8` matches the force-push rule, so every
ordinary `git push` was hard-blocked; when it did not misfire, the §4.4 prompt showed the raw JSON
instead of the command the human was approving. A gate that blocks the innocent teaches people to
reach for `--no-verify`, which disarms all of §4.

**The transcript directory was derived with the wrong rule.** Folding only `/` and `.` misses the
drive letter and every underscore, so the by-hand `context-usage.sh` / `session-stats.sh` call could
not find its own transcript on Windows at all — three sessions reported "could not measure" and
dropped the 🔋 line. Observed ground truth: the client folds `:` `\` `/` `.` and `_`.

**A machine-private path shipped in eight releases.** An absolute work path, pasted from a terminal
into a CHANGELOG entry, went out in v2.0.2 through v2.3.2. The file is fixed here; history and
published tarballs are deliberately left alone.

## What changed

| Area | Change |
|---|---|
| `guard-bash.sh` | Pure parameter-expansion slice of `tool_input.command` — **zero forks**, cheaper than the `sed` it replaces. Takes the *first* `"command"` key so a decoy inside the command cannot relocate the parse. |
| `context-usage.sh` · `session-stats.sh` | Correct cwd encoding + `pwd -W` for the native Windows path. The resolver is duplicated (a shared file would need adding to `build-plugin.sh`'s copy list, and a miss there breaks the plugin channel silently) and a gate now forbids the two copies from drifting. |
| `pre-commit` | New scanner (3): machine-private strings — the committing machine's own `$HOME` plus a gitignored `.private-terms.txt`, with `.private-allowlist.txt` as the escape. Whether a path is private is not a question a pattern can answer, so the terms come from the machine where the answer is knowable. |
| `start.sh` | New installs gitignore `.private-terms.txt` from the start. |

## Verification

20 new behavioural assertions, **each sabotage-tested** — the gate must fail when the fix is reverted:

- §7b · 8 — the jq-less branch: false positive gone, the §4.4 prompt shows the command, decoy key, escaped quotes, backslash paths
- §6i3 · 5 — encoding for POSIX / Windows / underscore, read **out of the hook** rather than restated in the test, plus the anti-drift check
- §6h C2 · 4 — private-path gate blocks `$HOME`, leaves `/Users/me` alone, honours the term file, stays overridable
- §5e · 3 — the executable bit, on disk **and in the git index**

Measured on the real target: **Git Bash 5.2 / MINGW64**, parser 5/5; the encoder reproduces that
machine's actual project directory exactly. The fallback branch was also compared against `jq`'s own
verdicts across 15 payloads — identical in all 15.

### The tests were the bug, too

The existing no-jq assertions (`commit` asks, `reset --hard` blocks) were **true of the broken blob
as well**, so they passed throughout. Their sandbox was built with `command -v`, which returns a bare
name when a shell function shadows the tool — producing a symlink pointing at itself — and `jq` stayed
visible through the shell's hash table, so the section silently skipped in a full run while passing in
isolation. The sandbox now resolves with `type -P`, probes from a fresh process, carries a canary, and
a skip is a failure that states its reason.

`bash claude-starter/eval/smoke-test.sh` — PASSED, 0 errors. Plugin edition rebuilt and in sync.
No version bump; release stays a separate decision.
