### PR TITLE
fix(plugin): regenerate the manifest the release bump hand-edited

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,19 +2,11 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-starter-kit",
   "displayName": "Claude Starter Kit",
-  "description": "Agentic Working Kit \u2014 disciplined agents, skills, slash commands, and tool-level gate hooks (commit/push approval, destructive-op & write guards, context-fill measurement, session rehydration) for Claude Code. The git-commit trace/secret/bloat scan needs the full install (start.sh / adopt.sh).",
+  "description": "Agentic Working Kit — disciplined agents, skills, slash commands, and tool-level gate hooks (commit/push approval, destructive-op & write guards, context-fill measurement, session rehydration) for Claude Code. The git-commit trace/secret/bloat scan needs the full install (start.sh / adopt.sh).",
   "version": "2.8.0",
-  "author": {
-    "name": "Bar\u0131\u015f Yerlikaya"
-  },
+  "author": { "name": "Barış Yerlikaya" },
   "homepage": "https://github.com/byerlikaya/claude-starter-kit",
   "repository": "https://github.com/byerlikaya/claude-starter-kit",
   "license": "MIT",
-  "keywords": [
-    "claude-code",
-    "agents",
-    "skills",
-    "workflow",
-    "hooks"
-  ]
+  "keywords": ["claude-code", "agents", "skills", "workflow", "hooks"]
 }


### PR DESCRIPTION
The `v2.8.0` release stopped at **Verify the plugin edition is in sync**, before building the tarball. Nothing was published: every publish step is `skipped` in [run 34276128238](https://github.com/byerlikaya/claude-starter-kit/actions/runs/34276128238).

## Cause

`plugin/.claude-plugin/plugin.json` is generated by `packaging/build-plugin.sh`. The version bump edited it by hand instead, and re-encoding the JSON changed three things the generator does not:

```diff
-  "description": "... Kit — disciplined agents ..."
+  "description": "... Kit — disciplined agents ..."
-  "author": {
-    "name": "Barış Yerlikaya"
-  },
+  "author": { "name": "Barış Yerlikaya" },
-  "keywords": [
-    "claude-code",
-    ...
-  ]
+  "keywords": ["claude-code", "agents", "skills", "workflow", "hooks"]
```

Non-ASCII escaped to `\uXXXX`, and the compact `author` and `keywords` lines were expanded. The file stayed valid JSON, which is why nothing local caught it — `verify.sh manifests` validates the schema, and the sync check lives in `release.yml`.

## Fix

`bash packaging/build-plugin.sh`, committed as generated. `VERSION` is the only carrier the manifest needs; the generator reads it.

The release sequence should therefore be: bump `VERSION`, `package.json`, both README badges and the CHANGELOG heading by hand — then **run the generator** for `plugin.json`.

`bash packaging/verify.sh` — 7/7 locally.

## After merge

`v2.8.0` currently points at `0ccd9cd`, which carries the bad manifest. It published nothing and created no GitHub Release, so it needs to move to the fixed commit before the release can run again.