### PR TITLE
fix(studio): one slow file open stopped the whole panel, not just the request

### DIFF
--- a/claude-starter/studio/server/index.js
+++ b/claude-starter/studio/server/index.js
@@ -202,7 +202,7 @@ async function handle(req, res) {
     const self = { name: SELF_NAME, local: true, ok: true, sessions: mine.length };
     // Sessions reachable on other machines. Not live and not this machine's —
     // a snapshot of what a Remote-Control-connected session last recorded.
-    const roster = remoteRoster();
+    const roster = await remoteRoster();
     if (!PEERS.length) return sendJson(res, 200, { ...local, sessions: mine, origins: [self], roster });
 
     const answers = await askAll(PEERS, '/api/fleet');
@@ -231,7 +231,7 @@ async function handle(req, res) {
     // Cached, not awaited. The list is local data; making it wait on a registry cost 8.37 s of
     // dead time whenever the feed hung, measured. The refresh runs behind this response.
     const latest = latestVersionCached();
-    const projects = listProjects({ currentCwd: cwd, kitOf: (c) => kitStatus(c, latest) });
+    const projects = await listProjects({ currentCwd: cwd, kitOf: (c) => kitStatus(c, latest) });
     for (const p of projects) { p.origin = SELF_NAME; p.local = true; }
 
     const origins = [{ name: SELF_NAME, local: true, ok: true, projects: projects.length }];
@@ -280,7 +280,7 @@ async function handle(req, res) {
   if (url.pathname === '/api/kit') {
     const cwd = url.searchParams.get('cwd') || process.cwd();
     const sid = url.searchParams.get('session');
-    const session = sid ? findSession(sid) : null;
+    const session = sid ? await findSession(sid) : null;
     const [report, stats, brd] = await Promise.all([
       gateReport(cwd),
       session ? sessionStats(cwd, session.file) : Promise.resolve({ measured: false, reason: 'no session named' }),
@@ -295,7 +295,7 @@ async function handle(req, res) {
 
   if (url.pathname === '/api/sessions') {
     const cwd = url.searchParams.get('cwd') || process.cwd();
-    const dir = projectDir(cwd);
+    const dir = await projectDir(cwd);
     if (!dir) {
       // Nothing was read. That is not the same as "this project never ran".
       return sendJson(res, 200, {
@@ -305,7 +305,7 @@ async function handle(req, res) {
         sessions: [],
       });
     }
-    const sessions = listSessions(dir).map((s) => ({
+    const sessions = (await listSessions(dir)).map((s) => ({
       sessionId: s.sessionId,
       bytes: s.bytes,
       modifiedAt: s.modifiedAt,
@@ -316,37 +316,37 @@ async function handle(req, res) {
 
   const graphMatch = url.pathname.match(/^\/api\/session\/([^/]+)\/graph$/);
   if (graphMatch) {
-    const session = findSession(decodeURIComponent(graphMatch[1]));
+    const session = await findSession(decodeURIComponent(graphMatch[1]));
     if (!session) {
       const relayed = await relay(url.pathname);
       if (relayed) return sendJson(res, 200, relayed);
       return sendJson(res, 404, { measured: false, reason: 'no such session on this machine or any peer' });
     }
     const started = Date.now();
-    const graph = buildGraph(session);
+    const graph = await buildGraph(session);
     return sendJson(res, 200, { ...graph, measured: true, buildMs: Date.now() - started });
   }
 
   const convMatch = url.pathname.match(/^\/api\/session\/([^/]+)\/conversation$/);
   if (convMatch) {
-    const session = findSession(decodeURIComponent(convMatch[1]));
+    const session = await findSession(decodeURIComponent(convMatch[1]));
     if (!session) {
       const relayed = await relay(url.pathname);
       if (relayed) return sendJson(res, 200, relayed);
       return sendJson(res, 404, { measured: false, reason: 'no such session on this machine or any peer' });
     }
-    return sendJson(res, 200, conversation(session));
+    return sendJson(res, 200, await conversation(session));
   }
 
   const agentMatch = url.pathname.match(/^\/api\/session\/([^/]+)\/agent\/([^/]+)$/);
   if (agentMatch) {
-    const session = findSession(decodeURIComponent(agentMatch[1]));
+    const session = await findSession(decodeURIComponent(agentMatch[1]));
     if (!session) {
       const relayed = await relay(url.pathname);
       if (relayed) return sendJson(res, 200, relayed);
       return sendJson(res, 404, { measured: false, reason: 'no such session' });
     }
-    const detail = agentDetail(session, decodeURIComponent(agentMatch[2]));
+    const detail = await agentDetail(session, decodeURIComponent(agentMatch[2]));
     if (!detail) return sendJson(res, 404, { measured: false, reason: 'no transcript for that agent' });
     return sendJson(res, 200, { ...detail, measured: true });
   }
@@ -355,8 +355,8 @@ async function handle(req, res) {
   const termMatch = url.pathname.match(/^\/api\/session\/([^/]+)\/terminal$/);
   if (termMatch) {
     const id = decodeURIComponent(termMatch[1]);
-    const session = findSession(id);
-    const cwd = url.searchParams.get('cwd') || (session ? sessionCwd(session.file, session.bytes) : null);
+    const session = await findSession(id);
+    const cwd = url.searchParams.get('cwd') || (session ? await sessionCwd(session.file, session.bytes) : null);
 
     if (req.method === 'GET') {
       // What WOULD run, so the panel can show it before anything is launched.
@@ -535,20 +535,27 @@ async function relay(pathname) {
   return null;
 }
 
-function signature(session) {
+// Async for the same reason projects.js is, and more urgently: this runs on every
+// stream tick — 700 ms, seven times more often than the project list is polled —
+// so a synchronous stat here is seven times more chances to stop the event loop on
+// a machine where one file open can take 31 s. The stall itself is not ours to fix;
+// keeping it inside the one tick that hit it is.
+async function signature(session) {
   const parts = [];
-  try { parts.push(String(fs.statSync(session.file).size)); } catch { parts.push('0'); }
+  try { parts.push(String((await fsp.stat(session.file)).size)); } catch { parts.push('0'); }
   try {
-    for (const n of fs.readdirSync(session.subagentsDir).sort()) {
-      try { parts.push(`${n}:${fs.statSync(path.join(session.subagentsDir, n)).size}`); } catch { /* raced */ }
-    }
+    const names = (await fsp.readdir(session.subagentsDir)).sort();
+    const sizes = await Promise.all(names.map(async (n) => {
+      try { return `${n}:${(await fsp.stat(path.join(session.subagentsDir, n))).size}`; } catch { return null; }
+    }));
+    for (const s of sizes) if (s !== null) parts.push(s);
   } catch { /* no subagents yet */ }
   return parts.join('|');
 }
 
-function stream(req, res, url) {
+async function stream(req, res, url) {
   const id = url.searchParams.get('session');
-  let session = id ? findSession(id) : null;
+  let session = id ? await findSession(id) : null;
 
   res.writeHead(200, {
     'content-type': 'text/event-stream; charset=utf-8',
@@ -577,18 +584,30 @@ function stream(req, res, url) {
     req.on('error', stopWait);
 
     let last = null;
-    const watch = (found) => {
+    // `setInterval` does not wait for an async callback, so a tick that outlasts the
+    // interval is joined by the next one rather than replacing it. Synchronous reads
+    // made that impossible — a blocked loop fires nothing — so this guard is repairing
+    // something the async conversion introduced, not a pre-existing bug. Measured with
+    // a 3 s read against a 700 ms tick: five callbacks in flight at once without it,
+    // one with it. A real 31 s read would stack about forty-four, each of them racing
+    // the same `last` and queueing another `1 + 1 + N` reads behind the first.
+    let busy = false;
+    const watch = async (found) => {
+      if (busy) return;
+      busy = true;
       try {
-        const sig = signature(found);
-        if (sig !== last) { last = sig; send('graph', buildGraph(found)); }
+        const sig = await signature(found);
+        if (sig !== last) { last = sig; send('graph', await buildGraph(found)); }
         else send('idle', { at: Date.now() });
       } catch (e) {
         send('fault', { measured: false, reason: String(e?.message ?? e) });
+      } finally {
+        busy = false;
       }
     };
 
-    timer = setInterval(() => {
-      const found = findSession(id);
+    timer = setInterval(async () => {
+      const found = await findSession(id);
       if (!found) return;                       // still waiting for the first turn
       clearInterval(timer);
       watch(found);
@@ -618,17 +637,22 @@ function stream(req, res, url) {
   }
 
   let last = null;
-  const tick = () => {
+  let busy = false;                             // same re-entrancy guard as the watcher above
+  const tick = async () => {
+    if (busy) return;
+    busy = true;
     try {
-      const sig = signature(session);
+      const sig = await signature(session);
       if (sig !== last) {
         last = sig;
-        send('graph', buildGraph(session));
+        send('graph', await buildGraph(session));
       } else {
         send('idle', { at: Date.now() });
       }
     } catch (e) {
       send('fault', { measured: false, reason: String(e?.message ?? e) });
+    } finally {
+      busy = false;
     }
   };
 

--- a/claude-starter/studio/server/lib/graph.js
+++ b/claude-starter/studio/server/lib/graph.js
@@ -14,7 +14,7 @@
 // `toolUseId` is the join. Whoever emitted that tool_use is the parent: the
 // session itself for depth 1, another agent for anything deeper.
 
-import fs from 'node:fs';
+import fsp from 'node:fs/promises';
 import path from 'node:path';
 
 import { readAll, contextFill } from './transcript.js';
@@ -119,8 +119,8 @@ function scanMain(records) {
 }
 
 /** Roll one agent's own transcript into the numbers its node shows. */
-function scanAgent(file) {
-  const { records } = readAll(file);
+async function scanAgent(file) {
+  const { records } = await readAll(file);
   const stats = {
     tools: {}, toolCount: 0, lastTool: null, errors: 0,
     tokens: null, startedAt: null, endedAt: null, turns: 0,
@@ -167,20 +167,25 @@ function scanAgent(file) {
   return stats;
 }
 
-function readAgentDir(subagentsDir) {
+async function readAgentDir(subagentsDir) {
   const out = [];
   // Nested too: a workflow puts its agents under subagents/workflows/<id>/.
-  for (const metaPath of agentMetaFiles(subagentsDir)) {
+  for (const metaPath of await agentMetaFiles(subagentsDir)) {
     const name = path.basename(metaPath);
     const dir = path.dirname(metaPath);
     if (!name.startsWith('agent-')) continue;
     const agentId = name.slice('agent-'.length, -'.meta.json'.length);
     let meta = {};
-    try { meta = JSON.parse(fs.readFileSync(metaPath, 'utf8')); } catch { /* keep going */ }
+    try { meta = JSON.parse(await fsp.readFile(metaPath, 'utf8')); } catch { /* keep going */ }
 
     const jsonl = path.join(dir, `agent-${agentId}.jsonl`);
     let mtime = null;
-    try { mtime = fs.statSync(jsonl).mtimeMs; } catch { /* not written yet */ }
+    try { mtime = (await fsp.stat(jsonl)).mtimeMs; } catch { /* not written yet */ }
+
+    // `stats` needs the transcript read; a missing file is a normal state (the
+    // agent has not written yet), so absence is a null rather than a throw.
+    let stats = null;
+    if (mtime !== null) stats = await scanAgent(jsonl);
 
     out.push({
       agentId,
@@ -193,7 +198,7 @@ function readAgentDir(subagentsDir) {
       // A workflow agent belongs to the run that spawned it, not the session
       // root; without this they all hang off the root as one flat fan.
       workflow: dir === subagentsDir ? null : path.basename(dir),
-      stats: fs.existsSync(jsonl) ? scanAgent(jsonl) : null,
+      stats,
     });
   }
   return out;
@@ -205,10 +210,10 @@ function readAgentDir(subagentsDir) {
  * rather than running — an unfinished agent whose file stopped growing is a
  * different fact from one that is working.
  */
-export function buildGraph(session, { staleMs = 120000 } = {}) {
-  const { records, malformed } = readAll(session.file);
+export async function buildGraph(session, { staleMs = 120000 } = {}) {
+  const { records, malformed } = await readAll(session.file);
   const main = scanMain(records);
-  const agents = readAgentDir(session.subagentsDir);
+  const agents = await readAgentDir(session.subagentsDir);
   const now = Date.now();
 
   // Ownership: session first, then every agent's own tool_use ids, so a nested
@@ -390,17 +395,17 @@ export const _internals = { scanMain, harvestCompletions, SESSION_NODE };
  * thousands of characters and the graph is pushed down an SSE stream every
  * time a file changes. This is fetched when someone opens a node.
  */
-export function agentDetail(session, agentId) {
+export async function agentDetail(session, agentId) {
   if (!/^[A-Za-z0-9_-]+$/.test(agentId)) return null;
 
   const file = path.join(session.subagentsDir, `agent-${agentId}.jsonl`);
-  if (!fs.existsSync(file)) return null;
+  try { await fsp.stat(file); } catch { return null; }
 
-  const { records, malformed } = readAll(file);
+  const { records, malformed } = await readAll(file);
 
   let meta = {};
   try {
-    meta = JSON.parse(fs.readFileSync(path.join(session.subagentsDir, `agent-${agentId}.meta.json`), 'utf8'));
+    meta = JSON.parse(await fsp.readFile(path.join(session.subagentsDir, `agent-${agentId}.meta.json`), 'utf8'));
   } catch { /* the transcript is still the source of truth */ }
 
   const timeline = [];
@@ -472,8 +477,8 @@ export function agentDetail(session, agentId) {
  * Sidechains are skipped: a subagent's exchange belongs to the graph, not to
  * the conversation the person had.
  */
-export function conversation(session, { limit = 400 } = {}) {
-  const { records } = readAll(session.file);
+export async function conversation(session, { limit = 400 } = {}) {
+  const { records } = await readAll(session.file);
   const out = [];
 
   for (const r of records) {

--- a/claude-starter/studio/server/lib/kit.js
+++ b/claude-starter/studio/server/lib/kit.js
@@ -8,7 +8,7 @@
 // Read-only. Detecting that a project is behind and updating it are different
 // acts, and only the first one happens here.
 
-import fs from 'node:fs';
+import fsp from 'node:fs/promises';
 import path from 'node:path';
 
 const FEED = process.env.CSK_UPDATE_URL
@@ -107,24 +107,30 @@ export function compareVersions(a, b) {
   return 0;
 }
 
-/** What the kit looks like inside one working directory. */
-export function kitStatus(cwd, latest) {
+/** What the kit looks like inside one working directory.
+ *
+ * Async because it runs once per project on the `/api/projects` path, and a
+ * synchronous read there blocks the whole panel when one file open stalls —
+ * see the note at the top of projects.js for the measurement.
+ */
+export async function kitStatus(cwd, latest) {
   if (!cwd) return { installed: false, reason: 'no working directory recorded' };
 
   const claude = path.join(cwd, '.claude');
   let version = null;
-  try { version = sane(fs.readFileSync(path.join(claude, 'VERSION'), 'utf8')); } catch { /* not installed */ }
+  try { version = sane(await fsp.readFile(path.join(claude, 'VERSION'), 'utf8')); } catch { /* not installed */ }
 
   if (!version) {
     // Distinguish "no kit here" from "the directory is gone" — one is a choice,
     // the other is a dead path.
-    const present = fs.existsSync(cwd);
+    let present = false;
+    try { await fsp.stat(cwd); present = true; } catch { present = false; }
     return { installed: false, dirExists: present, reason: present ? 'kit not installed' : 'directory no longer exists' };
   }
 
   const conf = {};
   try {
-    for (const line of fs.readFileSync(path.join(claude, 'kit.conf'), 'utf8').split('\n')) {
+    for (const line of (await fsp.readFile(path.join(claude, 'kit.conf'), 'utf8')).split('\n')) {
       const m = line.match(/^\s*([A-Za-z_]+)\s*=\s*(.*)$/);
       if (m) conf[m[1]] = m[2].trim();
     }

--- a/claude-starter/studio/server/lib/projects.js
+++ b/claude-starter/studio/server/lib/projects.js
@@ -10,7 +10,15 @@
 // This is a re-implementation in another language on purpose — a fourth bash
 // copy would break that pin.
 
-import fs from 'node:fs';
+// EVERY filesystem call here is async, and that is the point rather than a style
+// choice. Measured on a Windows 11 machine whose EDR inspects file opens: reading
+// the 128 KiB tail of one transcript took 0-1 ms on fourteen runs out of fifteen
+// and 31,209 ms on the fifteenth. With `readSync` that stalled the event loop, so
+// the panel answered NOTHING for half a minute — `/api/projects` took 33,391 ms and
+// a separate `/api/health` on its own connection went unanswered for 312 of 324
+// pings. Async does not make the read faster; the same 30 s still passes. It keeps
+// the stall inside the one request that hit it while the rest of the panel stays up.
+import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -35,20 +43,19 @@ export function candidateDirs(cwd) {
 }
 
 /** The project directory for a cwd, or null when nothing was recorded yet. */
-export function projectDir(cwd) {
+export async function projectDir(cwd) {
   for (const name of candidateDirs(cwd)) {
     const p = path.join(PROJECTS_ROOT, name);
-    try { if (fs.statSync(p).isDirectory()) return p; } catch { /* next */ }
+    try { if ((await fsp.stat(p)).isDirectory()) return p; } catch { /* next */ }
   }
   return null;
 }
 
 /** Every project directory on this machine. */
-export function allProjectDirs() {
+export async function allProjectDirs() {
   try {
-    return fs.readdirSync(PROJECTS_ROOT, { withFileTypes: true })
-      .filter((e) => e.isDirectory())
-      .map((e) => path.join(PROJECTS_ROOT, e.name));
+    const entries = await fsp.readdir(PROJECTS_ROOT, { withFileTypes: true });
+    return entries.filter((e) => e.isDirectory()).map((e) => path.join(PROJECTS_ROOT, e.name));
   } catch {
     return [];
   }
@@ -62,18 +69,18 @@ export function allProjectDirs() {
 const TITLE_TAIL_BYTES = 131072;
 const titleCache = new Map(); // file -> { sig, title }
 
-export function sessionTitle(file, size, mtimeMs) {
+export async function sessionTitle(file, size, mtimeMs) {
   const sig = `${size}:${mtimeMs}`;
   const hit = titleCache.get(file);
   if (hit && hit.sig === sig) return hit.title;
 
   let title = null;
-  let fd;
+  let fh;
   try {
-    fd = fs.openSync(file, 'r');
+    fh = await fsp.open(file, 'r');
     const len = Math.min(size, TITLE_TAIL_BYTES);
     const buf = Buffer.allocUnsafe(len);
-    fs.readSync(fd, buf, 0, len, Math.max(0, size - len));
+    await fh.read(buf, 0, len, Math.max(0, size - len));
     const text = buf.toString('utf8');
 
     // Cheap prefilter: most sessions carry none of these, and parsing every
@@ -94,7 +101,7 @@ export function sessionTitle(file, size, mtimeMs) {
   } catch {
     title = null;
   } finally {
-    if (fd !== undefined) try { fs.closeSync(fd); } catch { /* already gone */ }
+    if (fh !== undefined) try { await fh.close(); } catch { /* already gone */ }
   }
 
   if (titleCache.size > 500) titleCache.clear();
@@ -107,23 +114,23 @@ export function sessionTitle(file, size, mtimeMs) {
 // which carries `cwd`. Head, not tail: the value never changes mid-session.
 const cwdCache = new Map();
 
-export function sessionCwd(file, size) {
+export async function sessionCwd(file, size) {
   const hit = cwdCache.get(file);
   if (hit && hit.size === size) return hit.cwd;
 
   let cwd = null;
-  let fd;
+  let fh;
   try {
-    fd = fs.openSync(file, 'r');
+    fh = await fsp.open(file, 'r');
     const len = Math.min(size, 8192);
     const buf = Buffer.allocUnsafe(len);
-    fs.readSync(fd, buf, 0, len, 0);
+    await fh.read(buf, 0, len, 0);
     cwd = buf.toString('utf8').match(/"cwd"\s*:\s*"((?:[^"\\]|\\.)*)"/)?.[1] ?? null;
     if (cwd) cwd = cwd.replace(/\\\\/g, '\\').replace(/\\"/g, '"');
   } catch {
     cwd = null;
   } finally {
-    if (fd !== undefined) try { fs.closeSync(fd); } catch { /* already gone */ }
+    if (fh !== undefined) try { await fh.close(); } catch { /* already gone */ }
   }
 
   if (cwdCache.size > 500) cwdCache.clear();
@@ -137,42 +144,43 @@ export function sessionCwd(file, size) {
  * beside it — counting only the top level is how you end up reporting that
  * nothing ever delegated.
  */
-export function listSessions(dir) {
+export async function listSessions(dir) {
   let entries;
-  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return []; }
+  try { entries = await fsp.readdir(dir, { withFileTypes: true }); } catch { return []; }
 
-  const out = [];
-  for (const e of entries) {
-    if (!e.isFile() || !e.name.endsWith('.jsonl')) continue;
+  // One transcript's reads do not depend on another's, so they run together.
+  // Sequential awaits cost 12 ms here where the synchronous version cost 7 —
+  // measured, 10 runs each — and that gap grows with the number of sessions.
+  // The order is irrelevant: the list is sorted by mtime below.
+  const settled = await Promise.all(entries.map(async (e) => {
+    if (!e.isFile() || !e.name.endsWith('.jsonl')) return null;
     const sessionId = e.name.slice(0, -'.jsonl'.length);
     const file = path.join(dir, e.name);
     let st;
-    try { st = fs.statSync(file); } catch { continue; }
+    try { st = await fsp.stat(file); } catch { return null; }
 
     const subagentsDir = path.join(dir, sessionId, 'subagents');
+    const [agentCount, title, cwd] = await Promise.all([
+      countAgentMetas(subagentsDir),
+      sessionTitle(file, st.size, st.mtimeMs),
+      sessionCwd(file, st.size),
+    ]);
 
-    out.push({
-      sessionId,
-      file,
-      subagentsDir,
-      bytes: st.size,
-      modifiedAt: st.mtimeMs,
-      agentCount: countAgentMetas(subagentsDir),
-      title: sessionTitle(file, st.size, st.mtimeMs),
-      cwd: sessionCwd(file, st.size),
-    });
-  }
+    return { sessionId, file, subagentsDir, bytes: st.size, modifiedAt: st.mtimeMs, agentCount, title, cwd };
+  }));
+
+  const out = settled.filter(Boolean);
   out.sort((a, b) => b.modifiedAt - a.modifiedAt);
   return out;
 }
 
 /** Find one session anywhere on this machine, by id. */
-export function findSession(sessionId) {
+export async function findSession(sessionId) {
   if (!/^[A-Za-z0-9._-]+$/.test(sessionId)) return null; // it becomes a path
-  for (const dir of allProjectDirs()) {
+  for (const dir of await allProjectDirs()) {
     const file = path.join(dir, `${sessionId}.jsonl`);
     try {
-      const st = fs.statSync(file);
+      const st = await fsp.stat(file);
       return {
         sessionId,
         file,
@@ -194,21 +202,19 @@ export function findSession(sessionId) {
  * machine, 324 of 596 metas — 54% — were in the nested form, so a flat read
  * silently reported a busy session as having delegated nothing.
  */
-export function countAgentMetas(subagentsDir) {
-  let n = 0;
-  for (const f of agentMetaFiles(subagentsDir)) { void f; n += 1; }
-  return n;
+export async function countAgentMetas(subagentsDir) {
+  return (await agentMetaFiles(subagentsDir)).length;
 }
 
 /** Every agent meta file under a subagents directory, nesting included. */
-export function agentMetaFiles(subagentsDir, depth = 0) {
+export async function agentMetaFiles(subagentsDir, depth = 0) {
   const out = [];
   if (depth > 3) return out;                    // workflows nest one level; this is slack
   let entries;
-  try { entries = fs.readdirSync(subagentsDir, { withFileTypes: true }); } catch { return out; }
+  try { entries = await fsp.readdir(subagentsDir, { withFileTypes: true }); } catch { return out; }
   for (const e of entries) {
     const p = path.join(subagentsDir, e.name);
-    if (e.isDirectory()) out.push(...agentMetaFiles(p, depth + 1));
+    if (e.isDirectory()) out.push(...await agentMetaFiles(p, depth + 1));
     else if (e.name.endsWith('.meta.json')) out.push(p);
   }
   return out;
@@ -221,11 +227,14 @@ export function agentMetaFiles(subagentsDir, depth = 0) {
  * name is a lossy fold of the path, so two different projects can share one.
  * The folder is only the fallback when no record carried a cwd.
  */
-export function listProjects({ currentCwd = null, limitPerProject = 60, kitOf = null } = {}) {
+export async function listProjects({ currentCwd = null, limitPerProject = 60, kitOf = null } = {}) {
   const groups = new Map();
 
-  for (const dir of allProjectDirs()) {
-    for (const s of listSessions(dir)) {
+  const dirs = await allProjectDirs();
+  const perDir = await Promise.all(dirs.map(async (dir) => [dir, await listSessions(dir)]));
+
+  for (const [dir, sessions] of perDir) {
+    for (const s of sessions) {
       const key = s.cwd ?? `dir:${path.basename(dir)}`;
       if (!groups.has(key)) {
         groups.set(key, { key, cwd: s.cwd, dir, label: labelFor(s.cwd, dir), sessions: [] });
@@ -234,17 +243,18 @@ export function listProjects({ currentCwd = null, limitPerProject = 60, kitOf = 
     }
   }
 
-  const out = [...groups.values()].map((g) => {
+  const out = [];
+  for (const g of groups.values()) {
     g.sessions.sort((a, b) => b.modifiedAt - a.modifiedAt);
-    const kit = kitOf ? kitOf(g.cwd) : null;
-    return {
+    const kit = kitOf ? await kitOf(g.cwd) : null;
+    out.push({
       ...g,
       kit,
       // Most transcript folders on a busy machine point at directories that no
       // longer exist — test scratch dirs, moved checkouts. They are counted,
       // not deleted: the panel says how many it is holding back rather than
       // quietly shortening the list.
-      exists: kit?.dirExists ?? (g.cwd ? existsCached(g.cwd) : false),
+      exists: kit?.dirExists ?? (g.cwd ? await existsCached(g.cwd) : false),
       total: g.sessions.length,
       agentTotal: g.sessions.reduce((n, s) => n + s.agentCount, 0),
       modifiedAt: g.sessions[0]?.modifiedAt ?? 0,
@@ -252,8 +262,8 @@ export function listProjects({ currentCwd = null, limitPerProject = 60, kitOf = 
       // Long histories are truncated rather than silently dropped, and the
       // count above still reports the whole.
       sessions: g.sessions.slice(0, limitPerProject),
-    };
-  });
+    });
+  }
 
   // Standing-in first, then live directories, then an outdated kit ahead of a
   // current one — the rows that need a decision float up.
@@ -272,10 +282,10 @@ function labelFor(cwd, dir) {
 }
 
 const existsMemo = new Map();
-function existsCached(p) {
+async function existsCached(p) {
   if (existsMemo.has(p)) return existsMemo.get(p);
   let v = false;
-  try { v = fs.existsSync(p); } catch { v = false; }
+  try { await fsp.stat(p); v = true; } catch { v = false; }
   if (existsMemo.size > 2000) existsMemo.clear();
   existsMemo.set(p, v);
   return v;

--- a/claude-starter/studio/server/lib/roster.js
+++ b/claude-starter/studio/server/lib/roster.js
@@ -14,7 +14,7 @@
 // because a stale list drawn as a live one is the kind of lie this panel is
 // built to avoid.
 
-import fs from 'node:fs';
+import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -61,18 +61,21 @@ export function parseRoster(text) {
   return { self: self ? { name: self[1], ref: self[2] } : null, peers };
 }
 
-function readTail(file, size, limit = TAIL_BYTES) {
-  let fd;
+// Async for the reason projects.js gives: this reads the tail of a transcript, which
+// is the exact operation measured at 31.2 s on one run in fifteen, and it runs on the
+// `/api/fleet` path the panel polls every 2 s — the shortest cycle in the app.
+async function readTail(file, size, limit = TAIL_BYTES) {
+  let fh;
   try {
-    fd = fs.openSync(file, 'r');
+    fh = await fsp.open(file, 'r');
     const len = Math.min(size, limit);
     const buf = Buffer.allocUnsafe(len);
-    fs.readSync(fd, buf, 0, len, Math.max(0, size - len));
+    await fh.read(buf, 0, len, Math.max(0, size - len));
     return buf.toString('utf8');
   } catch {
     return '';
   } finally {
-    if (fd !== undefined) try { fs.closeSync(fd); } catch { /* gone */ }
+    if (fh !== undefined) try { await fh.close(); } catch { /* gone */ }
   }
 }
 
@@ -82,25 +85,26 @@ function readTail(file, size, limit = TAIL_BYTES) {
  * Returns not-measured rather than an empty list when nothing has asked yet:
  * "no session has run ListAgents" and "you have no peers" are different facts.
  */
-export function remoteRoster() {
+export async function remoteRoster() {
   const files = [];
-  for (const dir of allProjectDirs()) {
+  for (const dir of await allProjectDirs()) {
     let entries;
-    try { entries = fs.readdirSync(dir); } catch { continue; }
-    for (const e of entries) {
-      if (!e.endsWith('.jsonl')) continue;
+    try { entries = await fsp.readdir(dir); } catch { continue; }
+    const stats = await Promise.all(entries.map(async (e) => {
+      if (!e.endsWith('.jsonl')) return null;
       const p = path.join(dir, e);
       try {
-        const st = fs.statSync(p);
-        files.push({ path: p, mtime: st.mtimeMs, size: st.size, sessionId: e.slice(0, -6) });
-      } catch { /* raced */ }
-    }
+        const st = await fsp.stat(p);
+        return { path: p, mtime: st.mtimeMs, size: st.size, sessionId: e.slice(0, -6) };
+      } catch { return null; }        // raced
+    }));
+    for (const s of stats) if (s) files.push(s);
   }
   files.sort((a, b) => b.mtime - a.mtime);
 
   let best = null;
   for (const [i, f] of files.slice(0, SCAN_FILES).entries()) {
-    const text = readTail(f.path, f.size, i < DEEP_FILES ? DEEP_BYTES : TAIL_BYTES);
+    const text = await readTail(f.path, f.size, i < DEEP_FILES ? DEEP_BYTES : TAIL_BYTES);
     if (!text.includes('Peer sessions')) continue;
 
     // The block lives INSIDE a JSON string, so its line breaks are the two
@@ -137,7 +141,7 @@ export function remoteRoster() {
     }
   }
 
-  const cached = readCache();
+  const cached = await readCache();
 
   if (!best) {
     if (cached) return { ...cached, fromCache: true };
@@ -166,15 +170,15 @@ export function remoteRoster() {
     return { ...cached, fromCache: true };
   }
 
-  writeCache(found);
+  await writeCache(found);
   return found;
 }
 
 const CACHE_MAX_AGE_MS = 12 * 60 * 60 * 1000;
 
-function readCache() {
+async function readCache() {
   try {
-    const c = JSON.parse(fs.readFileSync(CACHE_FILE, 'utf8'));
+    const c = JSON.parse(await fsp.readFile(CACHE_FILE, 'utf8'));
     if (!c?.measured || !Array.isArray(c.peers)) return null;
     if (typeof c.seenAt !== 'number' || c.seenAt < Date.now() - CACHE_MAX_AGE_MS) return null;
     return c;
@@ -183,6 +187,6 @@ function readCache() {
   }
 }
 
-function writeCache(roster) {
-  try { fs.writeFileSync(CACHE_FILE, JSON.stringify(roster)); } catch { /* best effort */ }
+async function writeCache(roster) {
+  try { await fsp.writeFile(CACHE_FILE, JSON.stringify(roster)); } catch { /* best effort */ }
 }

--- a/claude-starter/studio/server/lib/transcript.js
+++ b/claude-starter/studio/server/lib/transcript.js
@@ -7,7 +7,7 @@
 // A single record can itself be enormous (a pasted payload), so lines are
 // assembled from a carry buffer rather than assumed to fit in one read.
 
-import fs from 'node:fs';
+import fsp from 'node:fs/promises';
 
 export class JsonlReader {
   constructor(file) {
@@ -17,10 +17,15 @@ export class JsonlReader {
     this.malformed = 0; // counted, never silently swallowed
   }
 
-  /** Read everything appended since the last call. Returns parsed records. */
-  read() {
+  /** Read everything appended since the last call. Returns parsed records.
+   *
+   * Async because a transcript open can take 31 s on a machine whose security
+   * layer inspects it, and this sits under the stream tick — see the note at the
+   * top of projects.js. The read is no faster; it just no longer stops the loop.
+   */
+  async read() {
     let st;
-    try { st = fs.statSync(this.file); } catch { return []; }
+    try { st = await fsp.stat(this.file); } catch { return []; }
 
     // A shrunk file means it was replaced, not appended to. Start over rather
     // than reading from a stale offset into the middle of a record.
@@ -31,18 +36,18 @@ export class JsonlReader {
     if (st.size === this.offset) return [];
 
     let chunk;
-    let fd;
+    let fh;
     try {
-      fd = fs.openSync(this.file, 'r');
+      fh = await fsp.open(this.file, 'r');
       const len = st.size - this.offset;
       const buf = Buffer.allocUnsafe(len);
-      const got = fs.readSync(fd, buf, 0, len, this.offset);
-      chunk = buf.subarray(0, got).toString('utf8');
-      this.offset += got;
+      const { bytesRead } = await fh.read(buf, 0, len, this.offset);
+      chunk = buf.subarray(0, bytesRead).toString('utf8');
+      this.offset += bytesRead;
     } catch {
       return [];
     } finally {
-      if (fd !== undefined) try { fs.closeSync(fd); } catch { /* already gone */ }
+      if (fh !== undefined) try { await fh.close(); } catch { /* already gone */ }
     }
 
     const text = this.carry + chunk;
@@ -64,9 +69,9 @@ export class JsonlReader {
 }
 
 /** One-shot full read. Used for files we do not intend to follow. */
-export function readAll(file) {
+export async function readAll(file) {
   const r = new JsonlReader(file);
-  const records = r.read();
+  const records = await r.read();
   return { records, malformed: r.malformed };
 }
 

--- a/packaging/studio-serve-probe.mjs
+++ b/packaging/studio-serve-probe.mjs
@@ -165,23 +165,39 @@ const LIVENESS_MS = 2000;
 const timing = `the first /api/projects took ${waited}ms with a feed that never answers; a separate `
   + `/api/health on its own connection answered ${during.status} after ${duringMs}ms while it was in flight`;
 
-if (waited < 3000 && duringMs < LIVENESS_MS) {
-  check('the project list does not wait on the update feed', true, timing);
-  check('the panel answers other requests while the feed hangs', true, timing);
-} else if (waited > STALL_MS || duringMs > STALL_MS) {
-  // The known one. Reported, not passed and not failed: green would hide a defect we have measured,
-  // red goes red on one Windows run in eight and gets muted within a month.
-  knownIssue('the panel stalls while a transcript read blocks the loop',
-    `${timing} — nothing was served for ~${Math.round(Math.max(waited, duringMs) / 1000)}s`,
-    'listProjects reads transcripts with synchronous fs on the request path, so one slow file open '
-    + '(31.2s measured under a Windows security layer) blocks the whole event loop — present on main '
-    + 'too; the fix is async fs, tracked separately');
-  notApplicable('the project list does not wait on the update feed',
-    'this run hit the block above, so its timing measures that and cannot speak to the feed');
+// LIVENESS is the graded claim, and the timing is not.
+//
+// It used to be the other way round, and that was wrong twice over. `waited` says nothing about the
+// update feed — a run with the feed disabled entirely still stalled, which is what disproved that
+// reading — and it says nothing about the panel either: it is how long ONE file open took, which on a
+// machine whose security layer inspects opens is a property of the disk, not of this code. What the
+// panel owes its user is that a slow read stays inside the request that hit it. That is gradeable,
+// deterministic, and it is exactly what the async conversion bought:
+//
+//   sync  (main)   /api/projects 33,391 ms · a separate /api/health went unanswered 312 pings of 324
+//   async (here)   /api/projects 38,918 ms · the same health endpoint answered 195 of 195
+//
+// The read did not get faster. Nothing else went dark.
+check('the panel answers other requests while a read stalls', duringMs < LIVENESS_MS,
+  `${timing}${duringMs < LIVENESS_MS ? '' : ' — the event loop was blocked, so nothing the panel serves responded'}`);
+
+if (waited < 3000) {
+  check('the project list is served from local data, not a network round trip', true, timing);
+} else if (waited > STALL_MS) {
+  // Reported, not graded: the file open really did take half a minute, and no amount of code here
+  // makes a scanned disk faster. Green would hide it; red would fire on one Windows run in eight and
+  // be muted within a month. The graded half is above, and it stays green through exactly this run.
+  knownIssue('one transcript read took the stall shape',
+    `${timing} — the read itself took ~${Math.round(waited / 1000)}s`,
+    'a security layer inspecting file opens: 31.2s measured for a single 128 KiB tail read on this '
+    + 'machine, 0-1 ms on fourteen of fifteen runs. Not the kit\'s to fix; the kit\'s part was keeping '
+    + 'the rest of the panel answering, which the check above grades');
+  notApplicable('the project list is served from local data, not a network round trip',
+    'this run hit the stall above, so its timing measures the disk and cannot speak to the request path');
 } else {
-  // Neither fast nor the shape of the known block. Something else, and it should be loud.
-  check('the project list does not wait on the update feed', false,
-    `${timing} — slower than a local read and faster than the known block, so this is neither`);
+  // Neither a local read nor the shape of the known stall. Something else, and it should be loud.
+  check('the project list is served from local data, not a network round trip', false,
+    `${timing} — slower than a local read and faster than the known stall, so this is neither`);
 }
 
 const traversal = await get(port, `/../../../../etc/passwd?token=${TOKEN}`);

--- a/packaging/studio-test/selfcheck.mjs
+++ b/packaging/studio-test/selfcheck.mjs
@@ -706,7 +706,7 @@ check('free text after the status is carried, not parsed into a time it may not 
 check('prose without a roster yields nothing', parseRoster('there are no peers here') === null);
 check('an empty block yields nothing, not an empty roster', parseRoster('Peer sessions (0):') === null);
 
-const live = remoteRoster();
+const live = await remoteRoster();
 check('the roster is either measured or says why not',
   live.measured === true || typeof live.reason === 'string',
   live.measured ? `${live.remotes} remote, seen ${new Date(live.seenAt).toISOString()}` : live.reason);

--- a/plugin/studio/server/index.js
+++ b/plugin/studio/server/index.js
@@ -202,7 +202,7 @@ async function handle(req, res) {
     const self = { name: SELF_NAME, local: true, ok: true, sessions: mine.length };
     // Sessions reachable on other machines. Not live and not this machine's —
     // a snapshot of what a Remote-Control-connected session last recorded.
-    const roster = remoteRoster();
+    const roster = await remoteRoster();
     if (!PEERS.length) return sendJson(res, 200, { ...local, sessions: mine, origins: [self], roster });
 
     const answers = await askAll(PEERS, '/api/fleet');
@@ -231,7 +231,7 @@ async function handle(req, res) {
     // Cached, not awaited. The list is local data; making it wait on a registry cost 8.37 s of
     // dead time whenever the feed hung, measured. The refresh runs behind this response.
     const latest = latestVersionCached();
-    const projects = listProjects({ currentCwd: cwd, kitOf: (c) => kitStatus(c, latest) });
+    const projects = await listProjects({ currentCwd: cwd, kitOf: (c) => kitStatus(c, latest) });
     for (const p of projects) { p.origin = SELF_NAME; p.local = true; }
 
     const origins = [{ name: SELF_NAME, local: true, ok: true, projects: projects.length }];
@@ -280,7 +280,7 @@ async function handle(req, res) {
   if (url.pathname === '/api/kit') {
     const cwd = url.searchParams.get('cwd') || process.cwd();
     const sid = url.searchParams.get('session');
-    const session = sid ? findSession(sid) : null;
+    const session = sid ? await findSession(sid) : null;
     const [report, stats, brd] = await Promise.all([
       gateReport(cwd),
       session ? sessionStats(cwd, session.file) : Promise.resolve({ measured: false, reason: 'no session named' }),
@@ -295,7 +295,7 @@ async function handle(req, res) {
 
   if (url.pathname === '/api/sessions') {
     const cwd = url.searchParams.get('cwd') || process.cwd();
-    const dir = projectDir(cwd);
+    const dir = await projectDir(cwd);
     if (!dir) {
       // Nothing was read. That is not the same as "this project never ran".
       return sendJson(res, 200, {
@@ -305,7 +305,7 @@ async function handle(req, res) {
         sessions: [],
       });
     }
-    const sessions = listSessions(dir).map((s) => ({
+    const sessions = (await listSessions(dir)).map((s) => ({
       sessionId: s.sessionId,
       bytes: s.bytes,
       modifiedAt: s.modifiedAt,
@@ -316,37 +316,37 @@ async function handle(req, res) {
 
   const graphMatch = url.pathname.match(/^\/api\/session\/([^/]+)\/graph$/);
   if (graphMatch) {
-    const session = findSession(decodeURIComponent(graphMatch[1]));
+    const session = await findSession(decodeURIComponent(graphMatch[1]));
     if (!session) {
       const relayed = await relay(url.pathname);
       if (relayed) return sendJson(res, 200, relayed);
       return sendJson(res, 404, { measured: false, reason: 'no such session on this machine or any peer' });
     }
     const started = Date.now();
-    const graph = buildGraph(session);
+    const graph = await buildGraph(session);
     return sendJson(res, 200, { ...graph, measured: true, buildMs: Date.now() - started });
   }
 
   const convMatch = url.pathname.match(/^\/api\/session\/([^/]+)\/conversation$/);
   if (convMatch) {
-    const session = findSession(decodeURIComponent(convMatch[1]));
+    const session = await findSession(decodeURIComponent(convMatch[1]));
     if (!session) {
       const relayed = await relay(url.pathname);
       if (relayed) return sendJson(res, 200, relayed);
       return sendJson(res, 404, { measured: false, reason: 'no such session on this machine or any peer' });
     }
-    return sendJson(res, 200, conversation(session));
+    return sendJson(res, 200, await conversation(session));
   }
 
   const agentMatch = url.pathname.match(/^\/api\/session\/([^/]+)\/agent\/([^/]+)$/);
   if (agentMatch) {
-    const session = findSession(decodeURIComponent(agentMatch[1]));
+    const session = await findSession(decodeURIComponent(agentMatch[1]));
     if (!session) {
       const relayed = await relay(url.pathname);
       if (relayed) return sendJson(res, 200, relayed);
       return sendJson(res, 404, { measured: false, reason: 'no such session' });
     }
-    const detail = agentDetail(session, decodeURIComponent(agentMatch[2]));
+    const detail = await agentDetail(session, decodeURIComponent(agentMatch[2]));
     if (!detail) return sendJson(res, 404, { measured: false, reason: 'no transcript for that agent' });
     return sendJson(res, 200, { ...detail, measured: true });
   }
@@ -355,8 +355,8 @@ async function handle(req, res) {
   const termMatch = url.pathname.match(/^\/api\/session\/([^/]+)\/terminal$/);
   if (termMatch) {
     const id = decodeURIComponent(termMatch[1]);
-    const session = findSession(id);
-    const cwd = url.searchParams.get('cwd') || (session ? sessionCwd(session.file, session.bytes) : null);
+    const session = await findSession(id);
+    const cwd = url.searchParams.get('cwd') || (session ? await sessionCwd(session.file, session.bytes) : null);
 
     if (req.method === 'GET') {
       // What WOULD run, so the panel can show it before anything is launched.
@@ -535,20 +535,27 @@ async function relay(pathname) {
   return null;
 }
 
-function signature(session) {
+// Async for the same reason projects.js is, and more urgently: this runs on every
+// stream tick — 700 ms, seven times more often than the project list is polled —
+// so a synchronous stat here is seven times more chances to stop the event loop on
+// a machine where one file open can take 31 s. The stall itself is not ours to fix;
+// keeping it inside the one tick that hit it is.
+async function signature(session) {
   const parts = [];
-  try { parts.push(String(fs.statSync(session.file).size)); } catch { parts.push('0'); }
+  try { parts.push(String((await fsp.stat(session.file)).size)); } catch { parts.push('0'); }
   try {
-    for (const n of fs.readdirSync(session.subagentsDir).sort()) {
-      try { parts.push(`${n}:${fs.statSync(path.join(session.subagentsDir, n)).size}`); } catch { /* raced */ }
-    }
+    const names = (await fsp.readdir(session.subagentsDir)).sort();
+    const sizes = await Promise.all(names.map(async (n) => {
+      try { return `${n}:${(await fsp.stat(path.join(session.subagentsDir, n))).size}`; } catch { return null; }
+    }));
+    for (const s of sizes) if (s !== null) parts.push(s);
   } catch { /* no subagents yet */ }
   return parts.join('|');
 }
 
-function stream(req, res, url) {
+async function stream(req, res, url) {
   const id = url.searchParams.get('session');
-  let session = id ? findSession(id) : null;
+  let session = id ? await findSession(id) : null;
 
   res.writeHead(200, {
     'content-type': 'text/event-stream; charset=utf-8',
@@ -577,18 +584,30 @@ function stream(req, res, url) {
     req.on('error', stopWait);
 
     let last = null;
-    const watch = (found) => {
+    // `setInterval` does not wait for an async callback, so a tick that outlasts the
+    // interval is joined by the next one rather than replacing it. Synchronous reads
+    // made that impossible — a blocked loop fires nothing — so this guard is repairing
+    // something the async conversion introduced, not a pre-existing bug. Measured with
+    // a 3 s read against a 700 ms tick: five callbacks in flight at once without it,
+    // one with it. A real 31 s read would stack about forty-four, each of them racing
+    // the same `last` and queueing another `1 + 1 + N` reads behind the first.
+    let busy = false;
+    const watch = async (found) => {
+      if (busy) return;
+      busy = true;
       try {
-        const sig = signature(found);
-        if (sig !== last) { last = sig; send('graph', buildGraph(found)); }
+        const sig = await signature(found);
+        if (sig !== last) { last = sig; send('graph', await buildGraph(found)); }
         else send('idle', { at: Date.now() });
       } catch (e) {
         send('fault', { measured: false, reason: String(e?.message ?? e) });
+      } finally {
+        busy = false;
       }
     };
 
-    timer = setInterval(() => {
-      const found = findSession(id);
+    timer = setInterval(async () => {
+      const found = await findSession(id);
       if (!found) return;                       // still waiting for the first turn
       clearInterval(timer);
       watch(found);
@@ -618,17 +637,22 @@ function stream(req, res, url) {
   }
 
   let last = null;
-  const tick = () => {
+  let busy = false;                             // same re-entrancy guard as the watcher above
+  const tick = async () => {
+    if (busy) return;
+    busy = true;
     try {
-      const sig = signature(session);
+      const sig = await signature(session);
       if (sig !== last) {
         last = sig;
-        send('graph', buildGraph(session));
+        send('graph', await buildGraph(session));
       } else {
         send('idle', { at: Date.now() });
       }
     } catch (e) {
       send('fault', { measured: false, reason: String(e?.message ?? e) });
+    } finally {
+      busy = false;
     }
   };
 

--- a/plugin/studio/server/lib/graph.js
+++ b/plugin/studio/server/lib/graph.js
@@ -14,7 +14,7 @@
 // `toolUseId` is the join. Whoever emitted that tool_use is the parent: the
 // session itself for depth 1, another agent for anything deeper.
 
-import fs from 'node:fs';
+import fsp from 'node:fs/promises';
 import path from 'node:path';
 
 import { readAll, contextFill } from './transcript.js';
@@ -119,8 +119,8 @@ function scanMain(records) {
 }
 
 /** Roll one agent's own transcript into the numbers its node shows. */
-function scanAgent(file) {
-  const { records } = readAll(file);
+async function scanAgent(file) {
+  const { records } = await readAll(file);
   const stats = {
     tools: {}, toolCount: 0, lastTool: null, errors: 0,
     tokens: null, startedAt: null, endedAt: null, turns: 0,
@@ -167,20 +167,25 @@ function scanAgent(file) {
   return stats;
 }
 
-function readAgentDir(subagentsDir) {
+async function readAgentDir(subagentsDir) {
   const out = [];
   // Nested too: a workflow puts its agents under subagents/workflows/<id>/.
-  for (const metaPath of agentMetaFiles(subagentsDir)) {
+  for (const metaPath of await agentMetaFiles(subagentsDir)) {
     const name = path.basename(metaPath);
     const dir = path.dirname(metaPath);
     if (!name.startsWith('agent-')) continue;
     const agentId = name.slice('agent-'.length, -'.meta.json'.length);
     let meta = {};
-    try { meta = JSON.parse(fs.readFileSync(metaPath, 'utf8')); } catch { /* keep going */ }
+    try { meta = JSON.parse(await fsp.readFile(metaPath, 'utf8')); } catch { /* keep going */ }
 
     const jsonl = path.join(dir, `agent-${agentId}.jsonl`);
     let mtime = null;
-    try { mtime = fs.statSync(jsonl).mtimeMs; } catch { /* not written yet */ }
+    try { mtime = (await fsp.stat(jsonl)).mtimeMs; } catch { /* not written yet */ }
+
+    // `stats` needs the transcript read; a missing file is a normal state (the
+    // agent has not written yet), so absence is a null rather than a throw.
+    let stats = null;
+    if (mtime !== null) stats = await scanAgent(jsonl);
 
     out.push({
       agentId,
@@ -193,7 +198,7 @@ function readAgentDir(subagentsDir) {
       // A workflow agent belongs to the run that spawned it, not the session
       // root; without this they all hang off the root as one flat fan.
       workflow: dir === subagentsDir ? null : path.basename(dir),
-      stats: fs.existsSync(jsonl) ? scanAgent(jsonl) : null,
+      stats,
     });
   }
   return out;
@@ -205,10 +210,10 @@ function readAgentDir(subagentsDir) {
  * rather than running — an unfinished agent whose file stopped growing is a
  * different fact from one that is working.
  */
-export function buildGraph(session, { staleMs = 120000 } = {}) {
-  const { records, malformed } = readAll(session.file);
+export async function buildGraph(session, { staleMs = 120000 } = {}) {
+  const { records, malformed } = await readAll(session.file);
   const main = scanMain(records);
-  const agents = readAgentDir(session.subagentsDir);
+  const agents = await readAgentDir(session.subagentsDir);
   const now = Date.now();
 
   // Ownership: session first, then every agent's own tool_use ids, so a nested
@@ -390,17 +395,17 @@ export const _internals = { scanMain, harvestCompletions, SESSION_NODE };
  * thousands of characters and the graph is pushed down an SSE stream every
  * time a file changes. This is fetched when someone opens a node.
  */
-export function agentDetail(session, agentId) {
+export async function agentDetail(session, agentId) {
   if (!/^[A-Za-z0-9_-]+$/.test(agentId)) return null;
 
   const file = path.join(session.subagentsDir, `agent-${agentId}.jsonl`);
-  if (!fs.existsSync(file)) return null;
+  try { await fsp.stat(file); } catch { return null; }
 
-  const { records, malformed } = readAll(file);
+  const { records, malformed } = await readAll(file);
 
   let meta = {};
   try {
-    meta = JSON.parse(fs.readFileSync(path.join(session.subagentsDir, `agent-${agentId}.meta.json`), 'utf8'));
+    meta = JSON.parse(await fsp.readFile(path.join(session.subagentsDir, `agent-${agentId}.meta.json`), 'utf8'));
   } catch { /* the transcript is still the source of truth */ }
 
   const timeline = [];
@@ -472,8 +477,8 @@ export function agentDetail(session, agentId) {
  * Sidechains are skipped: a subagent's exchange belongs to the graph, not to
  * the conversation the person had.
  */
-export function conversation(session, { limit = 400 } = {}) {
-  const { records } = readAll(session.file);
+export async function conversation(session, { limit = 400 } = {}) {
+  const { records } = await readAll(session.file);
   const out = [];
 
   for (const r of records) {

--- a/plugin/studio/server/lib/kit.js
+++ b/plugin/studio/server/lib/kit.js
@@ -8,7 +8,7 @@
 // Read-only. Detecting that a project is behind and updating it are different
 // acts, and only the first one happens here.
 
-import fs from 'node:fs';
+import fsp from 'node:fs/promises';
 import path from 'node:path';
 
 const FEED = process.env.CSK_UPDATE_URL
@@ -107,24 +107,30 @@ export function compareVersions(a, b) {
   return 0;
 }
 
-/** What the kit looks like inside one working directory. */
-export function kitStatus(cwd, latest) {
+/** What the kit looks like inside one working directory.
+ *
+ * Async because it runs once per project on the `/api/projects` path, and a
+ * synchronous read there blocks the whole panel when one file open stalls —
+ * see the note at the top of projects.js for the measurement.
+ */
+export async function kitStatus(cwd, latest) {
   if (!cwd) return { installed: false, reason: 'no working directory recorded' };
 
   const claude = path.join(cwd, '.claude');
   let version = null;
-  try { version = sane(fs.readFileSync(path.join(claude, 'VERSION'), 'utf8')); } catch { /* not installed */ }
+  try { version = sane(await fsp.readFile(path.join(claude, 'VERSION'), 'utf8')); } catch { /* not installed */ }
 
   if (!version) {
     // Distinguish "no kit here" from "the directory is gone" — one is a choice,
     // the other is a dead path.
-    const present = fs.existsSync(cwd);
+    let present = false;
+    try { await fsp.stat(cwd); present = true; } catch { present = false; }
     return { installed: false, dirExists: present, reason: present ? 'kit not installed' : 'directory no longer exists' };
   }
 
   const conf = {};
   try {
-    for (const line of fs.readFileSync(path.join(claude, 'kit.conf'), 'utf8').split('\n')) {
+    for (const line of (await fsp.readFile(path.join(claude, 'kit.conf'), 'utf8')).split('\n')) {
       const m = line.match(/^\s*([A-Za-z_]+)\s*=\s*(.*)$/);
       if (m) conf[m[1]] = m[2].trim();
     }

--- a/plugin/studio/server/lib/projects.js
+++ b/plugin/studio/server/lib/projects.js
@@ -10,7 +10,15 @@
 // This is a re-implementation in another language on purpose — a fourth bash
 // copy would break that pin.
 
-import fs from 'node:fs';
+// EVERY filesystem call here is async, and that is the point rather than a style
+// choice. Measured on a Windows 11 machine whose EDR inspects file opens: reading
+// the 128 KiB tail of one transcript took 0-1 ms on fourteen runs out of fifteen
+// and 31,209 ms on the fifteenth. With `readSync` that stalled the event loop, so
+// the panel answered NOTHING for half a minute — `/api/projects` took 33,391 ms and
+// a separate `/api/health` on its own connection went unanswered for 312 of 324
+// pings. Async does not make the read faster; the same 30 s still passes. It keeps
+// the stall inside the one request that hit it while the rest of the panel stays up.
+import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -35,20 +43,19 @@ export function candidateDirs(cwd) {
 }
 
 /** The project directory for a cwd, or null when nothing was recorded yet. */
-export function projectDir(cwd) {
+export async function projectDir(cwd) {
   for (const name of candidateDirs(cwd)) {
     const p = path.join(PROJECTS_ROOT, name);
-    try { if (fs.statSync(p).isDirectory()) return p; } catch { /* next */ }
+    try { if ((await fsp.stat(p)).isDirectory()) return p; } catch { /* next */ }
   }
   return null;
 }
 
 /** Every project directory on this machine. */
-export function allProjectDirs() {
+export async function allProjectDirs() {
   try {
-    return fs.readdirSync(PROJECTS_ROOT, { withFileTypes: true })
-      .filter((e) => e.isDirectory())
-      .map((e) => path.join(PROJECTS_ROOT, e.name));
+    const entries = await fsp.readdir(PROJECTS_ROOT, { withFileTypes: true });
+    return entries.filter((e) => e.isDirectory()).map((e) => path.join(PROJECTS_ROOT, e.name));
   } catch {
     return [];
   }
@@ -62,18 +69,18 @@ export function allProjectDirs() {
 const TITLE_TAIL_BYTES = 131072;
 const titleCache = new Map(); // file -> { sig, title }
 
-export function sessionTitle(file, size, mtimeMs) {
+export async function sessionTitle(file, size, mtimeMs) {
   const sig = `${size}:${mtimeMs}`;
   const hit = titleCache.get(file);
   if (hit && hit.sig === sig) return hit.title;
 
   let title = null;
-  let fd;
+  let fh;
   try {
-    fd = fs.openSync(file, 'r');
+    fh = await fsp.open(file, 'r');
     const len = Math.min(size, TITLE_TAIL_BYTES);
     const buf = Buffer.allocUnsafe(len);
-    fs.readSync(fd, buf, 0, len, Math.max(0, size - len));
+    await fh.read(buf, 0, len, Math.max(0, size - len));
     const text = buf.toString('utf8');
 
     // Cheap prefilter: most sessions carry none of these, and parsing every
@@ -94,7 +101,7 @@ export function sessionTitle(file, size, mtimeMs) {
   } catch {
     title = null;
   } finally {
-    if (fd !== undefined) try { fs.closeSync(fd); } catch { /* already gone */ }
+    if (fh !== undefined) try { await fh.close(); } catch { /* already gone */ }
   }
 
   if (titleCache.size > 500) titleCache.clear();
@@ -107,23 +114,23 @@ export function sessionTitle(file, size, mtimeMs) {
 // which carries `cwd`. Head, not tail: the value never changes mid-session.
 const cwdCache = new Map();
 
-export function sessionCwd(file, size) {
+export async function sessionCwd(file, size) {
   const hit = cwdCache.get(file);
   if (hit && hit.size === size) return hit.cwd;
 
   let cwd = null;
-  let fd;
+  let fh;
   try {
-    fd = fs.openSync(file, 'r');
+    fh = await fsp.open(file, 'r');
     const len = Math.min(size, 8192);
     const buf = Buffer.allocUnsafe(len);
-    fs.readSync(fd, buf, 0, len, 0);
+    await fh.read(buf, 0, len, 0);
     cwd = buf.toString('utf8').match(/"cwd"\s*:\s*"((?:[^"\\]|\\.)*)"/)?.[1] ?? null;
     if (cwd) cwd = cwd.replace(/\\\\/g, '\\').replace(/\\"/g, '"');
   } catch {
     cwd = null;
   } finally {
-    if (fd !== undefined) try { fs.closeSync(fd); } catch { /* already gone */ }
+    if (fh !== undefined) try { await fh.close(); } catch { /* already gone */ }
   }
 
   if (cwdCache.size > 500) cwdCache.clear();
@@ -137,42 +144,43 @@ export function sessionCwd(file, size) {
  * beside it — counting only the top level is how you end up reporting that
  * nothing ever delegated.
  */
-export function listSessions(dir) {
+export async function listSessions(dir) {
   let entries;
-  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return []; }
+  try { entries = await fsp.readdir(dir, { withFileTypes: true }); } catch { return []; }
 
-  const out = [];
-  for (const e of entries) {
-    if (!e.isFile() || !e.name.endsWith('.jsonl')) continue;
+  // One transcript's reads do not depend on another's, so they run together.
+  // Sequential awaits cost 12 ms here where the synchronous version cost 7 —
+  // measured, 10 runs each — and that gap grows with the number of sessions.
+  // The order is irrelevant: the list is sorted by mtime below.
+  const settled = await Promise.all(entries.map(async (e) => {
+    if (!e.isFile() || !e.name.endsWith('.jsonl')) return null;
     const sessionId = e.name.slice(0, -'.jsonl'.length);
     const file = path.join(dir, e.name);
     let st;
-    try { st = fs.statSync(file); } catch { continue; }
+    try { st = await fsp.stat(file); } catch { return null; }
 
     const subagentsDir = path.join(dir, sessionId, 'subagents');
+    const [agentCount, title, cwd] = await Promise.all([
+      countAgentMetas(subagentsDir),
+      sessionTitle(file, st.size, st.mtimeMs),
+      sessionCwd(file, st.size),
+    ]);
 
-    out.push({
-      sessionId,
-      file,
-      subagentsDir,
-      bytes: st.size,
-      modifiedAt: st.mtimeMs,
-      agentCount: countAgentMetas(subagentsDir),
-      title: sessionTitle(file, st.size, st.mtimeMs),
-      cwd: sessionCwd(file, st.size),
-    });
-  }
+    return { sessionId, file, subagentsDir, bytes: st.size, modifiedAt: st.mtimeMs, agentCount, title, cwd };
+  }));
+
+  const out = settled.filter(Boolean);
   out.sort((a, b) => b.modifiedAt - a.modifiedAt);
   return out;
 }
 
 /** Find one session anywhere on this machine, by id. */
-export function findSession(sessionId) {
+export async function findSession(sessionId) {
   if (!/^[A-Za-z0-9._-]+$/.test(sessionId)) return null; // it becomes a path
-  for (const dir of allProjectDirs()) {
+  for (const dir of await allProjectDirs()) {
     const file = path.join(dir, `${sessionId}.jsonl`);
     try {
-      const st = fs.statSync(file);
+      const st = await fsp.stat(file);
       return {
         sessionId,
         file,
@@ -194,21 +202,19 @@ export function findSession(sessionId) {
  * machine, 324 of 596 metas — 54% — were in the nested form, so a flat read
  * silently reported a busy session as having delegated nothing.
  */
-export function countAgentMetas(subagentsDir) {
-  let n = 0;
-  for (const f of agentMetaFiles(subagentsDir)) { void f; n += 1; }
-  return n;
+export async function countAgentMetas(subagentsDir) {
+  return (await agentMetaFiles(subagentsDir)).length;
 }
 
 /** Every agent meta file under a subagents directory, nesting included. */
-export function agentMetaFiles(subagentsDir, depth = 0) {
+export async function agentMetaFiles(subagentsDir, depth = 0) {
   const out = [];
   if (depth > 3) return out;                    // workflows nest one level; this is slack
   let entries;
-  try { entries = fs.readdirSync(subagentsDir, { withFileTypes: true }); } catch { return out; }
+  try { entries = await fsp.readdir(subagentsDir, { withFileTypes: true }); } catch { return out; }
   for (const e of entries) {
     const p = path.join(subagentsDir, e.name);
-    if (e.isDirectory()) out.push(...agentMetaFiles(p, depth + 1));
+    if (e.isDirectory()) out.push(...await agentMetaFiles(p, depth + 1));
     else if (e.name.endsWith('.meta.json')) out.push(p);
   }
   return out;
@@ -221,11 +227,14 @@ export function agentMetaFiles(subagentsDir, depth = 0) {
  * name is a lossy fold of the path, so two different projects can share one.
  * The folder is only the fallback when no record carried a cwd.
  */
-export function listProjects({ currentCwd = null, limitPerProject = 60, kitOf = null } = {}) {
+export async function listProjects({ currentCwd = null, limitPerProject = 60, kitOf = null } = {}) {
   const groups = new Map();
 
-  for (const dir of allProjectDirs()) {
-    for (const s of listSessions(dir)) {
+  const dirs = await allProjectDirs();
+  const perDir = await Promise.all(dirs.map(async (dir) => [dir, await listSessions(dir)]));
+
+  for (const [dir, sessions] of perDir) {
+    for (const s of sessions) {
       const key = s.cwd ?? `dir:${path.basename(dir)}`;
       if (!groups.has(key)) {
         groups.set(key, { key, cwd: s.cwd, dir, label: labelFor(s.cwd, dir), sessions: [] });
@@ -234,17 +243,18 @@ export function listProjects({ currentCwd = null, limitPerProject = 60, kitOf = 
     }
   }
 
-  const out = [...groups.values()].map((g) => {
+  const out = [];
+  for (const g of groups.values()) {
     g.sessions.sort((a, b) => b.modifiedAt - a.modifiedAt);
-    const kit = kitOf ? kitOf(g.cwd) : null;
-    return {
+    const kit = kitOf ? await kitOf(g.cwd) : null;
+    out.push({
       ...g,
       kit,
       // Most transcript folders on a busy machine point at directories that no
       // longer exist — test scratch dirs, moved checkouts. They are counted,
       // not deleted: the panel says how many it is holding back rather than
       // quietly shortening the list.
-      exists: kit?.dirExists ?? (g.cwd ? existsCached(g.cwd) : false),
+      exists: kit?.dirExists ?? (g.cwd ? await existsCached(g.cwd) : false),
       total: g.sessions.length,
       agentTotal: g.sessions.reduce((n, s) => n + s.agentCount, 0),
       modifiedAt: g.sessions[0]?.modifiedAt ?? 0,
@@ -252,8 +262,8 @@ export function listProjects({ currentCwd = null, limitPerProject = 60, kitOf = 
       // Long histories are truncated rather than silently dropped, and the
       // count above still reports the whole.
       sessions: g.sessions.slice(0, limitPerProject),
-    };
-  });
+    });
+  }
 
   // Standing-in first, then live directories, then an outdated kit ahead of a
   // current one — the rows that need a decision float up.
@@ -272,10 +282,10 @@ function labelFor(cwd, dir) {
 }
 
 const existsMemo = new Map();
-function existsCached(p) {
+async function existsCached(p) {
   if (existsMemo.has(p)) return existsMemo.get(p);
   let v = false;
-  try { v = fs.existsSync(p); } catch { v = false; }
+  try { await fsp.stat(p); v = true; } catch { v = false; }
   if (existsMemo.size > 2000) existsMemo.clear();
   existsMemo.set(p, v);
   return v;

--- a/plugin/studio/server/lib/roster.js
+++ b/plugin/studio/server/lib/roster.js
@@ -14,7 +14,7 @@
 // because a stale list drawn as a live one is the kind of lie this panel is
 // built to avoid.
 
-import fs from 'node:fs';
+import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -61,18 +61,21 @@ export function parseRoster(text) {
   return { self: self ? { name: self[1], ref: self[2] } : null, peers };
 }
 
-function readTail(file, size, limit = TAIL_BYTES) {
-  let fd;
+// Async for the reason projects.js gives: this reads the tail of a transcript, which
+// is the exact operation measured at 31.2 s on one run in fifteen, and it runs on the
+// `/api/fleet` path the panel polls every 2 s — the shortest cycle in the app.
+async function readTail(file, size, limit = TAIL_BYTES) {
+  let fh;
   try {
-    fd = fs.openSync(file, 'r');
+    fh = await fsp.open(file, 'r');
     const len = Math.min(size, limit);
     const buf = Buffer.allocUnsafe(len);
-    fs.readSync(fd, buf, 0, len, Math.max(0, size - len));
+    await fh.read(buf, 0, len, Math.max(0, size - len));
     return buf.toString('utf8');
   } catch {
     return '';
   } finally {
-    if (fd !== undefined) try { fs.closeSync(fd); } catch { /* gone */ }
+    if (fh !== undefined) try { await fh.close(); } catch { /* gone */ }
   }
 }
 
@@ -82,25 +85,26 @@ function readTail(file, size, limit = TAIL_BYTES) {
  * Returns not-measured rather than an empty list when nothing has asked yet:
  * "no session has run ListAgents" and "you have no peers" are different facts.
  */
-export function remoteRoster() {
+export async function remoteRoster() {
   const files = [];
-  for (const dir of allProjectDirs()) {
+  for (const dir of await allProjectDirs()) {
     let entries;
-    try { entries = fs.readdirSync(dir); } catch { continue; }
-    for (const e of entries) {
-      if (!e.endsWith('.jsonl')) continue;
+    try { entries = await fsp.readdir(dir); } catch { continue; }
+    const stats = await Promise.all(entries.map(async (e) => {
+      if (!e.endsWith('.jsonl')) return null;
       const p = path.join(dir, e);
       try {
-        const st = fs.statSync(p);
-        files.push({ path: p, mtime: st.mtimeMs, size: st.size, sessionId: e.slice(0, -6) });
-      } catch { /* raced */ }
-    }
+        const st = await fsp.stat(p);
+        return { path: p, mtime: st.mtimeMs, size: st.size, sessionId: e.slice(0, -6) };
+      } catch { return null; }        // raced
+    }));
+    for (const s of stats) if (s) files.push(s);
   }
   files.sort((a, b) => b.mtime - a.mtime);
 
   let best = null;
   for (const [i, f] of files.slice(0, SCAN_FILES).entries()) {
-    const text = readTail(f.path, f.size, i < DEEP_FILES ? DEEP_BYTES : TAIL_BYTES);
+    const text = await readTail(f.path, f.size, i < DEEP_FILES ? DEEP_BYTES : TAIL_BYTES);
     if (!text.includes('Peer sessions')) continue;
 
     // The block lives INSIDE a JSON string, so its line breaks are the two
@@ -137,7 +141,7 @@ export function remoteRoster() {
     }
   }
 
-  const cached = readCache();
+  const cached = await readCache();
 
   if (!best) {
     if (cached) return { ...cached, fromCache: true };
@@ -166,15 +170,15 @@ export function remoteRoster() {
     return { ...cached, fromCache: true };
   }
 
-  writeCache(found);
+  await writeCache(found);
   return found;
 }
 
 const CACHE_MAX_AGE_MS = 12 * 60 * 60 * 1000;
 
-function readCache() {
+async function readCache() {
   try {
-    const c = JSON.parse(fs.readFileSync(CACHE_FILE, 'utf8'));
+    const c = JSON.parse(await fsp.readFile(CACHE_FILE, 'utf8'));
     if (!c?.measured || !Array.isArray(c.peers)) return null;
     if (typeof c.seenAt !== 'number' || c.seenAt < Date.now() - CACHE_MAX_AGE_MS) return null;
     return c;
@@ -183,6 +187,6 @@ function readCache() {
   }
 }
 
-function writeCache(roster) {
-  try { fs.writeFileSync(CACHE_FILE, JSON.stringify(roster)); } catch { /* best effort */ }
+async function writeCache(roster) {
+  try { await fsp.writeFile(CACHE_FILE, JSON.stringify(roster)); } catch { /* best effort */ }
 }

--- a/plugin/studio/server/lib/transcript.js
+++ b/plugin/studio/server/lib/transcript.js
@@ -7,7 +7,7 @@
 // A single record can itself be enormous (a pasted payload), so lines are
 // assembled from a carry buffer rather than assumed to fit in one read.
 
-import fs from 'node:fs';
+import fsp from 'node:fs/promises';
 
 export class JsonlReader {
   constructor(file) {
@@ -17,10 +17,15 @@ export class JsonlReader {
     this.malformed = 0; // counted, never silently swallowed
   }
 
-  /** Read everything appended since the last call. Returns parsed records. */
-  read() {
+  /** Read everything appended since the last call. Returns parsed records.
+   *
+   * Async because a transcript open can take 31 s on a machine whose security
+   * layer inspects it, and this sits under the stream tick — see the note at the
+   * top of projects.js. The read is no faster; it just no longer stops the loop.
+   */
+  async read() {
     let st;
-    try { st = fs.statSync(this.file); } catch { return []; }
+    try { st = await fsp.stat(this.file); } catch { return []; }
 
     // A shrunk file means it was replaced, not appended to. Start over rather
     // than reading from a stale offset into the middle of a record.
@@ -31,18 +36,18 @@ export class JsonlReader {
     if (st.size === this.offset) return [];
 
     let chunk;
-    let fd;
+    let fh;
     try {
-      fd = fs.openSync(this.file, 'r');
+      fh = await fsp.open(this.file, 'r');
       const len = st.size - this.offset;
       const buf = Buffer.allocUnsafe(len);
-      const got = fs.readSync(fd, buf, 0, len, this.offset);
-      chunk = buf.subarray(0, got).toString('utf8');
-      this.offset += got;
+      const { bytesRead } = await fh.read(buf, 0, len, this.offset);
+      chunk = buf.subarray(0, bytesRead).toString('utf8');
+      this.offset += bytesRead;
     } catch {
       return [];
     } finally {
-      if (fd !== undefined) try { fs.closeSync(fd); } catch { /* already gone */ }
+      if (fh !== undefined) try { await fh.close(); } catch { /* already gone */ }
     }
 
     const text = this.carry + chunk;
@@ -64,9 +69,9 @@ export class JsonlReader {
 }
 
 /** One-shot full read. Used for files we do not intend to follow. */
-export function readAll(file) {
+export async function readAll(file) {
   const r = new JsonlReader(file);
-  const records = r.read();
+  const records = await r.read();
   return { records, malformed: r.malformed };
 }
 


### PR DESCRIPTION
`/api/projects` froze the panel for half a minute at a time. The read was slow for a reason outside
this repo; the freeze was ours, and this removes it. **No version carrier is touched** — `VERSION`,
`package.json`, the badges, `CHANGELOG.md` and `plugin.json` are all untouched, so merging this
publishes nothing.

## What was happening

The panel reads transcript tails to title sessions and find their working directory. Those reads were
synchronous. On a Windows machine whose security layer inspects file opens, one open occasionally does
not return for half a minute — measured directly, outside the panel, with no product code involved:

```
reading the 128 KiB tail of one transcript, 15 runs
  14 runs   0-1 ms
   1 run    31,209 ms
```

Because the read was synchronous, that stall belonged to the event loop rather than to the request.
The panel stopped serving anything:

| | `/api/projects` | a separate `/api/health` on its own connection |
|:--|--:|--:|
| before | 33,391 ms | **unanswered for 312 of 324 pings** |
| after | 38,918 ms | **answered 195 of 195** |

The read did not get faster, and this PR does not claim it would. A scanned disk is not the kit's to
fix. Keeping the stall inside the one request that hit it is.

## Every polled path, in order of how often it runs

The project list is where this was found, and it turned out to be the *least* exposed of the four:

| interval | path | what was synchronous |
|:--|:--|:--|
| **700 ms** | stream tick → `signature()` | `1 + 1 + N` stats per tick, `N` = the session's subagent count — seventeen on a busy session, which is the session the panel exists for |
| **700 ms** | stream tick → `buildGraph` | `graph.js` and the transcript reader under it |
| **2 s** | `/api/fleet` → `roster.js` | transcript tail reads, the same operation as above |
| **5 s** | `/api/projects` | where the freeze was first measured |

After this, no path the panel polls performs a synchronous filesystem call.

## Cost, and what it is a fraction of

```
main (synchronous)            7 ms
async, sequential awaits     19-22 ms
async, independent reads together    15-16 ms
```

Converting to async does not by itself make anything concurrent — it only stops the blocking. Reads
that do not depend on each other now run together, which recovers most of the difference. The
remaining **+8 ms is 0.16% of the 5 s poll interval** (`app.js: SESSION_POLL_MS = 5000`). A bare
"8 ms" tells a reader nothing; the fraction does.

## A hazard the conversion itself introduced

`setInterval` does not wait for an async callback. A tick that outlasts its interval is *joined* by
the next one rather than replacing it — impossible while the loop blocked, possible now. Measured
with a 3 s read against a 700 ms tick:

```
without a guard   11 ticks started in 8 s · 5 callbacks in flight at once
with a guard       3 ticks started in 8 s · 1
```

A real 31 s read would stack about forty-four, each racing the same `last` and queueing another
`1 + 1 + N` reads behind the first. Both stream callbacks now carry a re-entrancy guard.

## The gate moved with the fix

`studio-serve-probe.mjs` graded *timing*, and timing says nothing about this code: the same stall
appears with the update feed disabled entirely, which is what disproved the earlier reading. What the
panel owes its user is that a slow read stays inside the request that hit it, and that is gradeable:

```
ok     the panel answers other requests while a read stalls     ← graded
KNOWN  one transcript read took the stall shape                 ← observed, not graded
N/A    the project list is served from local data…              ← that run cannot speak to it
```

Mutation, both directions:

```
new gate + old (synchronous) product   FAIL "the panel answers other requests while a read stalls" · rc=1
new gate + new (async) product         same check passes · rc=0
```

14 consecutive runs on Windows: `rc=0` every time, `KNOWN` printed once — this machine's stall rate.

## Verification

```
studio     237/237 assertions passed
e2e        10/10 served checks, installed layout · 10/10, plugin layout · VERIFY: 1 passed
selftest   4/4
```

`selfcheck.mjs:709` called `remoteRoster()` synchronously and caught the conversion — the suite was
pinning the calling contract, and the `await` there is part of this change.

## Not converted, and suspect for the same reason

These carry the same synchronous pattern and could stall the same way. None of them sit on a polled
path, and **none of them were measured** — they are listed so the next reader knows where to look, not
as a claim that they are safe:

```
kit-telemetry.js  11    permissions.js  10    palette.js  3
pty.js             2    session.js       1    terminal.js 1
index.js           3    (selftest ×2 and one realpathSync at startup — not on a request path)
```
