### PR TITLE
fix(hooks): the JSON parser was quadratic, and the timeout turned that into a fail-open

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,9 +16,19 @@ plugin/hooks/commit-msg text eol=lf
 claude-starter/profiles.conf text eol=lf
 *.conf text eol=lf
 # Blocklists/allowlists and other data files the hooks read line-by-line as patterns: a CRLF checkout leaves a '\r'
-# on every pattern, which then never matches the LF diff — silently blinding the trace/secret gate on Windows. The
-# pre-commit also strips a trailing '\r' defensively, but keeping these LF means it never sees one.
+# on every pattern, which then never matches the LF diff — silently blinding the trace/secret gate on Windows.
+# pre-commit AND commit-msg both strip a trailing '\r' defensively — but only since the commit that added it to
+# the second one, which had gone without it and was the single gate on the commit message. This pin covers the
+# kit's own checkout; it does NOT cover a user's project, where the same file is installed and nothing pins it.
+# That is what the strip is for, and why "defensively" is the wrong word for it: it is the real defence.
 *.txt text eol=lf
+# JSON is not parsed line-by-line by anything here, so this is not a correctness pin — it is a pin
+# against a permanent phantom diff. Measured on a Windows clone: plugin/.claude-plugin/plugin.json and
+# plugin/hooks/hooks.json show as modified forever while `git hash-object` matches the index blob
+# exactly, because core.autocrlf rewrites them on checkout and nothing here pinned them back. A commit
+# to "fix" it is empty, and the plugin sync gate reads a diff that is not one. settings.json is in the
+# same set and is the file that wires every hook.
+*.json text eol=lf
 # VERSION is read by the shell — `head -1` in start.sh:345, adopt.sh:203 and adopt.sh:633, and `read -r`
 # in session-update-check.sh. Measured on a Windows checkout: the file comes out `2.9.0\r\n`, and both of
 # those forms keep the CR (doctor.sh strips it with `tr -cd`, the others do not). Today the only visible

--- a/claude-starter/hooks/commit-msg
+++ b/claude-starter/hooks/commit-msg
@@ -25,7 +25,16 @@ GITROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 
 HIT=0
 while IFS= read -r pat || [ -n "$pat" ]; do
-  case "$pat" in ''|\#*) continue;; esac
+  pat="${pat%$'\r'}"                        # tolerate a CRLF blocklist — pre-commit:176 has had this
+  case "$pat" in ''|\#*) continue;; esac    # since the gate was written; its twin here did not, and
+                                            # the message scan was the ONLY reader with no fallback:
+                                            # pre-commit never sees the message, so a co-author
+                                            # trailer had exactly one gate and it was blind. Verified
+                                            # on two machines: LF blocklist rejects (rc=1), the same
+                                            # blocklist saved CRLF accepts (rc=0). Reachable without
+                                            # trying: the kit writes no .gitattributes into a user's
+                                            # project, Git for Windows defaults core.autocrlf=true,
+                                            # and this file is meant to be edited by hand.
   if [ -n "$AL" ] && grep -qxF -- "$pat" "$AL"; then continue; fi
   if grep -iqE -- "$pat" "$MSG_FILE"; then
     echo "TRACE-SCANNER (message): forbidden expression -> '$pat' (§4.1)"

--- a/claude-starter/hooks/context-usage.sh
+++ b/claude-starter/hooks/context-usage.sh
@@ -130,14 +130,17 @@ fi
 # probe are the ones where a process is cheap. It runs once per turn, not once per record.
 HAVE_JQ=0
 if command -v jq >/dev/null 2>&1 && printf '{}' | jq -e . >/dev/null 2>&1; then HAVE_JQ=1; fi
-scan() {                                             # reads JSONL on stdin, prints the total (or nothing)
+# `scan` prints one number per matching record and the caller keeps the LAST — taken with `${x##*NL}`,
+# which is shell, where `| tail -1` was a process on a hook that runs before every prompt.
+last_line() { printf '%s' "${1##*$'\n'}"; }
+scan() {                                             # reads JSONL on stdin, prints one total per record
   if [ "$HAVE_JQ" = 1 ]; then
     jq -r 'select((.isSidechain // false) == false)
       | select(.type == "assistant")
       | select(.message.usage.cache_read_input_tokens != null)
       | (.message.usage.input_tokens
          + (.message.usage.cache_read_input_tokens // 0)
-         + (.message.usage.cache_creation_input_tokens // 0))' 2>/dev/null | tail -1
+         + (.message.usage.cache_creation_input_tokens // 0))' 2>/dev/null
   else
     # No jq: parse the JSONL line-by-line — same predicate, same number.
     awk '
@@ -162,9 +165,34 @@ scan() {                                             # reads JSONL on stdin, pri
 # work no matter how fat the lines are — the same 60MB case scans in ~12ms. A front-truncated partial first line
 # simply fails to match, and since we keep the LAST match that is harmless. Widen once (256 KiB covers even a
 # large subagent fan-out of small usage records), then a SIZE-GUARDED whole-file last resort.
+#
+# The partial first line has to go before the scan, and that is not a tidiness point — it is why the
+# window never worked. The comment above reasons that a front-truncated line "simply fails to match",
+# which is true of awk and FALSE of jq: measured, jq ABORTS the whole stream on a malformed first
+# record and prints nothing, while awk skips the line and carries on. So on every machine that has jq
+# — which is most of them, and every developer laptop — both windows returned empty and the hook fell
+# through to scanning the ENTIRE transcript, every single turn. On a 45 MB session that is 45 MB read
+# per prompt, and the byte bound that this block exists to enforce was never once in force.
+#
+# Dropped with `tail -n +2`, NOT with `${W#*$'\n'}`. The parameter expansion looks free and is a trap:
+# on a window with no newline in it — a malformed transcript that is one enormous line, which the
+# suite fixtures on purpose — bash walks every prefix looking for a match it will never find. Measured
+# on a 4 MiB single-line file: it had not finished after 20 seconds, and it hung the gate for 36
+# minutes before that was noticed. One streaming process is the cheap option here, not the expensive
+# one. Only correct to drop when the tail actually truncated, hence the size test.
+# The size is asked ONCE, up front, and it pays for itself: it is the only exact way to know whether
+# a tail truncated, and knowing that is what lets the window work at all. Comparing the captured
+# length against the window does NOT work — `$( )` strips the trailing newline, so the capture is
+# never quite the window size and the drop never fires.
+SZ="$(wc -c < "$TR" 2>/dev/null)"; SZ="${SZ//[!0-9]/}"; SZ="${SZ:-0}"
 TOTAL=""
 for B in 262144 4194304; do                         # 256 KiB, then 4 MiB
-  TOTAL="$(tail -c "$B" "$TR" | scan)"
+  if [ "$SZ" -gt "$B" ]; then
+    TOTAL="$(tail -c "$B" "$TR" | tail -n +2 | scan)"   # the tail cut a line in half; jq aborts on it
+  else
+    TOTAL="$(tail -c "$B" "$TR" | scan)"                # whole file: the first line is intact
+  fi
+  TOTAL="$(last_line "$TOTAL")"
   [ -n "$TOTAL" ] && break
 done
 if [ -z "$TOTAL" ]; then
@@ -174,9 +202,8 @@ if [ -z "$TOTAL" ]; then
   # it is small enough to finish well inside the timeout (180MB ~= 4.7s under awk, so 200MB is safe under 30s);
   # past the cap, fail OPEN. A missing 🔋 line is recoverable — the model answers "could not measure" — whereas a
   # timed-out hook is just discarded noise.
-  SZ="$(wc -c < "$TR" 2>/dev/null | tr -cd '0-9')"; SZ="${SZ:-0}"
   CAP="${CSK_CONTEXT_MAX_BYTES:-209715200}"         # 200 MiB; override per-repo
-  [ "${SZ:-0}" -le "$CAP" ] && TOTAL="$(scan < "$TR")"
+  [ "${SZ:-0}" -le "$CAP" ] && TOTAL="$(last_line "$(scan < "$TR")")"
 fi
 # Same split as the missing-transcript case above: a hook stays quiet and exits 0, a by-hand call explains
 # itself and exits non-zero. Exec-form hook commands carry no `|| true` to swallow a status, so anything that
@@ -189,12 +216,18 @@ fi
 
 # LC_ALL=C: force a '.' decimal separator regardless of locale (tr_TR etc. would emit '77,2' and could
 # mis-parse the percentage). Generation AND every comparison below run under C so they stay consistent.
-PCT="$(LC_ALL=C awk -v t="$TOTAL" -v w="$WINDOW" 'BEGIN{printf "%.1f", (t/w)*100}')"
-# The DISPLAYED percentage stays awk's — %.1f rounds, and shell arithmetic truncates, so replacing it would
-# quietly move the number a user reads. The COMPARISONS do not need it: the thresholds are whole numbers, so
-# the integer part decides them, exactly as session-guard.sh already argues for its own two. That removes two
-# awk spawns from a hook that runs on every single prompt, and awk is the most expensive process this kit
-# starts on Git Bash (measured: 57 ms idle, 404 ms under load, against 62 ms for a bare `true`).
+# Integer arithmetic, not awk, and it ROUNDS rather than truncates — which is the whole reason awk was
+# here. `(t*1000 + w/2) / w` is round-half-up on tenths; verified against awk's %.1f across the range
+# before the swap, not after. That removes the single most expensive process this hook starts on Git
+# Bash (measured there: 57 ms idle, 404 ms under load, against 62 ms for a bare `true`).
+PCT_T=$(( (TOTAL * 1000 + WINDOW / 2) / WINDOW ))
+PCT="$((PCT_T / 10)).$((PCT_T % 10))"
+# The COMPARISONS take the integer part: the thresholds are whole numbers, so nothing below needs the tenth,
+# exactly as session-guard.sh already argues for its own two. This paragraph used to end "the DISPLAYED
+# percentage stays awk's, because %.1f rounds and shell arithmetic truncates" — a true statement about the
+# obvious integer division, and the reason awk survived here for so long. It stopped being true one commit
+# ago: the expression above rounds. A comment that describes a tool the code no longer calls is worse than
+# no comment, because the next reader trusts it instead of the line.
 PCTI="${PCT%%.*}"; case "$PCTI" in ''|*[!0-9]*) PCTI=0 ;; esac
 if   [ "$PCTI" -lt 50 ]; then LEVEL="continue"
 elif [ "$PCTI" -lt 75 ]; then LEVEL="medium"

--- a/claude-starter/hooks/guard-bash.sh
+++ b/claude-starter/hooks/guard-bash.sh
@@ -70,7 +70,7 @@ _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) s
                    # continuation byte can be 0x5C or 0x22, so a cut cannot land inside a character at a
                    # quote or backslash edge. What this line is worth in SPEED depends on the platform --
                    # read the table in _json_unescape below before quoting a number for it.
-  local pre rest seg tail out bs
+  local pre rest seg w r n base=0 j=0 cl lim run=0 chunk C=4096 W=256; local -a acc=("")
   # Every "step past X" here is arithmetic on a length, never `${s#"$literal"}`. That shape reads like a
   # constant-time strip and is not one: bash retries the pattern at every prefix length, so stripping an
   # n-byte literal costs O(n^2). It was in this function twice, and both were measured:
@@ -84,27 +84,46 @@ _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) s
   #     against 0.002s for `${tail:${#seg}+1}` doing exactly the same thing.
   # `${1%%"$2"*}` still finds the FIRST occurrence -- the longest suffix that starts with the key starts at the
   # earliest one -- so a command containing the literal text `"command":"` still cannot relocate the parse.
-  # Output is byte-identical to the previous shape across a 27-case battery: escaped quotes, backslash runs
-  # before a quote, the key twice, the key appearing first as a value, glob metacharacters, UTF-8, no closing
-  # quote, empty input. Two deliberately broken twins -- one byte off in each offset -- prove it can tell.
+  # Stepping by length removed the quadratic strip, but each escaped quote still sliced and re-assigned the
+  # whole remainder, so an escape-dense command stayed k*n here as well (2.2s of the 6.8s described in
+  # _json_unescape below, on Git Bash). The walk is chunked the same way: the payload is read 4096 bytes at a
+  # time and every per-quote operation stays inside the chunk. One thing is carried across edges on purpose
+  # -- the length of the backslash run in front of a quote -- because that run can straddle a window or a
+  # chunk, and its parity is what decides whether the quote ends the value. Isolated, escape-dense 44030 B:
+  # 2.61s -> 0.41s on Git Bash 5.3.15, 0.93s -> 0.09s on macOS/bash 3.2.
+  # Output is byte-identical to the previous shape across 378 cases at four chunk/window sizes down to 7 and 1
+  # bytes, and that shape to the one before it across a 27-case battery (escaped quotes, backslash runs before
+  # a quote, the key twice, the key appearing first as a value, glob metacharacters, UTF-8, no closing quote,
+  # empty input). Broken twins -- the run not carried across a window, a byte skipped after a quote -- prove
+  # the battery sees both.
   pre="${1%%\"$2\"*}"                          # everything before the FIRST `"key"`
   [ "$pre" != "$1" ] || return 0               # key absent: emit nothing
   rest="${1:${#pre}+${#2}+2}"                  # past `"key"`
   seg="${rest%%\"*}"                           # skip `: "` up to the value's opening quote, when there is one
   [ "$seg" = "$rest" ] || rest="${rest:${#seg}+1}"
-  out=""; tail="$rest"
   # Walk to the closing quote that is NOT escaped. A `"` preceded by an odd number of backslashes is content.
+  n=${#rest}; chunk="${rest:0:C}"; cl=${#chunk}
   while :; do
-    seg="${tail%%\"*}"
-    [ "$seg" != "$tail" ] || { out="$out$seg"; break; }   # no closing quote at all: take the rest
-    out="$out$seg"
-    bs="${seg##*[!\\]}"                    # trailing backslash run ("" when the last char is not a backslash)
-    case "$seg" in *[!\\]*) ;; *) bs="$seg" ;; esac       # all-backslash segment: the run is the whole segment
-    if [ $(( ${#bs} % 2 )) -eq 1 ]; then out="$out\""; tail="${tail:${#seg}+1}"; else break; fi
+    lim=$((cl - j))
+    if [ "$lim" -le 0 ]; then
+      [ $((base + cl)) -lt "$n" ] || break                 # no closing quote at all: everything is already taken
+      base=$((base + j)); chunk="${rest:base:C}"; cl=${#chunk}; j=0; continue
+    fi
+    [ "$lim" -le "$W" ] || lim=$W
+    w="${chunk:j:lim}"
+    seg="${w%%\"*}"
+    if [ "$seg" = "$w" ]; then                             # no quote in view: take all of it, carry the run
+      acc+=("$w"); j=$((j+lim))
+      r="${w##*[!\\]}"; case "$w" in *[!\\]*) run=${#r} ;; *) run=$((run+${#w})) ;; esac
+      continue
+    fi
+    acc+=("$seg"); j=$((j+${#seg}+1))
+    r="${seg##*[!\\]}"; case "$seg" in *[!\\]*) run=${#r} ;; *) run=$((run+${#seg})) ;; esac
+    if [ $((run % 2)) -eq 1 ]; then acc+=("\""); run=0; else break; fi
   done
-  printf '%s' "$out"
+  local IFS=''; printf '%s' "${acc[*]}"
 }
-_json_unescape(){  # left-to-right, one whole run per escape; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
+_json_unescape(){  # left-to-right, a chunk at a time; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
   # This is the tier-3 path below -- the one a stock Windows install actually runs on. It used to walk ONE
   # CHARACTER at a time, which is O(n^2) twice over: `${s%"${s#?}"}` matches a pattern the length of the
   # entire remainder just to read one character, and `out="$out$c"` recopies the output for each one.
@@ -135,44 +154,68 @@ _json_unescape(){  # left-to-right, one whole run per escape; a two-pass sed wou
   #     alone would justify the line, and it costs nothing. `local` restores the previous locale on return
   #     -- verified on bash 3.2 and on Git Bash 5.3.15, not assumed.
   #
-  # Heaviest real payload (46815 B, 2813 escapes), whole hook end to end, with _json_slice fixed as well: 2.1s
-  # on macOS/bash 3.2. On Git Bash an escape-dense command of that shape (44080 B, 2755 escapes) takes 6.8s --
-  # 11% of the timeout, so slowness rather than a hole -- and what is left there is k*n in BOTH functions
-  # (slice 2.2s, unescape 3.1s): every escape rescans and recopies the remainder. A sparse 100 KB command is
-  # 1.6-2.1s there. These numbers do not travel, which is why each one names its machine.
-  # Output is byte-identical to the old function across a
-  # 31-case battery (escaped quotes, `\\\\`, a lone trailing backslash, a truncated `\\u`, Turkish, emoji), and
-  # tier 1 and tier 3 return the same verdict on 22 gate cases. A deliberately-broken twin of the new function
-  # proves the battery can tell the two apart.
-  local s="$1" out="" pre c h
+  # Then the cost moved rather than went away. With the per-character walk gone, each escape still sliced the
+  # whole REMAINDER -- `s="${s:${#pre}+1}"` -- so an escape-dense command stayed k*n: on Git Bash a 44080 B
+  # command with 2755 escapes took 6.8s, 11% of the timeout. The input is now touched only a chunk at a time
+  # (`${s:base:C}`, once per 4096 bytes) and every per-escape operation stays inside that chunk, so no escape
+  # pays for the length of the whole command. That is the change that matters: bounding only the lookahead,
+  # while still indexing the full string, was measured too and gave about 4x on both machines, against 6-12x
+  # for the chunked walk. Five bytes are held back at a chunk's end whenever more input follows, so a
+  # `\uXXXX` that starts in a chunk ends in it.
+  # The output goes into an array joined once, not a string recopied at every append, and `\n`/`\t` are
+  # written `$'\n'`/`$'\t'`, so this file carries no raw TAB for an editor or a copy to turn into spaces.
+  #
+  # Measured, isolated, previous shape -> this one:
+  #     macOS/bash 3.2   escape-dense 44030 B, 2590 escapes .. 1.44s -> 0.12s
+  #                      sparse 100014 B, 4 escapes ........... 0.09s -> 0.02s
+  #     Git Bash 5.3.15  escape-dense 44030 B, 2590 escapes .. 3.92s -> 0.54s
+  #     (LANG empty)     sparse 99997 B, 4 escapes ............ 0.49s -> 0.07s
+  # These numbers do not travel, which is why each one names its machine.
+  #
+  # Output is byte-identical to the previous shape across 478 cases, each run at four chunk/window sizes
+  # down to 7 and 1 bytes so that an edge falls every few bytes; that shape was itself byte-identical to
+  # the original character walk across a 31-case battery (escaped quotes, `\\`, a lone trailing backslash, a
+  # truncated `\u`, Turkish, emoji). Deliberately broken twins -- the 5-byte margin cut to 4, the backslash
+  # not stepped over -- prove the battery sees both edges, and tier 1 and tier 3 return the same verdict on
+  # the gate cases.
   local LC_ALL=C
+  local s="$1" pre w c h n base=0 j=0 cl lim chunk C=4096 W=256; local -a acc=("")
   case "$s" in *\\*) ;; *) printf '%s' "$s"; return 0 ;; esac   # no escapes: the common case pays nothing
+  n=${#s}; chunk="${s:0:C}"; cl=${#chunk}
   while :; do
-    pre="${s%%\\*}"                                     # the whole literal run before the next backslash
-    if [ "$pre" = "$s" ]; then out="$out$s"; break; fi   # no backslash left: the remainder is literal
-    out="$out$pre"; s="${s:${#pre}+1}"
-    if [ -z "$s" ]; then out="$out\\"; break; fi         # a lone trailing backslash stays literal, as before
-    c="${s:0:1}"; s="${s:1}"
+    lim=$((cl - j))
+    if [ $((base + cl)) -lt "$n" ]; then                  # more input after this chunk: hold 5 bytes back, so
+      lim=$((lim - 5))                                     # a `\uXXXX` that starts in a chunk also ends in it
+      if [ "$lim" -le 0 ]; then base=$((base + j)); chunk="${s:base:C}"; cl=${#chunk}; j=0; continue; fi
+    else
+      [ "$lim" -gt 0 ] || break
+    fi
+    [ "$lim" -le "$W" ] || lim=$W
+    w="${chunk:j:lim}"
+    pre="${w%%\\*}"                                        # the literal run before the next backslash in view
+    if [ "$pre" = "$w" ]; then acc+=("$w"); j=$((j+lim)); continue; fi
+    acc+=("$pre"); j=$((j+${#pre}+1))
+    if [ $((base + j)) -ge "$n" ]; then acc+=("\\"); break; fi   # a lone trailing backslash stays literal, as before
+    c="${chunk:j:1}"; j=$((j+1))
     case "$c" in
-      n) out="$out
-" ;;
-      t) out="$out	" ;;
+      n) acc+=($'\n') ;;
+      t) acc+=($'\t') ;;
       r) ;;
-      b|f) out="$out " ;;
-      u) if [ ${#s} -ge 4 ]; then h="${s:0:4}"; s="${s:4}"; else h=""; fi   # a short tail leaves s alone, as before
+      b|f) acc+=(" ") ;;
+      u) if [ $((n - base - j)) -ge 4 ]; then h="${chunk:j:4}"; j=$((j+4)); else h=""; fi   # a short tail is left alone, as before
          # A `\uXXXX` used to become a literal `?`. That is not a lossy nicety, it is a hole: `\u002e` is `.`,
          # so `\u002eclaude/hooks/guard-bash.sh` decoded to `?claude/…` and matched no gate pattern, while jq
          # decoded the same bytes to the real path — the two tiers disagreed on whether a payload was an
          # attack. Printable ASCII is decoded properly (builtin printf, no fork); anything else still becomes
          # `?`, which is only ever a display concern because this value is used for MATCHING, never to write.
          case "$h" in
-           00[2-7][0-9a-fA-F]) printf -v c "\\x${h#00}"; out="$out$c" ;;
-           *)                  out="$out?" ;;
+           00[2-7][0-9a-fA-F]) printf -v c "\\x${h#00}"; acc+=("$c") ;;
+           *)                  acc+=("?") ;;
          esac ;;
-      *) out="$out$c" ;;
+      *) acc+=("$c") ;;
     esac
   done
-  printf '%s' "$out"
+  local IFS=''; printf '%s' "${acc[*]}"
 }
 # ---- /CSK-JSON-PARSE -----------------------------------------------------------------------------------
 # A TIER IS CHOSEN ON WHETHER IT WORKS, NOT ON WHETHER IT EXISTS. `command -v` answers the wrong question, and

--- a/claude-starter/hooks/guard-bash.sh
+++ b/claude-starter/hooks/guard-bash.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # Claude Code PreToolUse (Bash) guard. PreToolUse runs in EVERY permission mode, including bypass.
-# stdin JSON: {"tool_name":"Bash","tool_input":{"command":"..."},"permission_mode":"default|acceptEdits|auto|dontAsk|plan|bypassPermissions"}
+# stdin JSON, one line, in the key order captured from Claude Code 2.1.267 (values abridged):
+#   {"session_id":…,"transcript_path":…,"cwd":…,"prompt_id":…,
+#    "permission_mode":"default|acceptEdits|auto|dontAsk|plan|bypassPermissions","effort":{…},
+#    "hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"...","description":"..."},"tool_use_id":…}
+#   This line used to show `permission_mode` AFTER `tool_input`. It was never a capture, and it was wrong. The
+#   fallback parser below does not depend on the order either way, because the order is not a documented contract.
 #
 # §4.5 destructive operations -> HARD BLOCK (exit 2). No key, no mode, no escape.
 #
@@ -53,19 +58,40 @@ INPUT="$(cat)"
 # no Windows user is on. smoke-test §7b pins the fallback branch itself for exactly that reason.
 #
 # The slice is pure parameter expansion: zero forks, so it is CHEAPER than the sed it replaces (Git Bash charges
-# 62-135 ms per process on a Windows 11 desktop, and this hook runs on every Bash call). `${INPUT#*"command"}` is shortest-match, so it
-# takes the FIRST occurrence — greedy matching would let a command containing the literal text `"command":"`
-# relocate the parse and walk a payload straight past the rules.
+# 62-135 ms per process on a Windows 11 desktop, and this hook runs on every Bash call). It must take the FIRST
+# occurrence of the key: greedy matching would let a command containing the literal text `"command":"` relocate
+# the parse and walk a payload straight past the rules. HOW it does that is documented inside _json_slice, next to
+# the code, and only there -- this paragraph named the expansion once, and went stale the day it changed.
 # ---- CSK-JSON-PARSE ------------------------------------------------------------------------------------
 _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) string value, "" if absent
-  local rest="${1#*\"$2\"}" seg tail out bs
-  local LC_ALL=C   # Same reason, and the same platform caveat, as in _json_unescape below -- read the table
-                   # there before quoting a speedup for this. Measured here: 1.56s -> 0.31s on a 46882 B
-                   # payload on macOS with a locale set; far less on Git Bash, and nothing where LANG is
-                   # empty. Output verified identical. Safe because no UTF-8 continuation byte can be 0x5C
-                   # or 0x22, so walking bytes cannot split a character across a quote or backslash edge.
-  [ "$rest" != "$1" ] || return 0          # key absent: emit nothing
-  rest="${rest#*\"}"                       # skip `: "` up to the value's opening quote
+  local LC_ALL=C   # FIRST, so every expansion below -- the key search included -- counts and cuts in bytes.
+                   # Lengths from ${#x} are used as offsets into ${y:n}; with the locale set before any of
+                   # them, the two never disagree about a unit. Walking bytes is safe because no UTF-8
+                   # continuation byte can be 0x5C or 0x22, so a cut cannot land inside a character at a
+                   # quote or backslash edge. What this line is worth in SPEED depends on the platform --
+                   # read the table in _json_unescape below before quoting a number for it.
+  local pre rest seg tail out bs
+  # Every "step past X" here is arithmetic on a length, never `${s#"$literal"}`. That shape reads like a
+  # constant-time strip and is not one: bash retries the pattern at every prefix length, so stripping an
+  # n-byte literal costs O(n^2). It was in this function twice, and both were measured:
+  #   * `${1#*"$2"}` found the key -- cheap when the key sits near the front, quadratic in the distance to it
+  #     otherwise. `permission_mode` behind a 100 KB command took 7.94s on Git Bash, 0.27s in front of it.
+  #     Captured from Claude Code 2.1.267, the real order puts `permission_mode` BEFORE `tool_input`, so on
+  #     that version this cost was not reachable -- this file's header had shown the opposite order, and was
+  #     wrong. The parse stays order-independent regardless: the order is not a documented contract, and the
+  #     payload is still moving (`effort` is absent from the field list recorded on 2.1.246).
+  #   * `${tail#"$seg"\"}` stepped past each escaped quote: 16.8s for a single 100 KB step on Git Bash,
+  #     against 0.002s for `${tail:${#seg}+1}` doing exactly the same thing.
+  # `${1%%"$2"*}` still finds the FIRST occurrence -- the longest suffix that starts with the key starts at the
+  # earliest one -- so a command containing the literal text `"command":"` still cannot relocate the parse.
+  # Output is byte-identical to the previous shape across a 27-case battery: escaped quotes, backslash runs
+  # before a quote, the key twice, the key appearing first as a value, glob metacharacters, UTF-8, no closing
+  # quote, empty input. Two deliberately broken twins -- one byte off in each offset -- prove it can tell.
+  pre="${1%%\"$2\"*}"                          # everything before the FIRST `"key"`
+  [ "$pre" != "$1" ] || return 0               # key absent: emit nothing
+  rest="${1:${#pre}+${#2}+2}"                  # past `"key"`
+  seg="${rest%%\"*}"                           # skip `: "` up to the value's opening quote, when there is one
+  [ "$seg" = "$rest" ] || rest="${rest:${#seg}+1}"
   out=""; tail="$rest"
   # Walk to the closing quote that is NOT escaped. A `"` preceded by an odd number of backslashes is content.
   while :; do
@@ -74,7 +100,7 @@ _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) s
     out="$out$seg"
     bs="${seg##*[!\\]}"                    # trailing backslash run ("" when the last char is not a backslash)
     case "$seg" in *[!\\]*) ;; *) bs="$seg" ;; esac       # all-backslash segment: the run is the whole segment
-    if [ $(( ${#bs} % 2 )) -eq 1 ]; then out="$out\""; tail="${tail#"$seg"\"}"; else break; fi
+    if [ $(( ${#bs} % 2 )) -eq 1 ]; then out="$out\""; tail="${tail:${#seg}+1}"; else break; fi
   done
   printf '%s' "$out"
 }
@@ -109,9 +135,12 @@ _json_unescape(){  # left-to-right, one whole run per escape; a two-pass sed wou
   #     alone would justify the line, and it costs nothing. `local` restores the previous locale on return
   #     -- verified on bash 3.2 and on Git Bash 5.3.15, not assumed.
   #
-  # Heaviest real payload (46815 B, 2813 escapes), whole hook end to end: 3.42s on macOS/bash 3.2. Windows is
-  # slower and is measured there separately -- these numbers do not travel, which is the whole reason the
-  # figures above name the machine they came from. Output is byte-identical to the old function across a
+  # Heaviest real payload (46815 B, 2813 escapes), whole hook end to end, with _json_slice fixed as well: 2.1s
+  # on macOS/bash 3.2. On Git Bash an escape-dense command of that shape (44080 B, 2755 escapes) takes 6.8s --
+  # 11% of the timeout, so slowness rather than a hole -- and what is left there is k*n in BOTH functions
+  # (slice 2.2s, unescape 3.1s): every escape rescans and recopies the remainder. A sparse 100 KB command is
+  # 1.6-2.1s there. These numbers do not travel, which is why each one names its machine.
+  # Output is byte-identical to the old function across a
   # 31-case battery (escaped quotes, `\\\\`, a lone trailing backslash, a truncated `\\u`, Turkish, emoji), and
   # tier 1 and tier 3 return the same verdict on 22 gate cases. A deliberately-broken twin of the new function
   # proves the battery can tell the two apart.

--- a/claude-starter/hooks/guard-bash.sh
+++ b/claude-starter/hooks/guard-bash.sh
@@ -59,6 +59,11 @@ INPUT="$(cat)"
 # ---- CSK-JSON-PARSE ------------------------------------------------------------------------------------
 _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) string value, "" if absent
   local rest="${1#*\"$2\"}" seg tail out bs
+  local LC_ALL=C   # Same reason, and the same platform caveat, as in _json_unescape below -- read the table
+                   # there before quoting a speedup for this. Measured here: 1.56s -> 0.31s on a 46882 B
+                   # payload on macOS with a locale set; far less on Git Bash, and nothing where LANG is
+                   # empty. Output verified identical. Safe because no UTF-8 continuation byte can be 0x5C
+                   # or 0x22, so walking bytes cannot split a character across a quote or backslash edge.
   [ "$rest" != "$1" ] || return 0          # key absent: emit nothing
   rest="${rest#*\"}"                       # skip `: "` up to the value's opening quote
   out=""; tail="$rest"
@@ -73,34 +78,70 @@ _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) s
   done
   printf '%s' "$out"
 }
-_json_unescape(){  # single left-to-right pass; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
-  local s="$1" out="" c h
+_json_unescape(){  # left-to-right, one whole run per escape; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
+  # This is the tier-3 path below -- the one a stock Windows install actually runs on. It used to walk ONE
+  # CHARACTER at a time, which is O(n^2) twice over: `${s%"${s#?}"}` matches a pattern the length of the
+  # entire remainder just to read one character, and `out="$out$c"` recopies the output for each one.
+  #
+  # That was not a comfort question. This hook's timeout is 60s -- set in settings.json, NOT Claude Code's
+  # default, and reading the default instead is how a first pass at this got the consequence wrong. A
+  # PreToolUse hook KILLED at its timeout emits no exit 2, so every rule below is simply skipped. Measured on
+  # the tier-3 path with jq and python3 both shadowed, the old shape crossed 60s at ~4.3 KB. And 4.3 KB is
+  # not exotic: across 6791 Bash calls in 280 real transcripts, 2.49% of commands are bigger, and the largest
+  # is 46815 B, which the old shape needed roughly 39 minutes to decode. One Bash call in forty walked past
+  # §4.4 and §4.5 entirely, silently, on every stock Windows desktop.
+  #
+  # Two changes, and their wins are NOT the same shape -- writing them down as one number was the mistake
+  # this comment exists to avoid repeating:
+  #   * Taking the whole run up to the next backslash in ONE expansion, and indexing with `${s:0:1}` instead
+  #     of matching a pattern, is 47x on a 4.4 KB payload. This one holds on every machine.
+  #   * `local LC_ALL=C` makes these expansions byte-oriented instead of re-decoding the string on every
+  #     substring operation. What that is WORTH depends on the platform, and putting a single number here
+  #     would have been wrong three separate ways -- it was written as "another 5x" twice before this:
+  #         macOS / bash 3.2, a locale set .................. 5x
+  #         Git Bash 5.3.15, a locale set ................... 1.23x   (measured on the OLD shape; the new one
+  #                                                                    touches the locale once per escape
+  #                                                                    rather than once per character, so its
+  #                                                                    ratio is smaller and unmeasured)
+  #         Git Bash, LANG empty -- what Claude Code starts .. nothing at all
+  #     So speed is not what keeps this line; CORRECTNESS is, and that half holds everywhere. `[0-9a-fA-F]`
+  #     below is a collation-defined range outside the C locale: on a tr_TR desktop it is not 0-9a-f. That
+  #     alone would justify the line, and it costs nothing. `local` restores the previous locale on return
+  #     -- verified on bash 3.2 and on Git Bash 5.3.15, not assumed.
+  #
+  # Heaviest real payload (46815 B, 2813 escapes), whole hook end to end: 3.42s on macOS/bash 3.2. Windows is
+  # slower and is measured there separately -- these numbers do not travel, which is the whole reason the
+  # figures above name the machine they came from. Output is byte-identical to the old function across a
+  # 31-case battery (escaped quotes, `\\\\`, a lone trailing backslash, a truncated `\\u`, Turkish, emoji), and
+  # tier 1 and tier 3 return the same verdict on 22 gate cases. A deliberately-broken twin of the new function
+  # proves the battery can tell the two apart.
+  local s="$1" out="" pre c h
+  local LC_ALL=C
   case "$s" in *\\*) ;; *) printf '%s' "$s"; return 0 ;; esac   # no escapes: the common case pays nothing
-  while [ -n "$s" ]; do
-    c="${s%"${s#?}"}"; s="${s#?}"
-    if [ "$c" = "\\" ] && [ -n "$s" ]; then
-      c="${s%"${s#?}"}"; s="${s#?}"
-      case "$c" in
-        n) out="$out
+  while :; do
+    pre="${s%%\\*}"                                     # the whole literal run before the next backslash
+    if [ "$pre" = "$s" ]; then out="$out$s"; break; fi   # no backslash left: the remainder is literal
+    out="$out$pre"; s="${s:${#pre}+1}"
+    if [ -z "$s" ]; then out="$out\\"; break; fi         # a lone trailing backslash stays literal, as before
+    c="${s:0:1}"; s="${s:1}"
+    case "$c" in
+      n) out="$out
 " ;;
-        t) out="$out	" ;;
-        r) ;;
-        b|f) out="$out " ;;
-        u) h="${s%"${s#????}"}"; s="${s#????}"
-           # A `\uXXXX` used to become a literal `?`. That is not a lossy nicety, it is a hole: `\u002e` is `.`,
-           # so `\u002eclaude/hooks/guard-bash.sh` decoded to `?claude/…` and matched no gate pattern, while jq
-           # decoded the same bytes to the real path — the two tiers disagreed on whether a payload was an
-           # attack. Printable ASCII is decoded properly (builtin printf, no fork); anything else still becomes
-           # `?`, which is only ever a display concern because this value is used for MATCHING, never to write.
-           case "$h" in
-             00[2-7][0-9a-fA-F]) printf -v c "\\x${h#00}"; out="$out$c" ;;
-             *)                  out="$out?" ;;
-           esac ;;
-        *) out="$out$c" ;;
-      esac
-    else
-      out="$out$c"
-    fi
+      t) out="$out	" ;;
+      r) ;;
+      b|f) out="$out " ;;
+      u) if [ ${#s} -ge 4 ]; then h="${s:0:4}"; s="${s:4}"; else h=""; fi   # a short tail leaves s alone, as before
+         # A `\uXXXX` used to become a literal `?`. That is not a lossy nicety, it is a hole: `\u002e` is `.`,
+         # so `\u002eclaude/hooks/guard-bash.sh` decoded to `?claude/…` and matched no gate pattern, while jq
+         # decoded the same bytes to the real path — the two tiers disagreed on whether a payload was an
+         # attack. Printable ASCII is decoded properly (builtin printf, no fork); anything else still becomes
+         # `?`, which is only ever a display concern because this value is used for MATCHING, never to write.
+         case "$h" in
+           00[2-7][0-9a-fA-F]) printf -v c "\\x${h#00}"; out="$out$c" ;;
+           *)                  out="$out?" ;;
+         esac ;;
+      *) out="$out$c" ;;
+    esac
   done
   printf '%s' "$out"
 }

--- a/claude-starter/hooks/guard-write.sh
+++ b/claude-starter/hooks/guard-write.sh
@@ -39,6 +39,11 @@ INPUT="$(cat)"
 # ---- CSK-JSON-PARSE ------------------------------------------------------------------------------------
 _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) string value, "" if absent
   local rest="${1#*\"$2\"}" seg tail out bs
+  local LC_ALL=C   # Same reason, and the same platform caveat, as in _json_unescape below -- read the table
+                   # there before quoting a speedup for this. Measured here: 1.56s -> 0.31s on a 46882 B
+                   # payload on macOS with a locale set; far less on Git Bash, and nothing where LANG is
+                   # empty. Output verified identical. Safe because no UTF-8 continuation byte can be 0x5C
+                   # or 0x22, so walking bytes cannot split a character across a quote or backslash edge.
   [ "$rest" != "$1" ] || return 0          # key absent: emit nothing
   rest="${rest#*\"}"                       # skip `: "` up to the value's opening quote
   out=""; tail="$rest"
@@ -53,34 +58,70 @@ _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) s
   done
   printf '%s' "$out"
 }
-_json_unescape(){  # single left-to-right pass; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
-  local s="$1" out="" c h
+_json_unescape(){  # left-to-right, one whole run per escape; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
+  # This is the tier-3 path below -- the one a stock Windows install actually runs on. It used to walk ONE
+  # CHARACTER at a time, which is O(n^2) twice over: `${s%"${s#?}"}` matches a pattern the length of the
+  # entire remainder just to read one character, and `out="$out$c"` recopies the output for each one.
+  #
+  # That was not a comfort question. This hook's timeout is 60s -- set in settings.json, NOT Claude Code's
+  # default, and reading the default instead is how a first pass at this got the consequence wrong. A
+  # PreToolUse hook KILLED at its timeout emits no exit 2, so every rule below is simply skipped. Measured on
+  # the tier-3 path with jq and python3 both shadowed, the old shape crossed 60s at ~4.3 KB. And 4.3 KB is
+  # not exotic: across 6791 Bash calls in 280 real transcripts, 2.49% of commands are bigger, and the largest
+  # is 46815 B, which the old shape needed roughly 39 minutes to decode. One Bash call in forty walked past
+  # §4.4 and §4.5 entirely, silently, on every stock Windows desktop.
+  #
+  # Two changes, and their wins are NOT the same shape -- writing them down as one number was the mistake
+  # this comment exists to avoid repeating:
+  #   * Taking the whole run up to the next backslash in ONE expansion, and indexing with `${s:0:1}` instead
+  #     of matching a pattern, is 47x on a 4.4 KB payload. This one holds on every machine.
+  #   * `local LC_ALL=C` makes these expansions byte-oriented instead of re-decoding the string on every
+  #     substring operation. What that is WORTH depends on the platform, and putting a single number here
+  #     would have been wrong three separate ways -- it was written as "another 5x" twice before this:
+  #         macOS / bash 3.2, a locale set .................. 5x
+  #         Git Bash 5.3.15, a locale set ................... 1.23x   (measured on the OLD shape; the new one
+  #                                                                    touches the locale once per escape
+  #                                                                    rather than once per character, so its
+  #                                                                    ratio is smaller and unmeasured)
+  #         Git Bash, LANG empty -- what Claude Code starts .. nothing at all
+  #     So speed is not what keeps this line; CORRECTNESS is, and that half holds everywhere. `[0-9a-fA-F]`
+  #     below is a collation-defined range outside the C locale: on a tr_TR desktop it is not 0-9a-f. That
+  #     alone would justify the line, and it costs nothing. `local` restores the previous locale on return
+  #     -- verified on bash 3.2 and on Git Bash 5.3.15, not assumed.
+  #
+  # Heaviest real payload (46815 B, 2813 escapes), whole hook end to end: 3.42s on macOS/bash 3.2. Windows is
+  # slower and is measured there separately -- these numbers do not travel, which is the whole reason the
+  # figures above name the machine they came from. Output is byte-identical to the old function across a
+  # 31-case battery (escaped quotes, `\\\\`, a lone trailing backslash, a truncated `\\u`, Turkish, emoji), and
+  # tier 1 and tier 3 return the same verdict on 22 gate cases. A deliberately-broken twin of the new function
+  # proves the battery can tell the two apart.
+  local s="$1" out="" pre c h
+  local LC_ALL=C
   case "$s" in *\\*) ;; *) printf '%s' "$s"; return 0 ;; esac   # no escapes: the common case pays nothing
-  while [ -n "$s" ]; do
-    c="${s%"${s#?}"}"; s="${s#?}"
-    if [ "$c" = "\\" ] && [ -n "$s" ]; then
-      c="${s%"${s#?}"}"; s="${s#?}"
-      case "$c" in
-        n) out="$out
+  while :; do
+    pre="${s%%\\*}"                                     # the whole literal run before the next backslash
+    if [ "$pre" = "$s" ]; then out="$out$s"; break; fi   # no backslash left: the remainder is literal
+    out="$out$pre"; s="${s:${#pre}+1}"
+    if [ -z "$s" ]; then out="$out\\"; break; fi         # a lone trailing backslash stays literal, as before
+    c="${s:0:1}"; s="${s:1}"
+    case "$c" in
+      n) out="$out
 " ;;
-        t) out="$out	" ;;
-        r) ;;
-        b|f) out="$out " ;;
-        u) h="${s%"${s#????}"}"; s="${s#????}"
-           # A `\uXXXX` used to become a literal `?`. That is not a lossy nicety, it is a hole: `\u002e` is `.`,
-           # so `\u002eclaude/hooks/guard-bash.sh` decoded to `?claude/…` and matched no gate pattern, while jq
-           # decoded the same bytes to the real path — the two tiers disagreed on whether a payload was an
-           # attack. Printable ASCII is decoded properly (builtin printf, no fork); anything else still becomes
-           # `?`, which is only ever a display concern because this value is used for MATCHING, never to write.
-           case "$h" in
-             00[2-7][0-9a-fA-F]) printf -v c "\\x${h#00}"; out="$out$c" ;;
-             *)                  out="$out?" ;;
-           esac ;;
-        *) out="$out$c" ;;
-      esac
-    else
-      out="$out$c"
-    fi
+      t) out="$out	" ;;
+      r) ;;
+      b|f) out="$out " ;;
+      u) if [ ${#s} -ge 4 ]; then h="${s:0:4}"; s="${s:4}"; else h=""; fi   # a short tail leaves s alone, as before
+         # A `\uXXXX` used to become a literal `?`. That is not a lossy nicety, it is a hole: `\u002e` is `.`,
+         # so `\u002eclaude/hooks/guard-bash.sh` decoded to `?claude/…` and matched no gate pattern, while jq
+         # decoded the same bytes to the real path — the two tiers disagreed on whether a payload was an
+         # attack. Printable ASCII is decoded properly (builtin printf, no fork); anything else still becomes
+         # `?`, which is only ever a display concern because this value is used for MATCHING, never to write.
+         case "$h" in
+           00[2-7][0-9a-fA-F]) printf -v c "\\x${h#00}"; out="$out$c" ;;
+           *)                  out="$out?" ;;
+         esac ;;
+      *) out="$out$c" ;;
+    esac
   done
   printf '%s' "$out"
 }

--- a/claude-starter/hooks/guard-write.sh
+++ b/claude-starter/hooks/guard-write.sh
@@ -38,14 +38,34 @@ INPUT="$(cat)"
 # safe while they cannot drift, so smoke-test pins these markers byte-identical rather than trusting it.
 # ---- CSK-JSON-PARSE ------------------------------------------------------------------------------------
 _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) string value, "" if absent
-  local rest="${1#*\"$2\"}" seg tail out bs
-  local LC_ALL=C   # Same reason, and the same platform caveat, as in _json_unescape below -- read the table
-                   # there before quoting a speedup for this. Measured here: 1.56s -> 0.31s on a 46882 B
-                   # payload on macOS with a locale set; far less on Git Bash, and nothing where LANG is
-                   # empty. Output verified identical. Safe because no UTF-8 continuation byte can be 0x5C
-                   # or 0x22, so walking bytes cannot split a character across a quote or backslash edge.
-  [ "$rest" != "$1" ] || return 0          # key absent: emit nothing
-  rest="${rest#*\"}"                       # skip `: "` up to the value's opening quote
+  local LC_ALL=C   # FIRST, so every expansion below -- the key search included -- counts and cuts in bytes.
+                   # Lengths from ${#x} are used as offsets into ${y:n}; with the locale set before any of
+                   # them, the two never disagree about a unit. Walking bytes is safe because no UTF-8
+                   # continuation byte can be 0x5C or 0x22, so a cut cannot land inside a character at a
+                   # quote or backslash edge. What this line is worth in SPEED depends on the platform --
+                   # read the table in _json_unescape below before quoting a number for it.
+  local pre rest seg tail out bs
+  # Every "step past X" here is arithmetic on a length, never `${s#"$literal"}`. That shape reads like a
+  # constant-time strip and is not one: bash retries the pattern at every prefix length, so stripping an
+  # n-byte literal costs O(n^2). It was in this function twice, and both were measured:
+  #   * `${1#*"$2"}` found the key -- cheap when the key sits near the front, quadratic in the distance to it
+  #     otherwise. `permission_mode` behind a 100 KB command took 7.94s on Git Bash, 0.27s in front of it.
+  #     Captured from Claude Code 2.1.267, the real order puts `permission_mode` BEFORE `tool_input`, so on
+  #     that version this cost was not reachable -- this file's header had shown the opposite order, and was
+  #     wrong. The parse stays order-independent regardless: the order is not a documented contract, and the
+  #     payload is still moving (`effort` is absent from the field list recorded on 2.1.246).
+  #   * `${tail#"$seg"\"}` stepped past each escaped quote: 16.8s for a single 100 KB step on Git Bash,
+  #     against 0.002s for `${tail:${#seg}+1}` doing exactly the same thing.
+  # `${1%%"$2"*}` still finds the FIRST occurrence -- the longest suffix that starts with the key starts at the
+  # earliest one -- so a command containing the literal text `"command":"` still cannot relocate the parse.
+  # Output is byte-identical to the previous shape across a 27-case battery: escaped quotes, backslash runs
+  # before a quote, the key twice, the key appearing first as a value, glob metacharacters, UTF-8, no closing
+  # quote, empty input. Two deliberately broken twins -- one byte off in each offset -- prove it can tell.
+  pre="${1%%\"$2\"*}"                          # everything before the FIRST `"key"`
+  [ "$pre" != "$1" ] || return 0               # key absent: emit nothing
+  rest="${1:${#pre}+${#2}+2}"                  # past `"key"`
+  seg="${rest%%\"*}"                           # skip `: "` up to the value's opening quote, when there is one
+  [ "$seg" = "$rest" ] || rest="${rest:${#seg}+1}"
   out=""; tail="$rest"
   # Walk to the closing quote that is NOT escaped. A `"` preceded by an odd number of backslashes is content.
   while :; do
@@ -54,7 +74,7 @@ _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) s
     out="$out$seg"
     bs="${seg##*[!\\]}"                    # trailing backslash run ("" when the last char is not a backslash)
     case "$seg" in *[!\\]*) ;; *) bs="$seg" ;; esac       # all-backslash segment: the run is the whole segment
-    if [ $(( ${#bs} % 2 )) -eq 1 ]; then out="$out\""; tail="${tail#"$seg"\"}"; else break; fi
+    if [ $(( ${#bs} % 2 )) -eq 1 ]; then out="$out\""; tail="${tail:${#seg}+1}"; else break; fi
   done
   printf '%s' "$out"
 }
@@ -89,9 +109,12 @@ _json_unescape(){  # left-to-right, one whole run per escape; a two-pass sed wou
   #     alone would justify the line, and it costs nothing. `local` restores the previous locale on return
   #     -- verified on bash 3.2 and on Git Bash 5.3.15, not assumed.
   #
-  # Heaviest real payload (46815 B, 2813 escapes), whole hook end to end: 3.42s on macOS/bash 3.2. Windows is
-  # slower and is measured there separately -- these numbers do not travel, which is the whole reason the
-  # figures above name the machine they came from. Output is byte-identical to the old function across a
+  # Heaviest real payload (46815 B, 2813 escapes), whole hook end to end, with _json_slice fixed as well: 2.1s
+  # on macOS/bash 3.2. On Git Bash an escape-dense command of that shape (44080 B, 2755 escapes) takes 6.8s --
+  # 11% of the timeout, so slowness rather than a hole -- and what is left there is k*n in BOTH functions
+  # (slice 2.2s, unescape 3.1s): every escape rescans and recopies the remainder. A sparse 100 KB command is
+  # 1.6-2.1s there. These numbers do not travel, which is why each one names its machine.
+  # Output is byte-identical to the old function across a
   # 31-case battery (escaped quotes, `\\\\`, a lone trailing backslash, a truncated `\\u`, Turkish, emoji), and
   # tier 1 and tier 3 return the same verdict on 22 gate cases. A deliberately-broken twin of the new function
   # proves the battery can tell the two apart.

--- a/claude-starter/hooks/guard-write.sh
+++ b/claude-starter/hooks/guard-write.sh
@@ -44,7 +44,7 @@ _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) s
                    # continuation byte can be 0x5C or 0x22, so a cut cannot land inside a character at a
                    # quote or backslash edge. What this line is worth in SPEED depends on the platform --
                    # read the table in _json_unescape below before quoting a number for it.
-  local pre rest seg tail out bs
+  local pre rest seg w r n base=0 j=0 cl lim run=0 chunk C=4096 W=256; local -a acc=("")
   # Every "step past X" here is arithmetic on a length, never `${s#"$literal"}`. That shape reads like a
   # constant-time strip and is not one: bash retries the pattern at every prefix length, so stripping an
   # n-byte literal costs O(n^2). It was in this function twice, and both were measured:
@@ -58,27 +58,46 @@ _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) s
   #     against 0.002s for `${tail:${#seg}+1}` doing exactly the same thing.
   # `${1%%"$2"*}` still finds the FIRST occurrence -- the longest suffix that starts with the key starts at the
   # earliest one -- so a command containing the literal text `"command":"` still cannot relocate the parse.
-  # Output is byte-identical to the previous shape across a 27-case battery: escaped quotes, backslash runs
-  # before a quote, the key twice, the key appearing first as a value, glob metacharacters, UTF-8, no closing
-  # quote, empty input. Two deliberately broken twins -- one byte off in each offset -- prove it can tell.
+  # Stepping by length removed the quadratic strip, but each escaped quote still sliced and re-assigned the
+  # whole remainder, so an escape-dense command stayed k*n here as well (2.2s of the 6.8s described in
+  # _json_unescape below, on Git Bash). The walk is chunked the same way: the payload is read 4096 bytes at a
+  # time and every per-quote operation stays inside the chunk. One thing is carried across edges on purpose
+  # -- the length of the backslash run in front of a quote -- because that run can straddle a window or a
+  # chunk, and its parity is what decides whether the quote ends the value. Isolated, escape-dense 44030 B:
+  # 2.61s -> 0.41s on Git Bash 5.3.15, 0.93s -> 0.09s on macOS/bash 3.2.
+  # Output is byte-identical to the previous shape across 378 cases at four chunk/window sizes down to 7 and 1
+  # bytes, and that shape to the one before it across a 27-case battery (escaped quotes, backslash runs before
+  # a quote, the key twice, the key appearing first as a value, glob metacharacters, UTF-8, no closing quote,
+  # empty input). Broken twins -- the run not carried across a window, a byte skipped after a quote -- prove
+  # the battery sees both.
   pre="${1%%\"$2\"*}"                          # everything before the FIRST `"key"`
   [ "$pre" != "$1" ] || return 0               # key absent: emit nothing
   rest="${1:${#pre}+${#2}+2}"                  # past `"key"`
   seg="${rest%%\"*}"                           # skip `: "` up to the value's opening quote, when there is one
   [ "$seg" = "$rest" ] || rest="${rest:${#seg}+1}"
-  out=""; tail="$rest"
   # Walk to the closing quote that is NOT escaped. A `"` preceded by an odd number of backslashes is content.
+  n=${#rest}; chunk="${rest:0:C}"; cl=${#chunk}
   while :; do
-    seg="${tail%%\"*}"
-    [ "$seg" != "$tail" ] || { out="$out$seg"; break; }   # no closing quote at all: take the rest
-    out="$out$seg"
-    bs="${seg##*[!\\]}"                    # trailing backslash run ("" when the last char is not a backslash)
-    case "$seg" in *[!\\]*) ;; *) bs="$seg" ;; esac       # all-backslash segment: the run is the whole segment
-    if [ $(( ${#bs} % 2 )) -eq 1 ]; then out="$out\""; tail="${tail:${#seg}+1}"; else break; fi
+    lim=$((cl - j))
+    if [ "$lim" -le 0 ]; then
+      [ $((base + cl)) -lt "$n" ] || break                 # no closing quote at all: everything is already taken
+      base=$((base + j)); chunk="${rest:base:C}"; cl=${#chunk}; j=0; continue
+    fi
+    [ "$lim" -le "$W" ] || lim=$W
+    w="${chunk:j:lim}"
+    seg="${w%%\"*}"
+    if [ "$seg" = "$w" ]; then                             # no quote in view: take all of it, carry the run
+      acc+=("$w"); j=$((j+lim))
+      r="${w##*[!\\]}"; case "$w" in *[!\\]*) run=${#r} ;; *) run=$((run+${#w})) ;; esac
+      continue
+    fi
+    acc+=("$seg"); j=$((j+${#seg}+1))
+    r="${seg##*[!\\]}"; case "$seg" in *[!\\]*) run=${#r} ;; *) run=$((run+${#seg})) ;; esac
+    if [ $((run % 2)) -eq 1 ]; then acc+=("\""); run=0; else break; fi
   done
-  printf '%s' "$out"
+  local IFS=''; printf '%s' "${acc[*]}"
 }
-_json_unescape(){  # left-to-right, one whole run per escape; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
+_json_unescape(){  # left-to-right, a chunk at a time; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
   # This is the tier-3 path below -- the one a stock Windows install actually runs on. It used to walk ONE
   # CHARACTER at a time, which is O(n^2) twice over: `${s%"${s#?}"}` matches a pattern the length of the
   # entire remainder just to read one character, and `out="$out$c"` recopies the output for each one.
@@ -109,44 +128,68 @@ _json_unescape(){  # left-to-right, one whole run per escape; a two-pass sed wou
   #     alone would justify the line, and it costs nothing. `local` restores the previous locale on return
   #     -- verified on bash 3.2 and on Git Bash 5.3.15, not assumed.
   #
-  # Heaviest real payload (46815 B, 2813 escapes), whole hook end to end, with _json_slice fixed as well: 2.1s
-  # on macOS/bash 3.2. On Git Bash an escape-dense command of that shape (44080 B, 2755 escapes) takes 6.8s --
-  # 11% of the timeout, so slowness rather than a hole -- and what is left there is k*n in BOTH functions
-  # (slice 2.2s, unescape 3.1s): every escape rescans and recopies the remainder. A sparse 100 KB command is
-  # 1.6-2.1s there. These numbers do not travel, which is why each one names its machine.
-  # Output is byte-identical to the old function across a
-  # 31-case battery (escaped quotes, `\\\\`, a lone trailing backslash, a truncated `\\u`, Turkish, emoji), and
-  # tier 1 and tier 3 return the same verdict on 22 gate cases. A deliberately-broken twin of the new function
-  # proves the battery can tell the two apart.
-  local s="$1" out="" pre c h
+  # Then the cost moved rather than went away. With the per-character walk gone, each escape still sliced the
+  # whole REMAINDER -- `s="${s:${#pre}+1}"` -- so an escape-dense command stayed k*n: on Git Bash a 44080 B
+  # command with 2755 escapes took 6.8s, 11% of the timeout. The input is now touched only a chunk at a time
+  # (`${s:base:C}`, once per 4096 bytes) and every per-escape operation stays inside that chunk, so no escape
+  # pays for the length of the whole command. That is the change that matters: bounding only the lookahead,
+  # while still indexing the full string, was measured too and gave about 4x on both machines, against 6-12x
+  # for the chunked walk. Five bytes are held back at a chunk's end whenever more input follows, so a
+  # `\uXXXX` that starts in a chunk ends in it.
+  # The output goes into an array joined once, not a string recopied at every append, and `\n`/`\t` are
+  # written `$'\n'`/`$'\t'`, so this file carries no raw TAB for an editor or a copy to turn into spaces.
+  #
+  # Measured, isolated, previous shape -> this one:
+  #     macOS/bash 3.2   escape-dense 44030 B, 2590 escapes .. 1.44s -> 0.12s
+  #                      sparse 100014 B, 4 escapes ........... 0.09s -> 0.02s
+  #     Git Bash 5.3.15  escape-dense 44030 B, 2590 escapes .. 3.92s -> 0.54s
+  #     (LANG empty)     sparse 99997 B, 4 escapes ............ 0.49s -> 0.07s
+  # These numbers do not travel, which is why each one names its machine.
+  #
+  # Output is byte-identical to the previous shape across 478 cases, each run at four chunk/window sizes
+  # down to 7 and 1 bytes so that an edge falls every few bytes; that shape was itself byte-identical to
+  # the original character walk across a 31-case battery (escaped quotes, `\\`, a lone trailing backslash, a
+  # truncated `\u`, Turkish, emoji). Deliberately broken twins -- the 5-byte margin cut to 4, the backslash
+  # not stepped over -- prove the battery sees both edges, and tier 1 and tier 3 return the same verdict on
+  # the gate cases.
   local LC_ALL=C
+  local s="$1" pre w c h n base=0 j=0 cl lim chunk C=4096 W=256; local -a acc=("")
   case "$s" in *\\*) ;; *) printf '%s' "$s"; return 0 ;; esac   # no escapes: the common case pays nothing
+  n=${#s}; chunk="${s:0:C}"; cl=${#chunk}
   while :; do
-    pre="${s%%\\*}"                                     # the whole literal run before the next backslash
-    if [ "$pre" = "$s" ]; then out="$out$s"; break; fi   # no backslash left: the remainder is literal
-    out="$out$pre"; s="${s:${#pre}+1}"
-    if [ -z "$s" ]; then out="$out\\"; break; fi         # a lone trailing backslash stays literal, as before
-    c="${s:0:1}"; s="${s:1}"
+    lim=$((cl - j))
+    if [ $((base + cl)) -lt "$n" ]; then                  # more input after this chunk: hold 5 bytes back, so
+      lim=$((lim - 5))                                     # a `\uXXXX` that starts in a chunk also ends in it
+      if [ "$lim" -le 0 ]; then base=$((base + j)); chunk="${s:base:C}"; cl=${#chunk}; j=0; continue; fi
+    else
+      [ "$lim" -gt 0 ] || break
+    fi
+    [ "$lim" -le "$W" ] || lim=$W
+    w="${chunk:j:lim}"
+    pre="${w%%\\*}"                                        # the literal run before the next backslash in view
+    if [ "$pre" = "$w" ]; then acc+=("$w"); j=$((j+lim)); continue; fi
+    acc+=("$pre"); j=$((j+${#pre}+1))
+    if [ $((base + j)) -ge "$n" ]; then acc+=("\\"); break; fi   # a lone trailing backslash stays literal, as before
+    c="${chunk:j:1}"; j=$((j+1))
     case "$c" in
-      n) out="$out
-" ;;
-      t) out="$out	" ;;
+      n) acc+=($'\n') ;;
+      t) acc+=($'\t') ;;
       r) ;;
-      b|f) out="$out " ;;
-      u) if [ ${#s} -ge 4 ]; then h="${s:0:4}"; s="${s:4}"; else h=""; fi   # a short tail leaves s alone, as before
+      b|f) acc+=(" ") ;;
+      u) if [ $((n - base - j)) -ge 4 ]; then h="${chunk:j:4}"; j=$((j+4)); else h=""; fi   # a short tail is left alone, as before
          # A `\uXXXX` used to become a literal `?`. That is not a lossy nicety, it is a hole: `\u002e` is `.`,
          # so `\u002eclaude/hooks/guard-bash.sh` decoded to `?claude/…` and matched no gate pattern, while jq
          # decoded the same bytes to the real path — the two tiers disagreed on whether a payload was an
          # attack. Printable ASCII is decoded properly (builtin printf, no fork); anything else still becomes
          # `?`, which is only ever a display concern because this value is used for MATCHING, never to write.
          case "$h" in
-           00[2-7][0-9a-fA-F]) printf -v c "\\x${h#00}"; out="$out$c" ;;
-           *)                  out="$out?" ;;
+           00[2-7][0-9a-fA-F]) printf -v c "\\x${h#00}"; acc+=("$c") ;;
+           *)                  acc+=("?") ;;
          esac ;;
-      *) out="$out$c" ;;
+      *) acc+=("$c") ;;
     esac
   done
-  printf '%s' "$out"
+  local IFS=''; printf '%s' "${acc[*]}"
 }
 # ---- /CSK-JSON-PARSE -----------------------------------------------------------------------------------
 

--- a/plugin/hooks/commit-msg
+++ b/plugin/hooks/commit-msg
@@ -25,7 +25,16 @@ GITROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 
 HIT=0
 while IFS= read -r pat || [ -n "$pat" ]; do
-  case "$pat" in ''|\#*) continue;; esac
+  pat="${pat%$'\r'}"                        # tolerate a CRLF blocklist — pre-commit:176 has had this
+  case "$pat" in ''|\#*) continue;; esac    # since the gate was written; its twin here did not, and
+                                            # the message scan was the ONLY reader with no fallback:
+                                            # pre-commit never sees the message, so a co-author
+                                            # trailer had exactly one gate and it was blind. Verified
+                                            # on two machines: LF blocklist rejects (rc=1), the same
+                                            # blocklist saved CRLF accepts (rc=0). Reachable without
+                                            # trying: the kit writes no .gitattributes into a user's
+                                            # project, Git for Windows defaults core.autocrlf=true,
+                                            # and this file is meant to be edited by hand.
   if [ -n "$AL" ] && grep -qxF -- "$pat" "$AL"; then continue; fi
   if grep -iqE -- "$pat" "$MSG_FILE"; then
     echo "TRACE-SCANNER (message): forbidden expression -> '$pat' (§4.1)"

--- a/plugin/hooks/context-usage.sh
+++ b/plugin/hooks/context-usage.sh
@@ -130,14 +130,17 @@ fi
 # probe are the ones where a process is cheap. It runs once per turn, not once per record.
 HAVE_JQ=0
 if command -v jq >/dev/null 2>&1 && printf '{}' | jq -e . >/dev/null 2>&1; then HAVE_JQ=1; fi
-scan() {                                             # reads JSONL on stdin, prints the total (or nothing)
+# `scan` prints one number per matching record and the caller keeps the LAST — taken with `${x##*NL}`,
+# which is shell, where `| tail -1` was a process on a hook that runs before every prompt.
+last_line() { printf '%s' "${1##*$'\n'}"; }
+scan() {                                             # reads JSONL on stdin, prints one total per record
   if [ "$HAVE_JQ" = 1 ]; then
     jq -r 'select((.isSidechain // false) == false)
       | select(.type == "assistant")
       | select(.message.usage.cache_read_input_tokens != null)
       | (.message.usage.input_tokens
          + (.message.usage.cache_read_input_tokens // 0)
-         + (.message.usage.cache_creation_input_tokens // 0))' 2>/dev/null | tail -1
+         + (.message.usage.cache_creation_input_tokens // 0))' 2>/dev/null
   else
     # No jq: parse the JSONL line-by-line — same predicate, same number.
     awk '
@@ -162,9 +165,34 @@ scan() {                                             # reads JSONL on stdin, pri
 # work no matter how fat the lines are — the same 60MB case scans in ~12ms. A front-truncated partial first line
 # simply fails to match, and since we keep the LAST match that is harmless. Widen once (256 KiB covers even a
 # large subagent fan-out of small usage records), then a SIZE-GUARDED whole-file last resort.
+#
+# The partial first line has to go before the scan, and that is not a tidiness point — it is why the
+# window never worked. The comment above reasons that a front-truncated line "simply fails to match",
+# which is true of awk and FALSE of jq: measured, jq ABORTS the whole stream on a malformed first
+# record and prints nothing, while awk skips the line and carries on. So on every machine that has jq
+# — which is most of them, and every developer laptop — both windows returned empty and the hook fell
+# through to scanning the ENTIRE transcript, every single turn. On a 45 MB session that is 45 MB read
+# per prompt, and the byte bound that this block exists to enforce was never once in force.
+#
+# Dropped with `tail -n +2`, NOT with `${W#*$'\n'}`. The parameter expansion looks free and is a trap:
+# on a window with no newline in it — a malformed transcript that is one enormous line, which the
+# suite fixtures on purpose — bash walks every prefix looking for a match it will never find. Measured
+# on a 4 MiB single-line file: it had not finished after 20 seconds, and it hung the gate for 36
+# minutes before that was noticed. One streaming process is the cheap option here, not the expensive
+# one. Only correct to drop when the tail actually truncated, hence the size test.
+# The size is asked ONCE, up front, and it pays for itself: it is the only exact way to know whether
+# a tail truncated, and knowing that is what lets the window work at all. Comparing the captured
+# length against the window does NOT work — `$( )` strips the trailing newline, so the capture is
+# never quite the window size and the drop never fires.
+SZ="$(wc -c < "$TR" 2>/dev/null)"; SZ="${SZ//[!0-9]/}"; SZ="${SZ:-0}"
 TOTAL=""
 for B in 262144 4194304; do                         # 256 KiB, then 4 MiB
-  TOTAL="$(tail -c "$B" "$TR" | scan)"
+  if [ "$SZ" -gt "$B" ]; then
+    TOTAL="$(tail -c "$B" "$TR" | tail -n +2 | scan)"   # the tail cut a line in half; jq aborts on it
+  else
+    TOTAL="$(tail -c "$B" "$TR" | scan)"                # whole file: the first line is intact
+  fi
+  TOTAL="$(last_line "$TOTAL")"
   [ -n "$TOTAL" ] && break
 done
 if [ -z "$TOTAL" ]; then
@@ -174,9 +202,8 @@ if [ -z "$TOTAL" ]; then
   # it is small enough to finish well inside the timeout (180MB ~= 4.7s under awk, so 200MB is safe under 30s);
   # past the cap, fail OPEN. A missing 🔋 line is recoverable — the model answers "could not measure" — whereas a
   # timed-out hook is just discarded noise.
-  SZ="$(wc -c < "$TR" 2>/dev/null | tr -cd '0-9')"; SZ="${SZ:-0}"
   CAP="${CSK_CONTEXT_MAX_BYTES:-209715200}"         # 200 MiB; override per-repo
-  [ "${SZ:-0}" -le "$CAP" ] && TOTAL="$(scan < "$TR")"
+  [ "${SZ:-0}" -le "$CAP" ] && TOTAL="$(last_line "$(scan < "$TR")")"
 fi
 # Same split as the missing-transcript case above: a hook stays quiet and exits 0, a by-hand call explains
 # itself and exits non-zero. Exec-form hook commands carry no `|| true` to swallow a status, so anything that
@@ -189,12 +216,18 @@ fi
 
 # LC_ALL=C: force a '.' decimal separator regardless of locale (tr_TR etc. would emit '77,2' and could
 # mis-parse the percentage). Generation AND every comparison below run under C so they stay consistent.
-PCT="$(LC_ALL=C awk -v t="$TOTAL" -v w="$WINDOW" 'BEGIN{printf "%.1f", (t/w)*100}')"
-# The DISPLAYED percentage stays awk's — %.1f rounds, and shell arithmetic truncates, so replacing it would
-# quietly move the number a user reads. The COMPARISONS do not need it: the thresholds are whole numbers, so
-# the integer part decides them, exactly as session-guard.sh already argues for its own two. That removes two
-# awk spawns from a hook that runs on every single prompt, and awk is the most expensive process this kit
-# starts on Git Bash (measured: 57 ms idle, 404 ms under load, against 62 ms for a bare `true`).
+# Integer arithmetic, not awk, and it ROUNDS rather than truncates — which is the whole reason awk was
+# here. `(t*1000 + w/2) / w` is round-half-up on tenths; verified against awk's %.1f across the range
+# before the swap, not after. That removes the single most expensive process this hook starts on Git
+# Bash (measured there: 57 ms idle, 404 ms under load, against 62 ms for a bare `true`).
+PCT_T=$(( (TOTAL * 1000 + WINDOW / 2) / WINDOW ))
+PCT="$((PCT_T / 10)).$((PCT_T % 10))"
+# The COMPARISONS take the integer part: the thresholds are whole numbers, so nothing below needs the tenth,
+# exactly as session-guard.sh already argues for its own two. This paragraph used to end "the DISPLAYED
+# percentage stays awk's, because %.1f rounds and shell arithmetic truncates" — a true statement about the
+# obvious integer division, and the reason awk survived here for so long. It stopped being true one commit
+# ago: the expression above rounds. A comment that describes a tool the code no longer calls is worse than
+# no comment, because the next reader trusts it instead of the line.
 PCTI="${PCT%%.*}"; case "$PCTI" in ''|*[!0-9]*) PCTI=0 ;; esac
 if   [ "$PCTI" -lt 50 ]; then LEVEL="continue"
 elif [ "$PCTI" -lt 75 ]; then LEVEL="medium"

--- a/plugin/hooks/guard-bash.sh
+++ b/plugin/hooks/guard-bash.sh
@@ -70,7 +70,7 @@ _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) s
                    # continuation byte can be 0x5C or 0x22, so a cut cannot land inside a character at a
                    # quote or backslash edge. What this line is worth in SPEED depends on the platform --
                    # read the table in _json_unescape below before quoting a number for it.
-  local pre rest seg tail out bs
+  local pre rest seg w r n base=0 j=0 cl lim run=0 chunk C=4096 W=256; local -a acc=("")
   # Every "step past X" here is arithmetic on a length, never `${s#"$literal"}`. That shape reads like a
   # constant-time strip and is not one: bash retries the pattern at every prefix length, so stripping an
   # n-byte literal costs O(n^2). It was in this function twice, and both were measured:
@@ -84,27 +84,46 @@ _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) s
   #     against 0.002s for `${tail:${#seg}+1}` doing exactly the same thing.
   # `${1%%"$2"*}` still finds the FIRST occurrence -- the longest suffix that starts with the key starts at the
   # earliest one -- so a command containing the literal text `"command":"` still cannot relocate the parse.
-  # Output is byte-identical to the previous shape across a 27-case battery: escaped quotes, backslash runs
-  # before a quote, the key twice, the key appearing first as a value, glob metacharacters, UTF-8, no closing
-  # quote, empty input. Two deliberately broken twins -- one byte off in each offset -- prove it can tell.
+  # Stepping by length removed the quadratic strip, but each escaped quote still sliced and re-assigned the
+  # whole remainder, so an escape-dense command stayed k*n here as well (2.2s of the 6.8s described in
+  # _json_unescape below, on Git Bash). The walk is chunked the same way: the payload is read 4096 bytes at a
+  # time and every per-quote operation stays inside the chunk. One thing is carried across edges on purpose
+  # -- the length of the backslash run in front of a quote -- because that run can straddle a window or a
+  # chunk, and its parity is what decides whether the quote ends the value. Isolated, escape-dense 44030 B:
+  # 2.61s -> 0.41s on Git Bash 5.3.15, 0.93s -> 0.09s on macOS/bash 3.2.
+  # Output is byte-identical to the previous shape across 378 cases at four chunk/window sizes down to 7 and 1
+  # bytes, and that shape to the one before it across a 27-case battery (escaped quotes, backslash runs before
+  # a quote, the key twice, the key appearing first as a value, glob metacharacters, UTF-8, no closing quote,
+  # empty input). Broken twins -- the run not carried across a window, a byte skipped after a quote -- prove
+  # the battery sees both.
   pre="${1%%\"$2\"*}"                          # everything before the FIRST `"key"`
   [ "$pre" != "$1" ] || return 0               # key absent: emit nothing
   rest="${1:${#pre}+${#2}+2}"                  # past `"key"`
   seg="${rest%%\"*}"                           # skip `: "` up to the value's opening quote, when there is one
   [ "$seg" = "$rest" ] || rest="${rest:${#seg}+1}"
-  out=""; tail="$rest"
   # Walk to the closing quote that is NOT escaped. A `"` preceded by an odd number of backslashes is content.
+  n=${#rest}; chunk="${rest:0:C}"; cl=${#chunk}
   while :; do
-    seg="${tail%%\"*}"
-    [ "$seg" != "$tail" ] || { out="$out$seg"; break; }   # no closing quote at all: take the rest
-    out="$out$seg"
-    bs="${seg##*[!\\]}"                    # trailing backslash run ("" when the last char is not a backslash)
-    case "$seg" in *[!\\]*) ;; *) bs="$seg" ;; esac       # all-backslash segment: the run is the whole segment
-    if [ $(( ${#bs} % 2 )) -eq 1 ]; then out="$out\""; tail="${tail:${#seg}+1}"; else break; fi
+    lim=$((cl - j))
+    if [ "$lim" -le 0 ]; then
+      [ $((base + cl)) -lt "$n" ] || break                 # no closing quote at all: everything is already taken
+      base=$((base + j)); chunk="${rest:base:C}"; cl=${#chunk}; j=0; continue
+    fi
+    [ "$lim" -le "$W" ] || lim=$W
+    w="${chunk:j:lim}"
+    seg="${w%%\"*}"
+    if [ "$seg" = "$w" ]; then                             # no quote in view: take all of it, carry the run
+      acc+=("$w"); j=$((j+lim))
+      r="${w##*[!\\]}"; case "$w" in *[!\\]*) run=${#r} ;; *) run=$((run+${#w})) ;; esac
+      continue
+    fi
+    acc+=("$seg"); j=$((j+${#seg}+1))
+    r="${seg##*[!\\]}"; case "$seg" in *[!\\]*) run=${#r} ;; *) run=$((run+${#seg})) ;; esac
+    if [ $((run % 2)) -eq 1 ]; then acc+=("\""); run=0; else break; fi
   done
-  printf '%s' "$out"
+  local IFS=''; printf '%s' "${acc[*]}"
 }
-_json_unescape(){  # left-to-right, one whole run per escape; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
+_json_unescape(){  # left-to-right, a chunk at a time; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
   # This is the tier-3 path below -- the one a stock Windows install actually runs on. It used to walk ONE
   # CHARACTER at a time, which is O(n^2) twice over: `${s%"${s#?}"}` matches a pattern the length of the
   # entire remainder just to read one character, and `out="$out$c"` recopies the output for each one.
@@ -135,44 +154,68 @@ _json_unescape(){  # left-to-right, one whole run per escape; a two-pass sed wou
   #     alone would justify the line, and it costs nothing. `local` restores the previous locale on return
   #     -- verified on bash 3.2 and on Git Bash 5.3.15, not assumed.
   #
-  # Heaviest real payload (46815 B, 2813 escapes), whole hook end to end, with _json_slice fixed as well: 2.1s
-  # on macOS/bash 3.2. On Git Bash an escape-dense command of that shape (44080 B, 2755 escapes) takes 6.8s --
-  # 11% of the timeout, so slowness rather than a hole -- and what is left there is k*n in BOTH functions
-  # (slice 2.2s, unescape 3.1s): every escape rescans and recopies the remainder. A sparse 100 KB command is
-  # 1.6-2.1s there. These numbers do not travel, which is why each one names its machine.
-  # Output is byte-identical to the old function across a
-  # 31-case battery (escaped quotes, `\\\\`, a lone trailing backslash, a truncated `\\u`, Turkish, emoji), and
-  # tier 1 and tier 3 return the same verdict on 22 gate cases. A deliberately-broken twin of the new function
-  # proves the battery can tell the two apart.
-  local s="$1" out="" pre c h
+  # Then the cost moved rather than went away. With the per-character walk gone, each escape still sliced the
+  # whole REMAINDER -- `s="${s:${#pre}+1}"` -- so an escape-dense command stayed k*n: on Git Bash a 44080 B
+  # command with 2755 escapes took 6.8s, 11% of the timeout. The input is now touched only a chunk at a time
+  # (`${s:base:C}`, once per 4096 bytes) and every per-escape operation stays inside that chunk, so no escape
+  # pays for the length of the whole command. That is the change that matters: bounding only the lookahead,
+  # while still indexing the full string, was measured too and gave about 4x on both machines, against 6-12x
+  # for the chunked walk. Five bytes are held back at a chunk's end whenever more input follows, so a
+  # `\uXXXX` that starts in a chunk ends in it.
+  # The output goes into an array joined once, not a string recopied at every append, and `\n`/`\t` are
+  # written `$'\n'`/`$'\t'`, so this file carries no raw TAB for an editor or a copy to turn into spaces.
+  #
+  # Measured, isolated, previous shape -> this one:
+  #     macOS/bash 3.2   escape-dense 44030 B, 2590 escapes .. 1.44s -> 0.12s
+  #                      sparse 100014 B, 4 escapes ........... 0.09s -> 0.02s
+  #     Git Bash 5.3.15  escape-dense 44030 B, 2590 escapes .. 3.92s -> 0.54s
+  #     (LANG empty)     sparse 99997 B, 4 escapes ............ 0.49s -> 0.07s
+  # These numbers do not travel, which is why each one names its machine.
+  #
+  # Output is byte-identical to the previous shape across 478 cases, each run at four chunk/window sizes
+  # down to 7 and 1 bytes so that an edge falls every few bytes; that shape was itself byte-identical to
+  # the original character walk across a 31-case battery (escaped quotes, `\\`, a lone trailing backslash, a
+  # truncated `\u`, Turkish, emoji). Deliberately broken twins -- the 5-byte margin cut to 4, the backslash
+  # not stepped over -- prove the battery sees both edges, and tier 1 and tier 3 return the same verdict on
+  # the gate cases.
   local LC_ALL=C
+  local s="$1" pre w c h n base=0 j=0 cl lim chunk C=4096 W=256; local -a acc=("")
   case "$s" in *\\*) ;; *) printf '%s' "$s"; return 0 ;; esac   # no escapes: the common case pays nothing
+  n=${#s}; chunk="${s:0:C}"; cl=${#chunk}
   while :; do
-    pre="${s%%\\*}"                                     # the whole literal run before the next backslash
-    if [ "$pre" = "$s" ]; then out="$out$s"; break; fi   # no backslash left: the remainder is literal
-    out="$out$pre"; s="${s:${#pre}+1}"
-    if [ -z "$s" ]; then out="$out\\"; break; fi         # a lone trailing backslash stays literal, as before
-    c="${s:0:1}"; s="${s:1}"
+    lim=$((cl - j))
+    if [ $((base + cl)) -lt "$n" ]; then                  # more input after this chunk: hold 5 bytes back, so
+      lim=$((lim - 5))                                     # a `\uXXXX` that starts in a chunk also ends in it
+      if [ "$lim" -le 0 ]; then base=$((base + j)); chunk="${s:base:C}"; cl=${#chunk}; j=0; continue; fi
+    else
+      [ "$lim" -gt 0 ] || break
+    fi
+    [ "$lim" -le "$W" ] || lim=$W
+    w="${chunk:j:lim}"
+    pre="${w%%\\*}"                                        # the literal run before the next backslash in view
+    if [ "$pre" = "$w" ]; then acc+=("$w"); j=$((j+lim)); continue; fi
+    acc+=("$pre"); j=$((j+${#pre}+1))
+    if [ $((base + j)) -ge "$n" ]; then acc+=("\\"); break; fi   # a lone trailing backslash stays literal, as before
+    c="${chunk:j:1}"; j=$((j+1))
     case "$c" in
-      n) out="$out
-" ;;
-      t) out="$out	" ;;
+      n) acc+=($'\n') ;;
+      t) acc+=($'\t') ;;
       r) ;;
-      b|f) out="$out " ;;
-      u) if [ ${#s} -ge 4 ]; then h="${s:0:4}"; s="${s:4}"; else h=""; fi   # a short tail leaves s alone, as before
+      b|f) acc+=(" ") ;;
+      u) if [ $((n - base - j)) -ge 4 ]; then h="${chunk:j:4}"; j=$((j+4)); else h=""; fi   # a short tail is left alone, as before
          # A `\uXXXX` used to become a literal `?`. That is not a lossy nicety, it is a hole: `\u002e` is `.`,
          # so `\u002eclaude/hooks/guard-bash.sh` decoded to `?claude/…` and matched no gate pattern, while jq
          # decoded the same bytes to the real path — the two tiers disagreed on whether a payload was an
          # attack. Printable ASCII is decoded properly (builtin printf, no fork); anything else still becomes
          # `?`, which is only ever a display concern because this value is used for MATCHING, never to write.
          case "$h" in
-           00[2-7][0-9a-fA-F]) printf -v c "\\x${h#00}"; out="$out$c" ;;
-           *)                  out="$out?" ;;
+           00[2-7][0-9a-fA-F]) printf -v c "\\x${h#00}"; acc+=("$c") ;;
+           *)                  acc+=("?") ;;
          esac ;;
-      *) out="$out$c" ;;
+      *) acc+=("$c") ;;
     esac
   done
-  printf '%s' "$out"
+  local IFS=''; printf '%s' "${acc[*]}"
 }
 # ---- /CSK-JSON-PARSE -----------------------------------------------------------------------------------
 # A TIER IS CHOSEN ON WHETHER IT WORKS, NOT ON WHETHER IT EXISTS. `command -v` answers the wrong question, and

--- a/plugin/hooks/guard-bash.sh
+++ b/plugin/hooks/guard-bash.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # Claude Code PreToolUse (Bash) guard. PreToolUse runs in EVERY permission mode, including bypass.
-# stdin JSON: {"tool_name":"Bash","tool_input":{"command":"..."},"permission_mode":"default|acceptEdits|auto|dontAsk|plan|bypassPermissions"}
+# stdin JSON, one line, in the key order captured from Claude Code 2.1.267 (values abridged):
+#   {"session_id":…,"transcript_path":…,"cwd":…,"prompt_id":…,
+#    "permission_mode":"default|acceptEdits|auto|dontAsk|plan|bypassPermissions","effort":{…},
+#    "hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"...","description":"..."},"tool_use_id":…}
+#   This line used to show `permission_mode` AFTER `tool_input`. It was never a capture, and it was wrong. The
+#   fallback parser below does not depend on the order either way, because the order is not a documented contract.
 #
 # §4.5 destructive operations -> HARD BLOCK (exit 2). No key, no mode, no escape.
 #
@@ -53,19 +58,40 @@ INPUT="$(cat)"
 # no Windows user is on. smoke-test §7b pins the fallback branch itself for exactly that reason.
 #
 # The slice is pure parameter expansion: zero forks, so it is CHEAPER than the sed it replaces (Git Bash charges
-# 62-135 ms per process on a Windows 11 desktop, and this hook runs on every Bash call). `${INPUT#*"command"}` is shortest-match, so it
-# takes the FIRST occurrence — greedy matching would let a command containing the literal text `"command":"`
-# relocate the parse and walk a payload straight past the rules.
+# 62-135 ms per process on a Windows 11 desktop, and this hook runs on every Bash call). It must take the FIRST
+# occurrence of the key: greedy matching would let a command containing the literal text `"command":"` relocate
+# the parse and walk a payload straight past the rules. HOW it does that is documented inside _json_slice, next to
+# the code, and only there -- this paragraph named the expansion once, and went stale the day it changed.
 # ---- CSK-JSON-PARSE ------------------------------------------------------------------------------------
 _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) string value, "" if absent
-  local rest="${1#*\"$2\"}" seg tail out bs
-  local LC_ALL=C   # Same reason, and the same platform caveat, as in _json_unescape below -- read the table
-                   # there before quoting a speedup for this. Measured here: 1.56s -> 0.31s on a 46882 B
-                   # payload on macOS with a locale set; far less on Git Bash, and nothing where LANG is
-                   # empty. Output verified identical. Safe because no UTF-8 continuation byte can be 0x5C
-                   # or 0x22, so walking bytes cannot split a character across a quote or backslash edge.
-  [ "$rest" != "$1" ] || return 0          # key absent: emit nothing
-  rest="${rest#*\"}"                       # skip `: "` up to the value's opening quote
+  local LC_ALL=C   # FIRST, so every expansion below -- the key search included -- counts and cuts in bytes.
+                   # Lengths from ${#x} are used as offsets into ${y:n}; with the locale set before any of
+                   # them, the two never disagree about a unit. Walking bytes is safe because no UTF-8
+                   # continuation byte can be 0x5C or 0x22, so a cut cannot land inside a character at a
+                   # quote or backslash edge. What this line is worth in SPEED depends on the platform --
+                   # read the table in _json_unescape below before quoting a number for it.
+  local pre rest seg tail out bs
+  # Every "step past X" here is arithmetic on a length, never `${s#"$literal"}`. That shape reads like a
+  # constant-time strip and is not one: bash retries the pattern at every prefix length, so stripping an
+  # n-byte literal costs O(n^2). It was in this function twice, and both were measured:
+  #   * `${1#*"$2"}` found the key -- cheap when the key sits near the front, quadratic in the distance to it
+  #     otherwise. `permission_mode` behind a 100 KB command took 7.94s on Git Bash, 0.27s in front of it.
+  #     Captured from Claude Code 2.1.267, the real order puts `permission_mode` BEFORE `tool_input`, so on
+  #     that version this cost was not reachable -- this file's header had shown the opposite order, and was
+  #     wrong. The parse stays order-independent regardless: the order is not a documented contract, and the
+  #     payload is still moving (`effort` is absent from the field list recorded on 2.1.246).
+  #   * `${tail#"$seg"\"}` stepped past each escaped quote: 16.8s for a single 100 KB step on Git Bash,
+  #     against 0.002s for `${tail:${#seg}+1}` doing exactly the same thing.
+  # `${1%%"$2"*}` still finds the FIRST occurrence -- the longest suffix that starts with the key starts at the
+  # earliest one -- so a command containing the literal text `"command":"` still cannot relocate the parse.
+  # Output is byte-identical to the previous shape across a 27-case battery: escaped quotes, backslash runs
+  # before a quote, the key twice, the key appearing first as a value, glob metacharacters, UTF-8, no closing
+  # quote, empty input. Two deliberately broken twins -- one byte off in each offset -- prove it can tell.
+  pre="${1%%\"$2\"*}"                          # everything before the FIRST `"key"`
+  [ "$pre" != "$1" ] || return 0               # key absent: emit nothing
+  rest="${1:${#pre}+${#2}+2}"                  # past `"key"`
+  seg="${rest%%\"*}"                           # skip `: "` up to the value's opening quote, when there is one
+  [ "$seg" = "$rest" ] || rest="${rest:${#seg}+1}"
   out=""; tail="$rest"
   # Walk to the closing quote that is NOT escaped. A `"` preceded by an odd number of backslashes is content.
   while :; do
@@ -74,7 +100,7 @@ _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) s
     out="$out$seg"
     bs="${seg##*[!\\]}"                    # trailing backslash run ("" when the last char is not a backslash)
     case "$seg" in *[!\\]*) ;; *) bs="$seg" ;; esac       # all-backslash segment: the run is the whole segment
-    if [ $(( ${#bs} % 2 )) -eq 1 ]; then out="$out\""; tail="${tail#"$seg"\"}"; else break; fi
+    if [ $(( ${#bs} % 2 )) -eq 1 ]; then out="$out\""; tail="${tail:${#seg}+1}"; else break; fi
   done
   printf '%s' "$out"
 }
@@ -109,9 +135,12 @@ _json_unescape(){  # left-to-right, one whole run per escape; a two-pass sed wou
   #     alone would justify the line, and it costs nothing. `local` restores the previous locale on return
   #     -- verified on bash 3.2 and on Git Bash 5.3.15, not assumed.
   #
-  # Heaviest real payload (46815 B, 2813 escapes), whole hook end to end: 3.42s on macOS/bash 3.2. Windows is
-  # slower and is measured there separately -- these numbers do not travel, which is the whole reason the
-  # figures above name the machine they came from. Output is byte-identical to the old function across a
+  # Heaviest real payload (46815 B, 2813 escapes), whole hook end to end, with _json_slice fixed as well: 2.1s
+  # on macOS/bash 3.2. On Git Bash an escape-dense command of that shape (44080 B, 2755 escapes) takes 6.8s --
+  # 11% of the timeout, so slowness rather than a hole -- and what is left there is k*n in BOTH functions
+  # (slice 2.2s, unescape 3.1s): every escape rescans and recopies the remainder. A sparse 100 KB command is
+  # 1.6-2.1s there. These numbers do not travel, which is why each one names its machine.
+  # Output is byte-identical to the old function across a
   # 31-case battery (escaped quotes, `\\\\`, a lone trailing backslash, a truncated `\\u`, Turkish, emoji), and
   # tier 1 and tier 3 return the same verdict on 22 gate cases. A deliberately-broken twin of the new function
   # proves the battery can tell the two apart.

--- a/plugin/hooks/guard-bash.sh
+++ b/plugin/hooks/guard-bash.sh
@@ -59,6 +59,11 @@ INPUT="$(cat)"
 # ---- CSK-JSON-PARSE ------------------------------------------------------------------------------------
 _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) string value, "" if absent
   local rest="${1#*\"$2\"}" seg tail out bs
+  local LC_ALL=C   # Same reason, and the same platform caveat, as in _json_unescape below -- read the table
+                   # there before quoting a speedup for this. Measured here: 1.56s -> 0.31s on a 46882 B
+                   # payload on macOS with a locale set; far less on Git Bash, and nothing where LANG is
+                   # empty. Output verified identical. Safe because no UTF-8 continuation byte can be 0x5C
+                   # or 0x22, so walking bytes cannot split a character across a quote or backslash edge.
   [ "$rest" != "$1" ] || return 0          # key absent: emit nothing
   rest="${rest#*\"}"                       # skip `: "` up to the value's opening quote
   out=""; tail="$rest"
@@ -73,34 +78,70 @@ _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) s
   done
   printf '%s' "$out"
 }
-_json_unescape(){  # single left-to-right pass; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
-  local s="$1" out="" c h
+_json_unescape(){  # left-to-right, one whole run per escape; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
+  # This is the tier-3 path below -- the one a stock Windows install actually runs on. It used to walk ONE
+  # CHARACTER at a time, which is O(n^2) twice over: `${s%"${s#?}"}` matches a pattern the length of the
+  # entire remainder just to read one character, and `out="$out$c"` recopies the output for each one.
+  #
+  # That was not a comfort question. This hook's timeout is 60s -- set in settings.json, NOT Claude Code's
+  # default, and reading the default instead is how a first pass at this got the consequence wrong. A
+  # PreToolUse hook KILLED at its timeout emits no exit 2, so every rule below is simply skipped. Measured on
+  # the tier-3 path with jq and python3 both shadowed, the old shape crossed 60s at ~4.3 KB. And 4.3 KB is
+  # not exotic: across 6791 Bash calls in 280 real transcripts, 2.49% of commands are bigger, and the largest
+  # is 46815 B, which the old shape needed roughly 39 minutes to decode. One Bash call in forty walked past
+  # §4.4 and §4.5 entirely, silently, on every stock Windows desktop.
+  #
+  # Two changes, and their wins are NOT the same shape -- writing them down as one number was the mistake
+  # this comment exists to avoid repeating:
+  #   * Taking the whole run up to the next backslash in ONE expansion, and indexing with `${s:0:1}` instead
+  #     of matching a pattern, is 47x on a 4.4 KB payload. This one holds on every machine.
+  #   * `local LC_ALL=C` makes these expansions byte-oriented instead of re-decoding the string on every
+  #     substring operation. What that is WORTH depends on the platform, and putting a single number here
+  #     would have been wrong three separate ways -- it was written as "another 5x" twice before this:
+  #         macOS / bash 3.2, a locale set .................. 5x
+  #         Git Bash 5.3.15, a locale set ................... 1.23x   (measured on the OLD shape; the new one
+  #                                                                    touches the locale once per escape
+  #                                                                    rather than once per character, so its
+  #                                                                    ratio is smaller and unmeasured)
+  #         Git Bash, LANG empty -- what Claude Code starts .. nothing at all
+  #     So speed is not what keeps this line; CORRECTNESS is, and that half holds everywhere. `[0-9a-fA-F]`
+  #     below is a collation-defined range outside the C locale: on a tr_TR desktop it is not 0-9a-f. That
+  #     alone would justify the line, and it costs nothing. `local` restores the previous locale on return
+  #     -- verified on bash 3.2 and on Git Bash 5.3.15, not assumed.
+  #
+  # Heaviest real payload (46815 B, 2813 escapes), whole hook end to end: 3.42s on macOS/bash 3.2. Windows is
+  # slower and is measured there separately -- these numbers do not travel, which is the whole reason the
+  # figures above name the machine they came from. Output is byte-identical to the old function across a
+  # 31-case battery (escaped quotes, `\\\\`, a lone trailing backslash, a truncated `\\u`, Turkish, emoji), and
+  # tier 1 and tier 3 return the same verdict on 22 gate cases. A deliberately-broken twin of the new function
+  # proves the battery can tell the two apart.
+  local s="$1" out="" pre c h
+  local LC_ALL=C
   case "$s" in *\\*) ;; *) printf '%s' "$s"; return 0 ;; esac   # no escapes: the common case pays nothing
-  while [ -n "$s" ]; do
-    c="${s%"${s#?}"}"; s="${s#?}"
-    if [ "$c" = "\\" ] && [ -n "$s" ]; then
-      c="${s%"${s#?}"}"; s="${s#?}"
-      case "$c" in
-        n) out="$out
+  while :; do
+    pre="${s%%\\*}"                                     # the whole literal run before the next backslash
+    if [ "$pre" = "$s" ]; then out="$out$s"; break; fi   # no backslash left: the remainder is literal
+    out="$out$pre"; s="${s:${#pre}+1}"
+    if [ -z "$s" ]; then out="$out\\"; break; fi         # a lone trailing backslash stays literal, as before
+    c="${s:0:1}"; s="${s:1}"
+    case "$c" in
+      n) out="$out
 " ;;
-        t) out="$out	" ;;
-        r) ;;
-        b|f) out="$out " ;;
-        u) h="${s%"${s#????}"}"; s="${s#????}"
-           # A `\uXXXX` used to become a literal `?`. That is not a lossy nicety, it is a hole: `\u002e` is `.`,
-           # so `\u002eclaude/hooks/guard-bash.sh` decoded to `?claude/…` and matched no gate pattern, while jq
-           # decoded the same bytes to the real path — the two tiers disagreed on whether a payload was an
-           # attack. Printable ASCII is decoded properly (builtin printf, no fork); anything else still becomes
-           # `?`, which is only ever a display concern because this value is used for MATCHING, never to write.
-           case "$h" in
-             00[2-7][0-9a-fA-F]) printf -v c "\\x${h#00}"; out="$out$c" ;;
-             *)                  out="$out?" ;;
-           esac ;;
-        *) out="$out$c" ;;
-      esac
-    else
-      out="$out$c"
-    fi
+      t) out="$out	" ;;
+      r) ;;
+      b|f) out="$out " ;;
+      u) if [ ${#s} -ge 4 ]; then h="${s:0:4}"; s="${s:4}"; else h=""; fi   # a short tail leaves s alone, as before
+         # A `\uXXXX` used to become a literal `?`. That is not a lossy nicety, it is a hole: `\u002e` is `.`,
+         # so `\u002eclaude/hooks/guard-bash.sh` decoded to `?claude/…` and matched no gate pattern, while jq
+         # decoded the same bytes to the real path — the two tiers disagreed on whether a payload was an
+         # attack. Printable ASCII is decoded properly (builtin printf, no fork); anything else still becomes
+         # `?`, which is only ever a display concern because this value is used for MATCHING, never to write.
+         case "$h" in
+           00[2-7][0-9a-fA-F]) printf -v c "\\x${h#00}"; out="$out$c" ;;
+           *)                  out="$out?" ;;
+         esac ;;
+      *) out="$out$c" ;;
+    esac
   done
   printf '%s' "$out"
 }

--- a/plugin/hooks/guard-write.sh
+++ b/plugin/hooks/guard-write.sh
@@ -39,6 +39,11 @@ INPUT="$(cat)"
 # ---- CSK-JSON-PARSE ------------------------------------------------------------------------------------
 _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) string value, "" if absent
   local rest="${1#*\"$2\"}" seg tail out bs
+  local LC_ALL=C   # Same reason, and the same platform caveat, as in _json_unescape below -- read the table
+                   # there before quoting a speedup for this. Measured here: 1.56s -> 0.31s on a 46882 B
+                   # payload on macOS with a locale set; far less on Git Bash, and nothing where LANG is
+                   # empty. Output verified identical. Safe because no UTF-8 continuation byte can be 0x5C
+                   # or 0x22, so walking bytes cannot split a character across a quote or backslash edge.
   [ "$rest" != "$1" ] || return 0          # key absent: emit nothing
   rest="${rest#*\"}"                       # skip `: "` up to the value's opening quote
   out=""; tail="$rest"
@@ -53,34 +58,70 @@ _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) s
   done
   printf '%s' "$out"
 }
-_json_unescape(){  # single left-to-right pass; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
-  local s="$1" out="" c h
+_json_unescape(){  # left-to-right, one whole run per escape; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
+  # This is the tier-3 path below -- the one a stock Windows install actually runs on. It used to walk ONE
+  # CHARACTER at a time, which is O(n^2) twice over: `${s%"${s#?}"}` matches a pattern the length of the
+  # entire remainder just to read one character, and `out="$out$c"` recopies the output for each one.
+  #
+  # That was not a comfort question. This hook's timeout is 60s -- set in settings.json, NOT Claude Code's
+  # default, and reading the default instead is how a first pass at this got the consequence wrong. A
+  # PreToolUse hook KILLED at its timeout emits no exit 2, so every rule below is simply skipped. Measured on
+  # the tier-3 path with jq and python3 both shadowed, the old shape crossed 60s at ~4.3 KB. And 4.3 KB is
+  # not exotic: across 6791 Bash calls in 280 real transcripts, 2.49% of commands are bigger, and the largest
+  # is 46815 B, which the old shape needed roughly 39 minutes to decode. One Bash call in forty walked past
+  # §4.4 and §4.5 entirely, silently, on every stock Windows desktop.
+  #
+  # Two changes, and their wins are NOT the same shape -- writing them down as one number was the mistake
+  # this comment exists to avoid repeating:
+  #   * Taking the whole run up to the next backslash in ONE expansion, and indexing with `${s:0:1}` instead
+  #     of matching a pattern, is 47x on a 4.4 KB payload. This one holds on every machine.
+  #   * `local LC_ALL=C` makes these expansions byte-oriented instead of re-decoding the string on every
+  #     substring operation. What that is WORTH depends on the platform, and putting a single number here
+  #     would have been wrong three separate ways -- it was written as "another 5x" twice before this:
+  #         macOS / bash 3.2, a locale set .................. 5x
+  #         Git Bash 5.3.15, a locale set ................... 1.23x   (measured on the OLD shape; the new one
+  #                                                                    touches the locale once per escape
+  #                                                                    rather than once per character, so its
+  #                                                                    ratio is smaller and unmeasured)
+  #         Git Bash, LANG empty -- what Claude Code starts .. nothing at all
+  #     So speed is not what keeps this line; CORRECTNESS is, and that half holds everywhere. `[0-9a-fA-F]`
+  #     below is a collation-defined range outside the C locale: on a tr_TR desktop it is not 0-9a-f. That
+  #     alone would justify the line, and it costs nothing. `local` restores the previous locale on return
+  #     -- verified on bash 3.2 and on Git Bash 5.3.15, not assumed.
+  #
+  # Heaviest real payload (46815 B, 2813 escapes), whole hook end to end: 3.42s on macOS/bash 3.2. Windows is
+  # slower and is measured there separately -- these numbers do not travel, which is the whole reason the
+  # figures above name the machine they came from. Output is byte-identical to the old function across a
+  # 31-case battery (escaped quotes, `\\\\`, a lone trailing backslash, a truncated `\\u`, Turkish, emoji), and
+  # tier 1 and tier 3 return the same verdict on 22 gate cases. A deliberately-broken twin of the new function
+  # proves the battery can tell the two apart.
+  local s="$1" out="" pre c h
+  local LC_ALL=C
   case "$s" in *\\*) ;; *) printf '%s' "$s"; return 0 ;; esac   # no escapes: the common case pays nothing
-  while [ -n "$s" ]; do
-    c="${s%"${s#?}"}"; s="${s#?}"
-    if [ "$c" = "\\" ] && [ -n "$s" ]; then
-      c="${s%"${s#?}"}"; s="${s#?}"
-      case "$c" in
-        n) out="$out
+  while :; do
+    pre="${s%%\\*}"                                     # the whole literal run before the next backslash
+    if [ "$pre" = "$s" ]; then out="$out$s"; break; fi   # no backslash left: the remainder is literal
+    out="$out$pre"; s="${s:${#pre}+1}"
+    if [ -z "$s" ]; then out="$out\\"; break; fi         # a lone trailing backslash stays literal, as before
+    c="${s:0:1}"; s="${s:1}"
+    case "$c" in
+      n) out="$out
 " ;;
-        t) out="$out	" ;;
-        r) ;;
-        b|f) out="$out " ;;
-        u) h="${s%"${s#????}"}"; s="${s#????}"
-           # A `\uXXXX` used to become a literal `?`. That is not a lossy nicety, it is a hole: `\u002e` is `.`,
-           # so `\u002eclaude/hooks/guard-bash.sh` decoded to `?claude/…` and matched no gate pattern, while jq
-           # decoded the same bytes to the real path — the two tiers disagreed on whether a payload was an
-           # attack. Printable ASCII is decoded properly (builtin printf, no fork); anything else still becomes
-           # `?`, which is only ever a display concern because this value is used for MATCHING, never to write.
-           case "$h" in
-             00[2-7][0-9a-fA-F]) printf -v c "\\x${h#00}"; out="$out$c" ;;
-             *)                  out="$out?" ;;
-           esac ;;
-        *) out="$out$c" ;;
-      esac
-    else
-      out="$out$c"
-    fi
+      t) out="$out	" ;;
+      r) ;;
+      b|f) out="$out " ;;
+      u) if [ ${#s} -ge 4 ]; then h="${s:0:4}"; s="${s:4}"; else h=""; fi   # a short tail leaves s alone, as before
+         # A `\uXXXX` used to become a literal `?`. That is not a lossy nicety, it is a hole: `\u002e` is `.`,
+         # so `\u002eclaude/hooks/guard-bash.sh` decoded to `?claude/…` and matched no gate pattern, while jq
+         # decoded the same bytes to the real path — the two tiers disagreed on whether a payload was an
+         # attack. Printable ASCII is decoded properly (builtin printf, no fork); anything else still becomes
+         # `?`, which is only ever a display concern because this value is used for MATCHING, never to write.
+         case "$h" in
+           00[2-7][0-9a-fA-F]) printf -v c "\\x${h#00}"; out="$out$c" ;;
+           *)                  out="$out?" ;;
+         esac ;;
+      *) out="$out$c" ;;
+    esac
   done
   printf '%s' "$out"
 }

--- a/plugin/hooks/guard-write.sh
+++ b/plugin/hooks/guard-write.sh
@@ -38,14 +38,34 @@ INPUT="$(cat)"
 # safe while they cannot drift, so smoke-test pins these markers byte-identical rather than trusting it.
 # ---- CSK-JSON-PARSE ------------------------------------------------------------------------------------
 _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) string value, "" if absent
-  local rest="${1#*\"$2\"}" seg tail out bs
-  local LC_ALL=C   # Same reason, and the same platform caveat, as in _json_unescape below -- read the table
-                   # there before quoting a speedup for this. Measured here: 1.56s -> 0.31s on a 46882 B
-                   # payload on macOS with a locale set; far less on Git Bash, and nothing where LANG is
-                   # empty. Output verified identical. Safe because no UTF-8 continuation byte can be 0x5C
-                   # or 0x22, so walking bytes cannot split a character across a quote or backslash edge.
-  [ "$rest" != "$1" ] || return 0          # key absent: emit nothing
-  rest="${rest#*\"}"                       # skip `: "` up to the value's opening quote
+  local LC_ALL=C   # FIRST, so every expansion below -- the key search included -- counts and cuts in bytes.
+                   # Lengths from ${#x} are used as offsets into ${y:n}; with the locale set before any of
+                   # them, the two never disagree about a unit. Walking bytes is safe because no UTF-8
+                   # continuation byte can be 0x5C or 0x22, so a cut cannot land inside a character at a
+                   # quote or backslash edge. What this line is worth in SPEED depends on the platform --
+                   # read the table in _json_unescape below before quoting a number for it.
+  local pre rest seg tail out bs
+  # Every "step past X" here is arithmetic on a length, never `${s#"$literal"}`. That shape reads like a
+  # constant-time strip and is not one: bash retries the pattern at every prefix length, so stripping an
+  # n-byte literal costs O(n^2). It was in this function twice, and both were measured:
+  #   * `${1#*"$2"}` found the key -- cheap when the key sits near the front, quadratic in the distance to it
+  #     otherwise. `permission_mode` behind a 100 KB command took 7.94s on Git Bash, 0.27s in front of it.
+  #     Captured from Claude Code 2.1.267, the real order puts `permission_mode` BEFORE `tool_input`, so on
+  #     that version this cost was not reachable -- this file's header had shown the opposite order, and was
+  #     wrong. The parse stays order-independent regardless: the order is not a documented contract, and the
+  #     payload is still moving (`effort` is absent from the field list recorded on 2.1.246).
+  #   * `${tail#"$seg"\"}` stepped past each escaped quote: 16.8s for a single 100 KB step on Git Bash,
+  #     against 0.002s for `${tail:${#seg}+1}` doing exactly the same thing.
+  # `${1%%"$2"*}` still finds the FIRST occurrence -- the longest suffix that starts with the key starts at the
+  # earliest one -- so a command containing the literal text `"command":"` still cannot relocate the parse.
+  # Output is byte-identical to the previous shape across a 27-case battery: escaped quotes, backslash runs
+  # before a quote, the key twice, the key appearing first as a value, glob metacharacters, UTF-8, no closing
+  # quote, empty input. Two deliberately broken twins -- one byte off in each offset -- prove it can tell.
+  pre="${1%%\"$2\"*}"                          # everything before the FIRST `"key"`
+  [ "$pre" != "$1" ] || return 0               # key absent: emit nothing
+  rest="${1:${#pre}+${#2}+2}"                  # past `"key"`
+  seg="${rest%%\"*}"                           # skip `: "` up to the value's opening quote, when there is one
+  [ "$seg" = "$rest" ] || rest="${rest:${#seg}+1}"
   out=""; tail="$rest"
   # Walk to the closing quote that is NOT escaped. A `"` preceded by an odd number of backslashes is content.
   while :; do
@@ -54,7 +74,7 @@ _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) s
     out="$out$seg"
     bs="${seg##*[!\\]}"                    # trailing backslash run ("" when the last char is not a backslash)
     case "$seg" in *[!\\]*) ;; *) bs="$seg" ;; esac       # all-backslash segment: the run is the whole segment
-    if [ $(( ${#bs} % 2 )) -eq 1 ]; then out="$out\""; tail="${tail#"$seg"\"}"; else break; fi
+    if [ $(( ${#bs} % 2 )) -eq 1 ]; then out="$out\""; tail="${tail:${#seg}+1}"; else break; fi
   done
   printf '%s' "$out"
 }
@@ -89,9 +109,12 @@ _json_unescape(){  # left-to-right, one whole run per escape; a two-pass sed wou
   #     alone would justify the line, and it costs nothing. `local` restores the previous locale on return
   #     -- verified on bash 3.2 and on Git Bash 5.3.15, not assumed.
   #
-  # Heaviest real payload (46815 B, 2813 escapes), whole hook end to end: 3.42s on macOS/bash 3.2. Windows is
-  # slower and is measured there separately -- these numbers do not travel, which is the whole reason the
-  # figures above name the machine they came from. Output is byte-identical to the old function across a
+  # Heaviest real payload (46815 B, 2813 escapes), whole hook end to end, with _json_slice fixed as well: 2.1s
+  # on macOS/bash 3.2. On Git Bash an escape-dense command of that shape (44080 B, 2755 escapes) takes 6.8s --
+  # 11% of the timeout, so slowness rather than a hole -- and what is left there is k*n in BOTH functions
+  # (slice 2.2s, unescape 3.1s): every escape rescans and recopies the remainder. A sparse 100 KB command is
+  # 1.6-2.1s there. These numbers do not travel, which is why each one names its machine.
+  # Output is byte-identical to the old function across a
   # 31-case battery (escaped quotes, `\\\\`, a lone trailing backslash, a truncated `\\u`, Turkish, emoji), and
   # tier 1 and tier 3 return the same verdict on 22 gate cases. A deliberately-broken twin of the new function
   # proves the battery can tell the two apart.

--- a/plugin/hooks/guard-write.sh
+++ b/plugin/hooks/guard-write.sh
@@ -44,7 +44,7 @@ _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) s
                    # continuation byte can be 0x5C or 0x22, so a cut cannot land inside a character at a
                    # quote or backslash edge. What this line is worth in SPEED depends on the platform --
                    # read the table in _json_unescape below before quoting a number for it.
-  local pre rest seg tail out bs
+  local pre rest seg w r n base=0 j=0 cl lim run=0 chunk C=4096 W=256; local -a acc=("")
   # Every "step past X" here is arithmetic on a length, never `${s#"$literal"}`. That shape reads like a
   # constant-time strip and is not one: bash retries the pattern at every prefix length, so stripping an
   # n-byte literal costs O(n^2). It was in this function twice, and both were measured:
@@ -58,27 +58,46 @@ _json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) s
   #     against 0.002s for `${tail:${#seg}+1}` doing exactly the same thing.
   # `${1%%"$2"*}` still finds the FIRST occurrence -- the longest suffix that starts with the key starts at the
   # earliest one -- so a command containing the literal text `"command":"` still cannot relocate the parse.
-  # Output is byte-identical to the previous shape across a 27-case battery: escaped quotes, backslash runs
-  # before a quote, the key twice, the key appearing first as a value, glob metacharacters, UTF-8, no closing
-  # quote, empty input. Two deliberately broken twins -- one byte off in each offset -- prove it can tell.
+  # Stepping by length removed the quadratic strip, but each escaped quote still sliced and re-assigned the
+  # whole remainder, so an escape-dense command stayed k*n here as well (2.2s of the 6.8s described in
+  # _json_unescape below, on Git Bash). The walk is chunked the same way: the payload is read 4096 bytes at a
+  # time and every per-quote operation stays inside the chunk. One thing is carried across edges on purpose
+  # -- the length of the backslash run in front of a quote -- because that run can straddle a window or a
+  # chunk, and its parity is what decides whether the quote ends the value. Isolated, escape-dense 44030 B:
+  # 2.61s -> 0.41s on Git Bash 5.3.15, 0.93s -> 0.09s on macOS/bash 3.2.
+  # Output is byte-identical to the previous shape across 378 cases at four chunk/window sizes down to 7 and 1
+  # bytes, and that shape to the one before it across a 27-case battery (escaped quotes, backslash runs before
+  # a quote, the key twice, the key appearing first as a value, glob metacharacters, UTF-8, no closing quote,
+  # empty input). Broken twins -- the run not carried across a window, a byte skipped after a quote -- prove
+  # the battery sees both.
   pre="${1%%\"$2\"*}"                          # everything before the FIRST `"key"`
   [ "$pre" != "$1" ] || return 0               # key absent: emit nothing
   rest="${1:${#pre}+${#2}+2}"                  # past `"key"`
   seg="${rest%%\"*}"                           # skip `: "` up to the value's opening quote, when there is one
   [ "$seg" = "$rest" ] || rest="${rest:${#seg}+1}"
-  out=""; tail="$rest"
   # Walk to the closing quote that is NOT escaped. A `"` preceded by an odd number of backslashes is content.
+  n=${#rest}; chunk="${rest:0:C}"; cl=${#chunk}
   while :; do
-    seg="${tail%%\"*}"
-    [ "$seg" != "$tail" ] || { out="$out$seg"; break; }   # no closing quote at all: take the rest
-    out="$out$seg"
-    bs="${seg##*[!\\]}"                    # trailing backslash run ("" when the last char is not a backslash)
-    case "$seg" in *[!\\]*) ;; *) bs="$seg" ;; esac       # all-backslash segment: the run is the whole segment
-    if [ $(( ${#bs} % 2 )) -eq 1 ]; then out="$out\""; tail="${tail:${#seg}+1}"; else break; fi
+    lim=$((cl - j))
+    if [ "$lim" -le 0 ]; then
+      [ $((base + cl)) -lt "$n" ] || break                 # no closing quote at all: everything is already taken
+      base=$((base + j)); chunk="${rest:base:C}"; cl=${#chunk}; j=0; continue
+    fi
+    [ "$lim" -le "$W" ] || lim=$W
+    w="${chunk:j:lim}"
+    seg="${w%%\"*}"
+    if [ "$seg" = "$w" ]; then                             # no quote in view: take all of it, carry the run
+      acc+=("$w"); j=$((j+lim))
+      r="${w##*[!\\]}"; case "$w" in *[!\\]*) run=${#r} ;; *) run=$((run+${#w})) ;; esac
+      continue
+    fi
+    acc+=("$seg"); j=$((j+${#seg}+1))
+    r="${seg##*[!\\]}"; case "$seg" in *[!\\]*) run=${#r} ;; *) run=$((run+${#seg})) ;; esac
+    if [ $((run % 2)) -eq 1 ]; then acc+=("\""); run=0; else break; fi
   done
-  printf '%s' "$out"
+  local IFS=''; printf '%s' "${acc[*]}"
 }
-_json_unescape(){  # left-to-right, one whole run per escape; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
+_json_unescape(){  # left-to-right, a chunk at a time; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
   # This is the tier-3 path below -- the one a stock Windows install actually runs on. It used to walk ONE
   # CHARACTER at a time, which is O(n^2) twice over: `${s%"${s#?}"}` matches a pattern the length of the
   # entire remainder just to read one character, and `out="$out$c"` recopies the output for each one.
@@ -109,44 +128,68 @@ _json_unescape(){  # left-to-right, one whole run per escape; a two-pass sed wou
   #     alone would justify the line, and it costs nothing. `local` restores the previous locale on return
   #     -- verified on bash 3.2 and on Git Bash 5.3.15, not assumed.
   #
-  # Heaviest real payload (46815 B, 2813 escapes), whole hook end to end, with _json_slice fixed as well: 2.1s
-  # on macOS/bash 3.2. On Git Bash an escape-dense command of that shape (44080 B, 2755 escapes) takes 6.8s --
-  # 11% of the timeout, so slowness rather than a hole -- and what is left there is k*n in BOTH functions
-  # (slice 2.2s, unescape 3.1s): every escape rescans and recopies the remainder. A sparse 100 KB command is
-  # 1.6-2.1s there. These numbers do not travel, which is why each one names its machine.
-  # Output is byte-identical to the old function across a
-  # 31-case battery (escaped quotes, `\\\\`, a lone trailing backslash, a truncated `\\u`, Turkish, emoji), and
-  # tier 1 and tier 3 return the same verdict on 22 gate cases. A deliberately-broken twin of the new function
-  # proves the battery can tell the two apart.
-  local s="$1" out="" pre c h
+  # Then the cost moved rather than went away. With the per-character walk gone, each escape still sliced the
+  # whole REMAINDER -- `s="${s:${#pre}+1}"` -- so an escape-dense command stayed k*n: on Git Bash a 44080 B
+  # command with 2755 escapes took 6.8s, 11% of the timeout. The input is now touched only a chunk at a time
+  # (`${s:base:C}`, once per 4096 bytes) and every per-escape operation stays inside that chunk, so no escape
+  # pays for the length of the whole command. That is the change that matters: bounding only the lookahead,
+  # while still indexing the full string, was measured too and gave about 4x on both machines, against 6-12x
+  # for the chunked walk. Five bytes are held back at a chunk's end whenever more input follows, so a
+  # `\uXXXX` that starts in a chunk ends in it.
+  # The output goes into an array joined once, not a string recopied at every append, and `\n`/`\t` are
+  # written `$'\n'`/`$'\t'`, so this file carries no raw TAB for an editor or a copy to turn into spaces.
+  #
+  # Measured, isolated, previous shape -> this one:
+  #     macOS/bash 3.2   escape-dense 44030 B, 2590 escapes .. 1.44s -> 0.12s
+  #                      sparse 100014 B, 4 escapes ........... 0.09s -> 0.02s
+  #     Git Bash 5.3.15  escape-dense 44030 B, 2590 escapes .. 3.92s -> 0.54s
+  #     (LANG empty)     sparse 99997 B, 4 escapes ............ 0.49s -> 0.07s
+  # These numbers do not travel, which is why each one names its machine.
+  #
+  # Output is byte-identical to the previous shape across 478 cases, each run at four chunk/window sizes
+  # down to 7 and 1 bytes so that an edge falls every few bytes; that shape was itself byte-identical to
+  # the original character walk across a 31-case battery (escaped quotes, `\\`, a lone trailing backslash, a
+  # truncated `\u`, Turkish, emoji). Deliberately broken twins -- the 5-byte margin cut to 4, the backslash
+  # not stepped over -- prove the battery sees both edges, and tier 1 and tier 3 return the same verdict on
+  # the gate cases.
   local LC_ALL=C
+  local s="$1" pre w c h n base=0 j=0 cl lim chunk C=4096 W=256; local -a acc=("")
   case "$s" in *\\*) ;; *) printf '%s' "$s"; return 0 ;; esac   # no escapes: the common case pays nothing
+  n=${#s}; chunk="${s:0:C}"; cl=${#chunk}
   while :; do
-    pre="${s%%\\*}"                                     # the whole literal run before the next backslash
-    if [ "$pre" = "$s" ]; then out="$out$s"; break; fi   # no backslash left: the remainder is literal
-    out="$out$pre"; s="${s:${#pre}+1}"
-    if [ -z "$s" ]; then out="$out\\"; break; fi         # a lone trailing backslash stays literal, as before
-    c="${s:0:1}"; s="${s:1}"
+    lim=$((cl - j))
+    if [ $((base + cl)) -lt "$n" ]; then                  # more input after this chunk: hold 5 bytes back, so
+      lim=$((lim - 5))                                     # a `\uXXXX` that starts in a chunk also ends in it
+      if [ "$lim" -le 0 ]; then base=$((base + j)); chunk="${s:base:C}"; cl=${#chunk}; j=0; continue; fi
+    else
+      [ "$lim" -gt 0 ] || break
+    fi
+    [ "$lim" -le "$W" ] || lim=$W
+    w="${chunk:j:lim}"
+    pre="${w%%\\*}"                                        # the literal run before the next backslash in view
+    if [ "$pre" = "$w" ]; then acc+=("$w"); j=$((j+lim)); continue; fi
+    acc+=("$pre"); j=$((j+${#pre}+1))
+    if [ $((base + j)) -ge "$n" ]; then acc+=("\\"); break; fi   # a lone trailing backslash stays literal, as before
+    c="${chunk:j:1}"; j=$((j+1))
     case "$c" in
-      n) out="$out
-" ;;
-      t) out="$out	" ;;
+      n) acc+=($'\n') ;;
+      t) acc+=($'\t') ;;
       r) ;;
-      b|f) out="$out " ;;
-      u) if [ ${#s} -ge 4 ]; then h="${s:0:4}"; s="${s:4}"; else h=""; fi   # a short tail leaves s alone, as before
+      b|f) acc+=(" ") ;;
+      u) if [ $((n - base - j)) -ge 4 ]; then h="${chunk:j:4}"; j=$((j+4)); else h=""; fi   # a short tail is left alone, as before
          # A `\uXXXX` used to become a literal `?`. That is not a lossy nicety, it is a hole: `\u002e` is `.`,
          # so `\u002eclaude/hooks/guard-bash.sh` decoded to `?claude/…` and matched no gate pattern, while jq
          # decoded the same bytes to the real path — the two tiers disagreed on whether a payload was an
          # attack. Printable ASCII is decoded properly (builtin printf, no fork); anything else still becomes
          # `?`, which is only ever a display concern because this value is used for MATCHING, never to write.
          case "$h" in
-           00[2-7][0-9a-fA-F]) printf -v c "\\x${h#00}"; out="$out$c" ;;
-           *)                  out="$out?" ;;
+           00[2-7][0-9a-fA-F]) printf -v c "\\x${h#00}"; acc+=("$c") ;;
+           *)                  acc+=("?") ;;
          esac ;;
-      *) out="$out$c" ;;
+      *) acc+=("$c") ;;
     esac
   done
-  printf '%s' "$out"
+  local IFS=''; printf '%s' "${acc[*]}"
 }
 # ---- /CSK-JSON-PARSE -----------------------------------------------------------------------------------
 


### PR DESCRIPTION
Three fixes in the hooks that run on every turn. The first one is a security gate that
stopped existing on Windows; the other two are cost and a blind spot found alongside it.

## 1. The shared JSON parser was quadratic, and the 60s timeout made that a fail-open

`guard-bash.sh` and `guard-write.sh` fall back to a pure-bash JSON slice when neither jq
nor python3 works. That is not a degraded mode — it is the path a stock Windows install
actually runs, because Windows ships a python3 that resolves and cannot run.

That parser walked the payload one character at a time, and `${s%"${s#?}"}` matches a
pattern the length of the whole remainder to read a single character. The hook's timeout
is 60s, and a PreToolUse hook **killed** at its timeout emits no `exit 2` — so every
§4.4 and §4.5 rule below it is skipped.

Measured on the tier-3 path with jq and python3 both shadowed by a stub that resolves and
exits 49 (the Microsoft Store redirector's shape):

| payload | before |
|---|---|
| 4205 B | 59.0 s |
| **4405 B** | **67.9 s — past the timeout** |
| 4825 B | 89.6 s |

And that size is ordinary. Across **6791 Bash calls in 280 real transcripts**:

| | escaped command length |
|---|---|
| median | 333 B |
| p99 | 5723 B |
| max | 46815 B |
| **over 4300 B** | **169 calls — 2.49%** |

Roughly **one Bash call in forty** walked past the gate entirely, silently, on every stock
Windows desktop. The largest real payload needed about 39 minutes to decode.

**After:** that payload decodes in **3.28 s** end to end; the synthetic 4405 B case goes
67.9 s → 0.6 s. The jq tier is unchanged at 0.04 s. Zero-fork is intact — 193 `bash -x`
trace lines, no external tool call.

The two changes are recorded separately on purpose, because their wins are different
shapes: taking a whole run per expansion and indexing with `${s:0:1}` is **47x on every
platform**, while `local LC_ALL=C` ranges from 5x to nothing depending on the locale. So
the locale line is kept for **correctness**, not speed: `[0-9a-fA-F]` is a
collation-defined range outside the C locale.

### Why the decode can be trusted

- **31-case differential battery**, output byte-identical to the old function: escaped
  quotes, `\\`, a lone trailing backslash, a truncated `\u`, a Windows path, Turkish, emoji.
- The battery is **calibrated, not trusted**: a deliberately broken twin diverges on 2
  cases and a `\u`-branch marker on 3, so "no difference" is a demonstrated result rather
  than an untested one.
- **Tier 1 and tier 3 agree on 22 gate cases** — 15 Bash commands (§4.4 ask, §4.5 hard
  block, clean allows) and 7 Write paths.

## 2. The message trace scan was blind to a CRLF blocklist

`pre-commit` has stripped a trailing `\r` off every blocklist pattern since it was
written. `commit-msg` never did — and the two do not read the same thing. pre-commit
scans the diff; commit-msg scans the message, and nothing else reads the message. So an
authorship trailer had exactly one gate, and on Windows it was blind.

| state | result |
|---|---|
| blocklist saved LF | rejects, rc=1 |
| **same blocklist CRLF** | **accepted, rc=0** |
| clean message | accepts, rc=0 |

Reachable without trying: Git for Windows defaults `core.autocrlf=true`, the kit writes no
`.gitattributes` into a user's project, and this file is meant to be edited by hand.

Also pins `*.json` in the kit's own checkout. Measured on a Windows clone,
`plugin/.claude-plugin/plugin.json` and `plugin/hooks/hooks.json` report as modified
forever while `git hash-object` matches the index blob exactly — so the release workflow's
plugin sync gate reads a diff that is not one. `settings.json` is in the same set, and it
is the file that wires every hook.

## 3. The transcript byte window never took effect

`context-usage.sh` bounds its work to the last 256 KiB of the transcript. The bound never
held: `tail -c` cuts the first line in half, and while awk skips a malformed line, **jq
aborts the whole stream**. jq is the tier nearly every machine takes, so both windows
returned empty and the hook read the entire file every prompt — 45 MB per prompt on a 45 MB
session.

| | before | after |
|---|---|---|
| 45 MB transcript | 245 ms | **21 ms**, size-independent |
| forks | 14 | **7** |
| malformed single-line transcript | 36-minute hang | **0.15 s**, rc=1 |

Output byte-identical on six real transcripts. Process count is the metric rather than
wall-clock: a fork is ~1.7 ms here and 62–135 ms on Git Bash, so a wall-clock threshold
calibrated here would pass broken code and fail working code there.

## 4. The JSON slice was still quadratic, and the key order decided how much

With fix 1 in place the cost moved rather than disappeared. On Git Bash a 100 KB command still
took 30.8 s end to end — 19.7 s in `_json_slice(command)`, 7.9 s in
`_json_slice(permission_mode)`, 0.44 s in the unescape. Both slice costs are the same shape:
`${s#"$literal"}` retries the pattern at every prefix length, so it is O(n²). One 100 KB step
past an escaped quote took 16.8 s; `${tail:${#seg}+1}` does the same thing in 0.002 s.

The `permission_mode` half depends on key order, and the kit had written that order down two
ways: the header showed it after `tool_input`, every fixture put it before. A capture from
Claude Code 2.1.267 settles it:

```
session_id, transcript_path, cwd, prompt_id, permission_mode, effort,
hook_event_name, tool_name, tool_input, tool_use_id
```

`permission_mode` comes first, so that half was **not reachable** on that version and is not
claimed as a live defect. The header was wrong and now shows the captured order. The parse is
order-independent anyway, because the order is not a documented contract and the payload is
still changing (`effort` is new).

| Git Bash 5.3.15, LANG empty, whole hook | before | after |
|---|---|---|
| 46.8 KB, key after | 6.08 s | **1.01 s** |
| 100 KB, key before | 17.76 s | **1.58 s** |
| 100 KB, key after | 25.20 s | **2.09 s** |

Output is byte-identical to the previous function across 27 cases, with two calibration twins.
In 60 hook runs (15 commands × 2 modes × both orders), tier 1 and tier 3 agree on every verdict
and the order never changes one.

**Not fixed by this commit:** an escape-dense command (44 KB, 2755 escapes) still takes 6.8 s on
Git Bash. That is 11 % of the timeout, so slowness rather than a hole. The cause is that every
escape rescans and recopies the remainder, in both functions. Section 5 addresses it.

## 5. Walk the value a chunk at a time, so an escape stops paying for the whole command

After sections 1 and 4, an escape-dense command still took 6.8 s on Git Bash. Every escape sliced and
re-assigned the whole remainder of the value, in both functions: one full copy of the command per escape.
The value is now read 4096 bytes at a time, and every per-escape operation stays inside that chunk through
a 256-byte window. `_json_unescape` holds five bytes back at a chunk's end so a `\uXXXX` never splits.
`_json_slice` carries the backslash run in front of a quote across edges, because the run's parity decides
whether the quote ends the value.

| isolated, previous → this | unescape | slice |
|---|---|---|
| Git Bash, escape-dense 44 KB / 2590 escapes | 3.92 s → **0.54 s** | 2.61 s → **0.41 s** |
| Git Bash, sparse 100 KB / 4 escapes | 0.49 s → **0.07 s** | 0.35 s → **0.07 s** |
| macOS, escape-dense 44 KB | 1.44 s → **0.12 s** | 0.93 s → **0.09 s** |

End to end on macOS, stock-Windows tier: the real 46.8 KB command goes 2.07 s → **0.20 s**.

End to end on Git Bash 5.3.15 (LANG empty), whole hook, previous commit → this one, in one paired run:

| payload | captured key order | key late |
|---|---|---|
| escape-dense 44 KB | 5.36 s → **1.41 s** | 5.72 s → **1.51 s** |
| sparse 100 KB | 1.60 s → **0.93 s** | 1.70 s → **1.20 s** |

The parser is no longer the dominant cost there: the two functions account for about 0.95 s of the dense 1.41 s,
and the rest is the hook's own rules running over a 44 KB command. The 6.8 s quoted above for the dense shape comes
from an earlier, separate run; the table compares a paired one.

A bounded lookahead over the full string was built and measured as well. It gave about 4x on both machines,
against 6–12x for chunking. The expectation that this gap would be wider on Git Bash did not hold; chunking
is chosen because it wins on both platforms. A chunk size of 1024 is ~16 % faster on the dense shape and
~30 % slower on the sparse one; most commands fit in one 4096-byte chunk, so 4096 stays.

**Correctness.** The product text was compared with the previous commit on 940 cases, with its constants
rewritten to 7/1, 8/3 and 16/5 as well as 4096/256 so that an edge falls every few bytes: 3760 comparisons,
no difference. Twins derived from that text are caught at all three small sizes, and each on the class it
exists for: the margin cut to four separates on 48 comparisons, 40 of them a complete `\uXXXX` on a chunk
edge (a truncated `\u00` cannot tell the two apart), and on none of 14 negative cases where the `\u` branch never
runs; the run not carried across a window separates on 38.
On Git Bash 5.3.15 a battery of the same shape (468 cases, the same four sizes, twins and negative class) found no
difference in 5616 comparisons, with the margin twin separating in the `\uXXXX` class and never in the negative one.
In 60 hook runs across tiers, permission modes and both key orders the verdicts match the previous commit. On Git Bash, 97
verdict comparisons between the previous commit and this one (15 commands × 2 modes × 2 key orders, the new text's
own order independence, and 7 Write paths) found no difference, after first confirming that the gate still blocks
(`push --force`, rc 2) and still allows (`ls -la`, rc 0). That machine has no jq, so it covers tier 3 only.

## Gates

`VERIFY: 7 passed` · smoke 659 graded, 0 skipped · studio selfcheck 239/239 · ensure-node
38/38 · e2e 11/11 on both layouts. Plugin edition regenerated with `build-plugin.sh`, so
all four mirrored files are in sync.

## What is not measured here

Every figure names the machine it was taken on; these numbers do not travel. The 100 KB tail that
was open when this PR was opened is now measured on Git Bash (2.09 s, section 4). Tier 1 (jq) and tier 3
(pure bash) were compared against each other on macOS only; on Git Bash, where jq is absent, tier 3 was run on its
own. Windows CI carries jq, so there it exercises tier 1. Neither machine alone covers both tiers on Windows.
