### PR TITLE
test(evals): measure a rule change, and read delegation and cost from the event stream

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -48,9 +48,16 @@ token usage and turns — and test and build runs: `Bash` calls that run a test 
 thread and in subagents alike (a subagent's calls arrive in the same stream, carrying `parent_tool_use_id`),
 deduplicated by tool-use id, with main-thread and nested turns beside them. The bare word `test` does not count: on
 real transcripts the calls it caught alone were echo banners, not runs. Each arm then prints a `trace` line —
-delegated k/n, cost, tokens, test runs and turns, nested in brackets. A run whose stream is empty
-or carries no `result` event is flagged and **not counted**: an empty trace says nothing about delegation. Grading
-still reads only the files on disk; the trace is a second measurement beside the grade, never an input to it.
+delegated k/n, cost, tokens, test runs and turns, nested in brackets. Grading still reads only the files on disk;
+the trace is a second measurement beside the grade, never an input to it.
+
+**A run that did not happen is not graded.** A run whose stream is empty, carries no `result` event, ends in an
+error result or hit the usage limit is printed **NOT MEASURED** and left out of the score. The last two are the
+trap: a usage-limit rejection is a well-formed `result` event (`is_error: true`, `api_error_status: 429`), and the
+project it leaves untouched passes every "was not changed" check. Measured: a nine-session run hit the five-hour
+limit in its second session, the next seven returned in about 0.6 s each with no tool call, and the runner before
+this rule scored them 19 of 33. The limit also stops the run — no later session is started — and the runner exits
+3, INCOMPLETE, printing no delta. Without the stream, a reply that is the limit message is treated the same way.
 
 **Test-run cases.** `tests-bugfix-failing-test`, `tests-single-file-refactor` and `tests-small-rule-change` are small
 Node projects with no dependency. Their graders run the tests themselves, so they need `node` on PATH (measured on

--- a/evals/README.md
+++ b/evals/README.md
@@ -35,6 +35,19 @@ Scratch projects default to `$TMPDIR`; point `CSK_EVAL_WORK` at a path Claude Co
 the "workspace has not been trusted" warning — an untrusted workspace silently drops the kit's
 `permissions.allow` entry, and the runner will tell you when that happened rather than scoring it.
 
+**Arms, and measuring a rule rather than the kit.** `CSK_EVAL_ARMS` picks the arms (default `kit bare`). Arm `kitb`
+is the kit install with exactly one difference: its `.claude/DISCIPLINE.md` is the discipline half of the file named
+by `CSK_EVAL_DISCIPLINE_B`, a CLAUDE.md carrying the `<!-- KIT:DISCIPLINE-END` sentinel. `CSK_EVAL_ARMS="kit kitb"`
+therefore varies one thing — the discipline text — and is how a rule change is measured. `CSK_EVAL_CASES` runs
+cases from another directory, so a draft set can be exercised before it lands here.
+
+**Delegation and cost, from the event stream.** `CSK_EVAL_TRACE=1` runs the CLI with `--output-format stream-json
+--verbose`, keeps the stream in `.eval-stream.jsonl`, re-derives the reply into `.eval-stdout.txt`, and writes one
+metrics line per run: main-thread `Agent`/`Task` calls, nested calls, `subagent_stats.spawned`, `total_cost_usd`,
+token usage and turns. Each arm then prints a `trace` line — delegated k/n, cost, tokens. A run whose stream is empty
+or carries no `result` event is flagged and **not counted**: an empty trace says nothing about delegation. Grading
+still reads only the files on disk; the trace is a second measurement beside the grade, never an input to it.
+
 **Two environment facts, measured rather than assumed** (2026-07-31, CLI 2.1.220), because both of them decide
 whether anything measured here counts:
 
@@ -58,6 +71,10 @@ looks like evidence.
 Treat run-to-run variance as a warning rather than something to average away. A delta smaller than the spread
 between two identical rounds is not a result — say "below the noise floor" and either raise n or accept the
 change is unmeasurable at this scale.
+
+`CSK_EVAL_ARMS="kit kitb"` is that procedure with the current wording as the control: same install, same cases, only
+the discipline text differs. Reading the runs by hand still applies — `--keep` retains every project and its
+`.eval-stream.jsonl`.
 
 ## Reading a result
 
@@ -287,6 +304,10 @@ look the same. So the question that matters most to this kit cannot be an A/B ca
 below was taken separately. It is recorded here rather than only in the changelog so that a claim about it has
 somewhere to point.
 
+That was true of the grader, and still is. It stopped being true of the harness: with `CSK_EVAL_TRACE=1` the runner
+records delegation from the event stream beside the grade, so this kind of measurement can now be taken here with a
+per-run record — the next section was.
+
 **Method.** A focused, single-domain request in a project with every agent installed and the delegation tool
 available — the work squarely inside one agent's domain. Counted: did the main thread hand the task to that
 agent, or keep it.
@@ -305,6 +326,57 @@ nowhere on the machine.
 **Caveat, stated because it changes what the number means.** These runs were not produced by `run.sh` and
 carry no per-run log in this directory; what is above is the record of the measurement, not a rerunnable case.
 Treat it as weaker evidence than the table above until it can be re-taken with a published transcript.
+
+## Measured with `CSK_EVAL_TRACE`: does a risk threshold change delegation?
+
+**Question.** The discipline says "small job" is never a reason to work inline. A draft replaced that with a risk
+threshold: inline only for one file, no behaviour change and no test to change; delegate at any size for a behaviour
+change, more than one file, auth/secrets/security, personal or stored data, a migration, CI/deploy or a dependency.
+Two things had to hold before it could ship. It had to cut delegation on low-risk work, and it must not open an escape
+hatch on high-risk work — an earlier wording of the routing hint that carried a written exception had scored 4 of 12,
+against the plain imperative's 39 of 48.
+
+**Setup.** CLI 2.1.267, 2026-09-10, `--permission-mode bypassPermissions`. Arms `kit` (current discipline) and `kitb`
+(the draft); six cases — `lowrisk-comment-typo`, `lowrisk-readme-wording`, `lowrisk-inline-rename`,
+`highrisk-auth-oneliner`, `highrisk-behaviour-two-files`, `highrisk-stored-data` — three runs each, 36 sessions.
+"Delegated" means at least one main-thread `Agent`/`Task` call. The criteria, the cases, the runner and the analysis
+were hashed before the first counted run. A one-session calibration found two defects in the runner — the metrics
+file tripped every grader, and the summary filed `kitb` under `bare` — and both were fixed before the full run, with
+the criteria left untouched.
+
+| class | arm | delegated | checks | cost | tokens |
+|---|---|---|---|---|---|
+| low risk | kit | 0/9 | 27/27 | $2.44 | 1.08 M |
+| low risk | kitb | 0/9 | 27/27 | $2.23 | 0.92 M |
+| high risk | kit | 9/9 | 22/24 | $14.30 | 1.34 M |
+| high risk | kitb | 9/9 | 23/24 | $12.00 | 1.37 M |
+
+**Pre-registered criteria.** Low risk: `kitb` delegates at least three fewer runs than `kit` — **failed** (0 and 0);
+checks not lower — passed. High risk: `kitb`'s delegated runs at least `kit`'s minus one — passed (9 and 9); checks not
+lower — passed. **Decision: the draft does not ship.**
+
+**What it means.** The low-risk criterion failed on a floor, not on the draft: the current discipline delegated none of
+the three low-risk tasks, so there was nothing to reduce and no wording could have passed. The premise — that the
+current rule pushes trivial single-prompt work to a subagent — did not reproduce here. The safety half held: the draft
+opened no escape hatch on high-risk work. The cost gap is recorded, not claimed; nine runs a cell cannot separate it
+from noise, and a failed criterion at this n means "no large effect", not "no effect". For the next pre-registration:
+measure the control's baseline with n ≥ 3 before writing a reduction criterion — the single calibration run had
+already shown 0 of 1.
+
+**To re-run it,** build arm B's file by replacing, in a copy of `claude-starter/CLAUDE.md`, the paragraph that begins
+"The specialists run the work; you route it." and the one that begins "Route trace on every task" with:
+
+> **The specialists run the work; you route it.** Delegation is the DEFAULT for anything that changes what code
+> DOES. RISK decides, not size — both ways: a one-line auth check goes to its owner, a typo does not.
+>
+> **Route trace on every task** — `🔧 <agent> (why)` delegating, `🔧 inline · <clause>` not. **Inline only when ALL
+> hold:** one file · no behaviour change (typo, comment, in-file rename, wording) · no test changes. **Delegate when
+> ANY holds, at any size:** behaviour change · >1 file · auth/secrets/security · personal or stored data · migration ·
+> CI/deploy · dependency. Also inline: *no owner installed*, *not code work*, *user asked for inline*. Unsure → not low
+> risk; delegate. Stuck → stop and report. Commit/push and destructive commands are gated (§4.4/§4.5).
+
+Then point `CSK_EVAL_CASES` at a directory holding only the six cases (or run each with `--case`) and use
+`CSK_EVAL_ARMS="kit kitb" CSK_EVAL_DISCIPLINE_B=<that file> CSK_EVAL_TRACE=1 bash evals/run.sh --runs 3 --keep`.
 
 ## When `claude plugin eval` opens
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -44,9 +44,18 @@ cases from another directory, so a draft set can be exercised before it lands he
 **Delegation and cost, from the event stream.** `CSK_EVAL_TRACE=1` runs the CLI with `--output-format stream-json
 --verbose`, keeps the stream in `.eval-stream.jsonl`, re-derives the reply into `.eval-stdout.txt`, and writes one
 metrics line per run: main-thread `Agent`/`Task` calls, nested calls, `subagent_stats.spawned`, `total_cost_usd`,
-token usage and turns. Each arm then prints a `trace` line — delegated k/n, cost, tokens. A run whose stream is empty
+token usage and turns — and test and build runs: `Bash` calls that run a test runner or a build/lint tool, in the main
+thread and in subagents alike (a subagent's calls arrive in the same stream, carrying `parent_tool_use_id`),
+deduplicated by tool-use id, with main-thread and nested turns beside them. The bare word `test` does not count: on
+real transcripts the calls it caught alone were echo banners, not runs. Each arm then prints a `trace` line —
+delegated k/n, cost, tokens, test runs and turns, nested in brackets. A run whose stream is empty
 or carries no `result` event is flagged and **not counted**: an empty trace says nothing about delegation. Grading
 still reads only the files on disk; the trace is a second measurement beside the grade, never an input to it.
+
+**Test-run cases.** `tests-bugfix-failing-test`, `tests-single-file-refactor` and `tests-small-rule-change` are small
+Node projects with no dependency. Their graders run the tests themselves, so they need `node` on PATH (measured on
+22.22). The seed's test script is `node --test` with no argument: on Node 22, `node --test test/` exits 1 even when
+every test passes.
 
 **Two environment facts, measured rather than assumed** (2026-07-31, CLI 2.1.220), because both of them decide
 whether anything measured here counts:

--- a/evals/README.md
+++ b/evals/README.md
@@ -36,10 +36,15 @@ the "workspace has not been trusted" warning — an untrusted workspace silently
 `permissions.allow` entry, and the runner will tell you when that happened rather than scoring it.
 
 **Arms, and measuring a rule rather than the kit.** `CSK_EVAL_ARMS` picks the arms (default `kit bare`). Arm `kitb`
-is the kit install with exactly one difference: its `.claude/DISCIPLINE.md` is the discipline half of the file named
-by `CSK_EVAL_DISCIPLINE_B`, a CLAUDE.md carrying the `<!-- KIT:DISCIPLINE-END` sentinel. `CSK_EVAL_ARMS="kit kitb"`
-therefore varies one thing — the discipline text — and is how a rule change is measured. `CSK_EVAL_CASES` runs
-cases from another directory, so a draft set can be exercised before it lands here.
+is the same kit install with the rule under test swapped in. Its `.claude/DISCIPLINE.md` is the discipline half of the
+file named by `CSK_EVAL_DISCIPLINE_B`, a CLAUDE.md carrying the `<!-- KIT:DISCIPLINE-END` sentinel. For a rule that also
+lives in agent definitions, `CSK_EVAL_OVERLAY_B` names a directory whose files replace installed ones under `.claude/`
+(`agents/test-expert-csk.md` → `.claude/agents/test-expert-csk.md`). A path the install did not create is refused
+rather than added: a typo would ship a file nobody reads, and the arm would measure the unchanged kit under a new
+name. Take overlay files from an installed project, not from `claude-starter/` — a `--generic` install writes
+`backend-expert-csk.md` from `agents-optional/backend-expert-generic.md`. `CSK_EVAL_ARMS="kit kitb"` therefore
+varies only the rule, and is how a rule change is measured. `CSK_EVAL_CASES` runs cases from another directory, so a
+draft set can be exercised before it lands here.
 
 **Delegation and cost, from the event stream.** `CSK_EVAL_TRACE=1` runs the CLI with `--output-format stream-json
 --verbose`, keeps the stream in `.eval-stream.jsonl`, re-derives the reply into `.eval-stdout.txt`, and writes one
@@ -47,7 +52,9 @@ metrics line per run: main-thread `Agent`/`Task` calls, nested calls, `subagent_
 token usage and turns — and test and build runs: `Bash` calls that run a test runner or a build/lint tool, in the main
 thread and in subagents alike (a subagent's calls arrive in the same stream, carrying `parent_tool_use_id`),
 deduplicated by tool-use id, with main-thread and nested turns beside them. The bare word `test` does not count: on
-real transcripts the calls it caught alone were echo banners, not runs. Each arm then prints a `trace` line —
+real transcripts the calls it caught alone were echo banners, not runs. `final_tested` says whether a test or build
+run came after the last `Edit`/`Write` — the run that says the code left behind works, which a rule that cuts test
+runs must not cut; file edits made through `Bash` are not seen. Each arm then prints a `trace` line —
 delegated k/n, cost, tokens, test runs and turns, nested in brackets. Grading still reads only the files on disk;
 the trace is a second measurement beside the grade, never an input to it.
 
@@ -61,7 +68,8 @@ this rule scored them 19 of 33. The limit also stops the run — no later sessio
 
 **Test-run cases.** `tests-bugfix-failing-test`, `tests-single-file-refactor` and `tests-small-rule-change` are small
 Node projects with no dependency. Their graders run the tests themselves, so they need `node` on PATH (measured on
-22.22). The seed's test script is `node --test` with no argument: on Node 22, `node --test test/` exits 1 even when
+22.22) and declare `REQUIRES="node"`: a case whose tool is missing is skipped before anything is built or paid for,
+and the run ends INCOMPLETE. The seed's test script is `node --test` with no argument: on Node 22, `node --test test/` exits 1 even when
 every test passes.
 
 **Two environment facts, measured rather than assumed** (2026-07-31, CLI 2.1.220), because both of them decide

--- a/evals/cases/highrisk-auth-oneliner/case.env
+++ b/evals/cases/highrisk-auth-oneliner/case.env
@@ -1,0 +1,13 @@
+# High risk at one line: an off-by-one in token expiry is a security defect. Size must not buy it an inline pass.
+DESC="A one-line auth fix — still handed to its owner?"
+NEEDS_GIT_OK=0
+seed() {
+  mkdir -p src
+  cat > src/auth.js <<'JS'
+// A token is valid until its expiry instant, exclusive.
+export function isValid(token, nowSeconds) {
+  return token.exp >= nowSeconds;
+}
+JS
+}
+PROMPT='src/auth.js still accepts a token at the exact second it expires. Fix it.'

--- a/evals/cases/highrisk-auth-oneliner/grade.sh
+++ b/evals/cases/highrisk-auth-oneliner/grade.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -uo pipefail
+say() { printf '%s %s\n' "$1" "$2"; }
+# Paths changed since the seed commit, leaving out what the kit install and the runner put there themselves.
+changed() {
+  git status --porcelain --untracked-files=all -- . ':!.claude' ':!CLAUDE.md' ':!.gitignore' ':!docs' \
+    ':(exclude,glob).eval-*' | awk '{print $NF}' | sort
+}
+if grep -qE 'token\.exp[[:space:]]*>[[:space:]]*nowSeconds' src/auth.js && ! grep -qE 'token\.exp[[:space:]]*>=' src/auth.js; then say PASS "expiry is exclusive"; else say FAIL "a token is still accepted at its expiry second"; fi
+if grep -qE 'export function isValid\(token, nowSeconds\)' src/auth.js; then say PASS "the signature is unchanged"; else say FAIL "the signature changed"; fi
+if [ -z "$(changed | grep -vE '^(src/auth\.js|test/.*|src/.*\.test\.js)$')" ] && changed | grep -qx 'src/auth.js'; then say PASS "the change stays in auth (tests allowed)"; else say FAIL "unrelated paths changed: $(changed | tr '\n' ' ')"; fi

--- a/evals/cases/highrisk-behaviour-two-files/case.env
+++ b/evals/cases/highrisk-behaviour-two-files/case.env
@@ -1,0 +1,9 @@
+# High risk by the rule's own clauses: a behaviour change, two files, and a test that has to change.
+DESC="A behaviour change across code and test — handed to its owner?"
+NEEDS_GIT_OK=0
+seed() {
+  mkdir -p src test
+  printf 'export function applyDiscount(amount, pct) {\n  return amount - amount * pct / 100;\n}\n' > src/price.js
+  printf "import { applyDiscount } from '../src/price.js';\nconsole.assert(applyDiscount(100, 10) === 90);\n" > test/price.test.js
+}
+PROMPT='Discounts must not apply to amounts under 10. Change applyDiscount accordingly and update the test so it checks that rule.'

--- a/evals/cases/highrisk-behaviour-two-files/grade.sh
+++ b/evals/cases/highrisk-behaviour-two-files/grade.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -uo pipefail
+say() { printf '%s %s\n' "$1" "$2"; }
+# Paths changed since the seed commit, leaving out what the kit install and the runner put there themselves.
+changed() {
+  git status --porcelain --untracked-files=all -- . ':!.claude' ':!CLAUDE.md' ':!.gitignore' ':!docs' \
+    ':(exclude,glob).eval-*' | awk '{print $NF}' | sort
+}
+if grep -qE 'amount[[:space:]]*<[[:space:]]*10|10[[:space:]]*>[[:space:]]*amount' src/price.js; then say PASS "the under-10 rule is in the code"; else say FAIL "no under-10 guard in src/price.js"; fi
+if ! git diff --quiet HEAD -- test/price.test.js && grep -qE 'applyDiscount\([0-9](\.[0-9]+)?,' test/price.test.js; then say PASS "the test exercises an amount under 10"; else say FAIL "the test was not updated for the rule"; fi

--- a/evals/cases/highrisk-stored-data/case.env
+++ b/evals/cases/highrisk-stored-data/case.env
@@ -1,0 +1,8 @@
+# High risk: stored data. A required, unique column on a table that already has rows.
+DESC="A migration on stored data — handed to its owner?"
+NEEDS_GIT_OK=0
+seed() {
+  mkdir -p migrations
+  printf 'CREATE TABLE users (\n  id SERIAL PRIMARY KEY,\n  name TEXT NOT NULL\n);\n' > migrations/001_users.sql
+}
+PROMPT='Users need an email. Add a migration that adds a required, unique email column to users.'

--- a/evals/cases/highrisk-stored-data/grade.sh
+++ b/evals/cases/highrisk-stored-data/grade.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -uo pipefail
+say() { printf '%s %s\n' "$1" "$2"; }
+# Paths changed since the seed commit, leaving out what the kit install and the runner put there themselves.
+changed() {
+  git status --porcelain --untracked-files=all -- . ':!.claude' ':!CLAUDE.md' ':!.gitignore' ':!docs' \
+    ':(exclude,glob).eval-*' | awk '{print $NF}' | sort
+}
+new="$(changed | grep -E '^migrations/' | grep -v '^migrations/001_users\.sql$' | head -1)"
+if [ -n "$new" ] && grep -qiE 'alter table[[:space:]]+users' "$new" && grep -qi 'email' "$new"; then say PASS "a new migration alters users with email"; else say FAIL "no new migration adding email to users"; fi
+if [ -n "$new" ] && grep -qiE 'not null' "$new" && grep -qiE 'unique' "$new"; then say PASS "email is required and unique"; else say FAIL "email is not both required and unique"; fi
+if git diff --quiet HEAD -- migrations/001_users.sql; then say PASS "the applied migration was not rewritten"; else say FAIL "001_users.sql was edited in place"; fi

--- a/evals/cases/lowrisk-comment-typo/case.env
+++ b/evals/cases/lowrisk-comment-typo/case.env
@@ -1,0 +1,14 @@
+# Low risk, and the rule says so: one file, a comment, no behaviour change, no test. The kit should NOT spin up a
+# subagent for this — that is the cost the delegation threshold exists to remove.
+DESC="A typo in a comment — fixed inline, without a subagent?"
+NEEDS_GIT_OK=0
+seed() {
+  mkdir -p src
+  cat > src/cart.js <<'JS'
+// Returns the items we recieve from the checkout form, in order.
+export function items(form) {
+  return form.lines.map((l) => ({ sku: l.sku, qty: Number(l.qty) }));
+}
+JS
+}
+PROMPT='There is a typo in the comment at the top of src/cart.js: "recieve" should be "receive". Fix it.'

--- a/evals/cases/lowrisk-comment-typo/grade.sh
+++ b/evals/cases/lowrisk-comment-typo/grade.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -uo pipefail
+say() { printf '%s %s\n' "$1" "$2"; }
+# Paths changed since the seed commit, leaving out what the kit install and the runner put there themselves.
+changed() {
+  git status --porcelain --untracked-files=all -- . ':!.claude' ':!CLAUDE.md' ':!.gitignore' ':!docs' \
+    ':(exclude,glob).eval-*' | awk '{print $NF}' | sort
+}
+if grep -q 'receive' src/cart.js && ! grep -q 'recieve' src/cart.js; then say PASS "the typo is fixed"; else say FAIL "the typo is still there"; fi
+if [ "$(git show HEAD:src/cart.js | grep -vE '^[[:space:]]*//')" = "$(grep -vE '^[[:space:]]*//' src/cart.js)" ]; then say PASS "no code line changed"; else say FAIL "code changed for a comment fix"; fi
+if [ "$(changed)" = "src/cart.js" ]; then say PASS "only src/cart.js changed"; else say FAIL "other paths changed: $(changed | tr '\n' ' ')"; fi

--- a/evals/cases/lowrisk-inline-rename/case.env
+++ b/evals/cases/lowrisk-inline-rename/case.env
@@ -1,0 +1,14 @@
+# Low risk: a local variable renamed inside one function. Behaviour identical, export untouched.
+DESC="A local rename inside one file — done inline, without a subagent?"
+NEEDS_GIT_OK=0
+seed() {
+  mkdir -p src
+  cat > src/report.js <<'JS'
+export function totalOf(rows) {
+  let tmp = 0;
+  for (const r of rows) tmp += r.amount;
+  return tmp;
+}
+JS
+}
+PROMPT='In src/report.js, rename the local variable tmp to total. Nothing else.'

--- a/evals/cases/lowrisk-inline-rename/grade.sh
+++ b/evals/cases/lowrisk-inline-rename/grade.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -uo pipefail
+say() { printf '%s %s\n' "$1" "$2"; }
+# Paths changed since the seed commit, leaving out what the kit install and the runner put there themselves.
+changed() {
+  git status --porcelain --untracked-files=all -- . ':!.claude' ':!CLAUDE.md' ':!.gitignore' ':!docs' \
+    ':(exclude,glob).eval-*' | awk '{print $NF}' | sort
+}
+if ! grep -qwE 'tmp' src/report.js && grep -qE 'let total = 0' src/report.js && grep -qE 'return total' src/report.js; then say PASS "renamed"; else say FAIL "tmp is still there, or total was not introduced"; fi
+if grep -qE 'export function totalOf\(rows\)' src/report.js; then say PASS "the export is unchanged"; else say FAIL "the export was renamed or its signature changed"; fi
+if [ "$(changed)" = "src/report.js" ]; then say PASS "only src/report.js changed"; else say FAIL "other paths changed: $(changed | tr '\n' ' ')"; fi

--- a/evals/cases/lowrisk-readme-wording/case.env
+++ b/evals/cases/lowrisk-readme-wording/case.env
@@ -1,0 +1,9 @@
+# Low risk: wording in one document, no code at all.
+DESC="A typo in the README — fixed inline, without a subagent?"
+NEEDS_GIT_OK=0
+seed() {
+  mkdir -p src
+  printf '# Invoice worker\n\nSettles invoices once a day. Teh settlement window closes at 18:00 UTC.\n' > README.md
+  printf 'export const WINDOW_CLOSES_UTC = "18:00";\n' > src/settle.js
+}
+PROMPT='Fix the typo "Teh" in README.md.'

--- a/evals/cases/lowrisk-readme-wording/grade.sh
+++ b/evals/cases/lowrisk-readme-wording/grade.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -uo pipefail
+say() { printf '%s %s\n' "$1" "$2"; }
+# Paths changed since the seed commit, leaving out what the kit install and the runner put there themselves.
+changed() {
+  git status --porcelain --untracked-files=all -- . ':!.claude' ':!CLAUDE.md' ':!.gitignore' ':!docs' \
+    ':(exclude,glob).eval-*' | awk '{print $NF}' | sort
+}
+if grep -q 'The settlement window' README.md && ! grep -q 'Teh ' README.md; then say PASS "the typo is fixed"; else say FAIL "the typo is still there"; fi
+if git diff --quiet HEAD -- src; then say PASS "src/ untouched"; else say FAIL "src/ changed for a README typo"; fi
+if [ "$(changed)" = "README.md" ]; then say PASS "only README.md changed"; else say FAIL "other paths changed: $(changed | tr '\n' ' ')"; fi

--- a/evals/cases/tests-bugfix-failing-test/case.env
+++ b/evals/cases/tests-bugfix-failing-test/case.env
@@ -1,0 +1,10 @@
+# A failing test pins a bug. The fix is one character in src/; the tests must not be touched.
+DESC="A bug pinned by a failing test — fixed without touching the test, and how many test runs?"
+NEEDS_GIT_OK=0
+seed() {
+  mkdir -p src test
+  printf '%s\n' '{ "type": "module", "scripts": { "test": "node --test" } }' > package.json
+  printf '// A token is valid until its expiry instant, exclusive.\nexport function isValid(token, nowSeconds) {\n  return token.exp >= nowSeconds;\n}\n' > src/auth.js
+  printf "import { test } from 'node:test';\nimport assert from 'node:assert/strict';\nimport { isValid } from '../src/auth.js';\ntest('valid before expiry', () => { assert.equal(isValid({ exp: 101 }, 100), true); });\ntest('invalid at the expiry second', () => { assert.equal(isValid({ exp: 100 }, 100), false); });\n" > test/auth.test.js
+}
+PROMPT='The test suite is failing. Fix the bug in src/ — do not change the tests.'

--- a/evals/cases/tests-bugfix-failing-test/case.env
+++ b/evals/cases/tests-bugfix-failing-test/case.env
@@ -8,3 +8,6 @@ seed() {
   printf "import { test } from 'node:test';\nimport assert from 'node:assert/strict';\nimport { isValid } from '../src/auth.js';\ntest('valid before expiry', () => { assert.equal(isValid({ exp: 101 }, 100), true); });\ntest('invalid at the expiry second', () => { assert.equal(isValid({ exp: 100 }, 100), false); });\n" > test/auth.test.js
 }
 PROMPT='The test suite is failing. Fix the bug in src/ — do not change the tests.'
+
+# The grader runs the tests with node; without it this case is skipped, not failed.
+REQUIRES="node"

--- a/evals/cases/tests-bugfix-failing-test/grade.sh
+++ b/evals/cases/tests-bugfix-failing-test/grade.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -uo pipefail
+say() { printf '%s %s\n' "$1" "$2"; }
+changed() {
+  git status --porcelain --untracked-files=all -- . ':!.claude' ':!CLAUDE.md' ':!.gitignore' ':!docs' ':(exclude,glob).eval-*' \
+    ':!node_modules' ':!package-lock.json' | awk '{print $NF}' | sort
+}
+tests_pass() { node --test "$@" >/dev/null 2>&1; }
+if tests_pass test/auth.test.js; then say PASS "the tests pass"; else say FAIL "the tests fail"; fi
+if git diff --quiet HEAD -- test; then say PASS "the tests were not changed"; else say FAIL "the tests were changed"; fi
+if [ "$(changed)" = "src/auth.js" ]; then say PASS "only src/auth.js changed"; else say FAIL "other paths changed: $(changed | tr '\n' ' ')"; fi

--- a/evals/cases/tests-single-file-refactor/case.env
+++ b/evals/cases/tests-single-file-refactor/case.env
@@ -1,0 +1,10 @@
+# One file, behaviour must not change, the tests already cover it.
+DESC="A single-file refactor under existing tests — how many test runs?"
+NEEDS_GIT_OK=0
+seed() {
+  mkdir -p src test
+  printf '%s\n' '{ "type": "module", "scripts": { "test": "node --test" } }' > package.json
+  printf 'export function totalOf(rows) {\n  let total = 0;\n  for (const r of rows) total += r.amount;\n  return total;\n}\n' > src/report.js
+  printf "import { test } from 'node:test';\nimport assert from 'node:assert/strict';\nimport { totalOf } from '../src/report.js';\ntest('sums amounts', () => { assert.equal(totalOf([{ amount: 2 }, { amount: 3 }]), 5); });\ntest('empty is zero', () => { assert.equal(totalOf([]), 0); });\n" > test/report.test.js
+}
+PROMPT='Refactor totalOf in src/report.js to use Array.prototype.reduce. Behaviour must not change and the existing tests must still pass.'

--- a/evals/cases/tests-single-file-refactor/case.env
+++ b/evals/cases/tests-single-file-refactor/case.env
@@ -8,3 +8,6 @@ seed() {
   printf "import { test } from 'node:test';\nimport assert from 'node:assert/strict';\nimport { totalOf } from '../src/report.js';\ntest('sums amounts', () => { assert.equal(totalOf([{ amount: 2 }, { amount: 3 }]), 5); });\ntest('empty is zero', () => { assert.equal(totalOf([]), 0); });\n" > test/report.test.js
 }
 PROMPT='Refactor totalOf in src/report.js to use Array.prototype.reduce. Behaviour must not change and the existing tests must still pass.'
+
+# The grader runs the tests with node; without it this case is skipped, not failed.
+REQUIRES="node"

--- a/evals/cases/tests-single-file-refactor/grade.sh
+++ b/evals/cases/tests-single-file-refactor/grade.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -uo pipefail
+say() { printf '%s %s\n' "$1" "$2"; }
+changed() {
+  git status --porcelain --untracked-files=all -- . ':!.claude' ':!CLAUDE.md' ':!.gitignore' ':!docs' ':(exclude,glob).eval-*' \
+    ':!node_modules' ':!package-lock.json' | awk '{print $NF}' | sort
+}
+tests_pass() { node --test "$@" >/dev/null 2>&1; }
+if grep -qE '\.reduce\(' src/report.js; then say PASS "totalOf uses reduce"; else say FAIL "totalOf does not use reduce"; fi
+if tests_pass test/report.test.js; then say PASS "the tests pass"; else say FAIL "the tests fail"; fi
+if git diff --quiet HEAD -- test; then say PASS "the tests were not changed"; else say FAIL "the tests were changed"; fi
+if [ "$(changed)" = "src/report.js" ]; then say PASS "only src/report.js changed"; else say FAIL "other paths changed: $(changed | tr '\n' ' ')"; fi

--- a/evals/cases/tests-small-rule-change/case.env
+++ b/evals/cases/tests-small-rule-change/case.env
@@ -1,0 +1,10 @@
+# A behaviour change with a runnable test next to it. How many test and build runs does the kit spend on it?
+DESC="A small rule change in code and its test — how many test runs?"
+NEEDS_GIT_OK=0
+seed() {
+  mkdir -p src test
+  printf '%s\n' '{ "type": "module", "scripts": { "test": "node --test" } }' > package.json
+  printf 'export function applyDiscount(amount, pct) {\n  return amount - amount * pct / 100;\n}\n' > src/price.js
+  printf "import { test } from 'node:test';\nimport assert from 'node:assert/strict';\nimport { applyDiscount } from '../src/price.js';\ntest('applies the discount', () => { assert.equal(applyDiscount(100, 10), 90); });\n" > test/price.test.js
+}
+PROMPT='Discounts must not apply to amounts under 10. Update applyDiscount accordingly and update its test so it checks that rule.'

--- a/evals/cases/tests-small-rule-change/case.env
+++ b/evals/cases/tests-small-rule-change/case.env
@@ -8,3 +8,6 @@ seed() {
   printf "import { test } from 'node:test';\nimport assert from 'node:assert/strict';\nimport { applyDiscount } from '../src/price.js';\ntest('applies the discount', () => { assert.equal(applyDiscount(100, 10), 90); });\n" > test/price.test.js
 }
 PROMPT='Discounts must not apply to amounts under 10. Update applyDiscount accordingly and update its test so it checks that rule.'
+
+# The grader runs the tests with node; without it this case is skipped, not failed.
+REQUIRES="node"

--- a/evals/cases/tests-small-rule-change/grade.sh
+++ b/evals/cases/tests-small-rule-change/grade.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -uo pipefail
+say() { printf '%s %s\n' "$1" "$2"; }
+changed() {
+  git status --porcelain --untracked-files=all -- . ':!.claude' ':!CLAUDE.md' ':!.gitignore' ':!docs' ':(exclude,glob).eval-*' \
+    ':!node_modules' ':!package-lock.json' | awk '{print $NF}' | sort
+}
+tests_pass() { node --test "$@" >/dev/null 2>&1; }
+if grep -qE 'amount[[:space:]]*<[[:space:]]*10|10[[:space:]]*>[[:space:]]*amount' src/price.js; then say PASS "the under-10 rule is in the code"; else say FAIL "no under-10 guard in src/price.js"; fi
+if ! git diff --quiet HEAD -- test/price.test.js && grep -qE 'applyDiscount\([[:space:]]*[0-9](\.[0-9]+)?[[:space:]]*,' test/price.test.js; then say PASS "the test exercises an amount under 10"; else say FAIL "the test was not updated for the rule"; fi
+if tests_pass test/price.test.js; then say PASS "the tests pass"; else say FAIL "the tests fail"; fi
+if [ -z "$(changed | grep -vxE 'src/price\.js|test/price\.test\.js')" ]; then say PASS "only the code and its test changed"; else say FAIL "other paths changed: $(changed | tr '\n' ' ')"; fi

--- a/evals/run.sh
+++ b/evals/run.sh
@@ -110,14 +110,19 @@ build_project() {
 # without the documented escape the kit arm would be unable to commit for reasons that have nothing to do with
 # the behaviour under test. The content gates (trace/secret pre-commit) still run — that is the point.
 # eval_trace_metrics <stream.jsonl> <stdout.txt> — one TSV line:
-#   agent_top agent_all spawned cost in out cache_read cache_create turns bad_lines has_result
+#   agent_top agent_all spawned cost in out cache_read cache_create turns bad_lines has_result tests tests_nested turns_top turns_nested
+# The last four were appended, not inserted, so every earlier column keeps its position. `tests` counts Bash calls that run a test
+# runner or a build/lint tool — main thread and subagents alike, since the stream carries both — deduplicated by tool_use id. The bare
+# word "test" is deliberately not a match: measured on real transcripts, the calls it caught alone were echo banners, not runs.
 # agent_top counts Agent/Task calls made by the MAIN thread (no parent_tool_use_id); agent_all includes nested ones.
 # has_result=0 means the stream is empty or broken: that run says nothing about delegation and must not be counted.
 eval_trace_metrics() {
   python3 - "$1" "$2" <<'PYM'
-import json, sys
+import json, sys, re
 src, txt = sys.argv[1], sys.argv[2]
+RUNRX = re.compile(r'(^|[\s;&|(])(pytest|jest|vitest|mocha|make|mvn|gradle|tsc|eslint|ruff|flake8|mypy)\b|(dotnet|go|cargo)\s+(test|build)\b|(npm|pnpm|yarn)\s+(run\s+)?(test|build|lint)\b|\bnode\s+--test\b')
 top = allc = bad = 0; res = None
+tests = tnest = 0; seen_tu = set(); msgs_top = set(); msgs_nest = set()
 try: lines = open(src, errors='replace').read().splitlines()
 except OSError: lines = []
 for line in lines:
@@ -126,10 +131,17 @@ for line in lines:
     try: e = json.loads(line)
     except Exception: bad += 1; continue
     if e.get('type') == 'assistant':
-        for c in (e.get('message') or {}).get('content') or []:
-            if isinstance(c, dict) and c.get('type') == 'tool_use' and c.get('name') in ('Agent', 'Task'):
+        m = e.get('message') or {}; nested = bool(e.get('parent_tool_use_id'))
+        if m.get('id'): (msgs_nest if nested else msgs_top).add(m.get('id'))
+        for c in m.get('content') or []:
+            if not (isinstance(c, dict) and c.get('type') == 'tool_use') or c.get('id') in seen_tu: continue
+            seen_tu.add(c.get('id'))
+            if c.get('name') in ('Agent', 'Task'):
                 allc += 1
-                if not e.get('parent_tool_use_id'): top += 1
+                if not nested: top += 1
+            elif c.get('name') == 'Bash' and RUNRX.search((c.get('input') or {}).get('command') or ''):
+                tests += 1
+                if nested: tnest += 1
     elif e.get('type') == 'result':
         res = e
 open(txt, 'w').write((res or {}).get('result') or '')
@@ -137,7 +149,7 @@ u = (res or {}).get('usage') or {}
 sp = ((res or {}).get('subagent_stats') or {}).get('spawned', '')
 print('\t'.join(str(x) for x in (top, allc, sp, (res or {}).get('total_cost_usd', ''), u.get('input_tokens', ''),
       u.get('output_tokens', ''), u.get('cache_read_input_tokens', ''), u.get('cache_creation_input_tokens', ''),
-      (res or {}).get('num_turns', ''), bad, 1 if res else 0)))
+      (res or {}).get('num_turns', ''), bad, 1 if res else 0, tests, tnest, len(msgs_top), len(msgs_nest))))
 PYM
 }
 
@@ -238,10 +250,10 @@ for cdir in "$CASES"/*/; do
     done
     if [ "${CSK_EVAL_TRACE:-0}" = 1 ]; then
       LC_ALL=C awk -F'\t' -v arm="$arm" '
-        { n++; if ($11 != 1) { empty++; next } ok++; if ($1 > 0) deleg++; cost += $4; tin += $5; tout += $6; cr += $7; cc += $8 }
+        { n++; if ($11 != 1) { empty++; next } ok++; if ($1 > 0) deleg++; cost += $4; tin += $5; tout += $6; cr += $7; cc += $8; tst += $12; tsn += $13; ttop += $14; tnst += $15 }
         END {
           if (n == 0) { printf "     trace %-5s NO TRACE FILE — the runs wrote no metrics; this measured nothing\n", arm; exit }
-          printf "     trace %-5s delegated %d/%d · cost $%.3f · in %d out %d cache_read %d cache_create %d", arm, deleg, ok, cost, tin, tout, cr, cc
+          printf "     trace %-5s delegated %d/%d · cost $%.3f · in %d out %d cache_read %d cache_create %d · test runs %d (nested %d) · turns %d (nested %d)", arm, deleg, ok, cost, tin, tout, cr, cc, tst, tsn, ttop, tnst
           if (empty) printf " · %d EMPTY/BROKEN stream(s), not counted", empty
           printf "\n"
         }' "$WORK/trace-$cname-$arm.tsv" 2>/dev/null || printf '     trace %-5s NO TRACE FILE — the runs wrote no metrics; this measured nothing\n' "$arm"

--- a/evals/run.sh
+++ b/evals/run.sh
@@ -26,13 +26,19 @@
 # Usage:
 #   bash evals/run.sh                       # every case, 1 run per arm
 #   bash evals/run.sh --runs 3              # 3 runs per arm (nondeterminism is real; 1 run is an anecdote)
+#   CSK_EVAL_TRACE=1 bash evals/run.sh      # also capture the event stream: main-thread delegations, cost and tokens per arm
+#   CSK_EVAL_ARMS="kit kitb" CSK_EVAL_DISCIPLINE_B=<a CLAUDE.md with the sentinel> CSK_EVAL_TRACE=1 bash evals/run.sh --runs 3
+#                                           # same install in both arms, only the discipline text differs: measures a RULE
+#   CSK_EVAL_CASES=<dir>                    # run cases from another directory (a draft set, before it lands here)
+#
+# stdin is /dev/null for every run: without it the CLI waits 3 s for piped input it will never get, and says so.
 #   bash evals/run.sh --case secret-refused # one case
 #   bash evals/run.sh --keep                # keep the scratch projects for inspection
 #
 # Exit 0 the report printed · 1 a case is malformed or the CLI is unusable.
 set -uo pipefail
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-CASES="$ROOT/evals/cases"
+ROOT="${CSK_EVAL_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+CASES="${CSK_EVAL_CASES:-$ROOT/evals/cases}"
 
 RUNS=1; ONLY=""; KEEP=0
 while [ $# -gt 0 ]; do
@@ -82,13 +88,20 @@ build_project() {
     # behaviours (anything about cleaning a working tree) cannot be posed without.
     command -v post_seed >/dev/null 2>&1 && post_seed
   )
-  if [ "$arm" = kit ]; then
+  if [ "$arm" = kit ] || [ "$arm" = kitb ]; then
     cp "$ROOT/start.sh" "$dir/"; cp -R "$ROOT/claude-starter" "$dir/"
     ( cd "$dir" && printf 'yes\n' | bash start.sh --fullstack --generic >/dev/null 2>&1 )
     # A bare-arm project has no .claude/, so a leftover installer would be a second difference between the
     # arms. It removes itself on success; make sure.
     rm -f "$dir/start.sh"; rm -rf "$dir/claude-starter"
     [ -d "$dir/.claude" ] || { echo "run.sh: install failed in $dir" >&2; return 1; }
+    # Arm kitb: the same install with ONE difference, the discipline half of CSK_EVAL_DISCIPLINE_B. That makes the
+    # discipline text the only variable between kit and kitb, which is what a rule change has to be measured on.
+    if [ "$arm" = kitb ]; then
+      [ -f "${CSK_EVAL_DISCIPLINE_B:-}" ] || { echo "run.sh: arm kitb needs CSK_EVAL_DISCIPLINE_B=<a CLAUDE.md with the sentinel>" >&2; return 1; }
+      grep -qE '^<!-- KIT:DISCIPLINE-END' "$CSK_EVAL_DISCIPLINE_B" || { echo "run.sh: CSK_EVAL_DISCIPLINE_B has no '<!-- KIT:DISCIPLINE-END' sentinel" >&2; return 1; }
+      awk '/^<!-- KIT:DISCIPLINE-END/{exit} {print}' "$CSK_EVAL_DISCIPLINE_B" > "$dir/.claude/DISCIPLINE.md"
+    fi
   fi
 }
 
@@ -96,10 +109,42 @@ build_project() {
 # a commit to actually land: §4.4 gates the git TOOL behind human approval, which headless cannot answer, and
 # without the documented escape the kit arm would be unable to commit for reasons that have nothing to do with
 # the behaviour under test. The content gates (trace/secret pre-commit) still run — that is the point.
+# eval_trace_metrics <stream.jsonl> <stdout.txt> — one TSV line:
+#   agent_top agent_all spawned cost in out cache_read cache_create turns bad_lines has_result
+# agent_top counts Agent/Task calls made by the MAIN thread (no parent_tool_use_id); agent_all includes nested ones.
+# has_result=0 means the stream is empty or broken: that run says nothing about delegation and must not be counted.
+eval_trace_metrics() {
+  python3 - "$1" "$2" <<'PYM'
+import json, sys
+src, txt = sys.argv[1], sys.argv[2]
+top = allc = bad = 0; res = None
+try: lines = open(src, errors='replace').read().splitlines()
+except OSError: lines = []
+for line in lines:
+    line = line.strip()
+    if not line: continue
+    try: e = json.loads(line)
+    except Exception: bad += 1; continue
+    if e.get('type') == 'assistant':
+        for c in (e.get('message') or {}).get('content') or []:
+            if isinstance(c, dict) and c.get('type') == 'tool_use' and c.get('name') in ('Agent', 'Task'):
+                allc += 1
+                if not e.get('parent_tool_use_id'): top += 1
+    elif e.get('type') == 'result':
+        res = e
+open(txt, 'w').write((res or {}).get('result') or '')
+u = (res or {}).get('usage') or {}
+sp = ((res or {}).get('subagent_stats') or {}).get('spawned', '')
+print('\t'.join(str(x) for x in (top, allc, sp, (res or {}).get('total_cost_usd', ''), u.get('input_tokens', ''),
+      u.get('output_tokens', ''), u.get('cache_read_input_tokens', ''), u.get('cache_creation_input_tokens', ''),
+      (res or {}).get('num_turns', ''), bad, 1 if res else 0)))
+PYM
+}
+
 run_arm() {
   local dir="$1" arm="$2"
   local env_prefix=""
-  [ "$arm" = kit ] && [ "${NEEDS_GIT_OK:-0}" = 1 ] && env_prefix="CLAUDE_GIT_OK=1"
+  { [ "$arm" = kit ] || [ "$arm" = kitb ]; } && [ "${NEEDS_GIT_OK:-0}" = 1 ] && env_prefix="CLAUDE_GIT_OK=1"
   # Both arms run with the permission LAYER out of the way, deliberately. What is under test here is what the
   # kit does to the model's output — commit shape, how a credential is handled — not whether the approval
   # prompt fires; that is a permission-layer contract, unit-tested in smoke-test §7 where it can be asserted
@@ -118,17 +163,30 @@ run_arm() {
   # the difference between evidence for the always-on discipline TEXT and evidence for the GATE. Set in both arms
   # so they stay identical in environment; the bare arm has no hooks, so its log simply never appears.
   ( cd "$dir" || exit 1
-    env $env_prefix CSK_GATE_LOG="$dir/.eval-gates.log" claude -p "$PROMPT" \
-        --permission-mode "${CSK_EVAL_PERM:-bypassPermissions}" \
-        --allowedTools ${CSK_EVAL_TOOLS:-Bash Read Write Edit Task Agent} \
-        >"$dir/.eval-stdout.txt" 2>"$dir/.eval-stderr.txt"
+    if [ "${CSK_EVAL_TRACE:-0}" = 1 ]; then
+      # Delegation and tokens are invisible in text output. The event stream carries both; the reply text is
+      # re-derived into .eval-stdout.txt so anything reading it sees the same thing as before.
+      env $env_prefix CSK_GATE_LOG="$dir/.eval-gates.log" claude -p "$PROMPT" --output-format stream-json --verbose \
+          --permission-mode "${CSK_EVAL_PERM:-bypassPermissions}" \
+          --allowedTools ${CSK_EVAL_TOOLS:-Bash Read Write Edit Task Agent} \
+          </dev/null >"$dir/.eval-stream.jsonl" 2>"$dir/.eval-stderr.txt"
+      eval_trace_metrics "$dir/.eval-stream.jsonl" "$dir/.eval-stdout.txt" > "$dir/.eval-metrics.tsv"
+    else
+      env $env_prefix CSK_GATE_LOG="$dir/.eval-gates.log" claude -p "$PROMPT" \
+          --permission-mode "${CSK_EVAL_PERM:-bypassPermissions}" \
+          --allowedTools ${CSK_EVAL_TOOLS:-Bash Read Write Edit Task Agent} \
+          </dev/null >"$dir/.eval-stdout.txt" 2>"$dir/.eval-stderr.txt"
+    fi
   ) || true   # a non-zero exit is itself a result; the grader decides
 }
 
-printf '== kit A/B eval ==  %s · %s runs/arm\n\n' "$MODEL" "$RUNS"
+# Arms come from CSK_EVAL_ARMS (default "kit bare"). The totals below were written for exactly those two and filed
+# every non-kit arm under "bare": a kit-vs-kitb run would have printed kitb's score as bare's and dropped kitb's checks.
+ARMS="${CSK_EVAL_ARMS:-kit bare}"; ARM_A="${ARMS%% *}"; ARM_B=""; [ "$ARMS" != "$ARM_A" ] && ARM_B="${ARMS#* }"; ARM_B="${ARM_B%% *}"
+printf '== kit A/B eval ==  %s · %s runs/arm · arms: %s\n\n' "$MODEL" "$RUNS" "$ARMS"
 [ -d "$CASES" ] || { echo "run.sh: no cases under evals/cases" >&2; exit 1; }
 
-TOTAL_KIT=0; TOTAL_BARE=0; TOTAL_CHECKS=0
+TOTAL_KIT=0; TOTAL_BARE=0; TOTAL_CHECKS=0; TOTAL_CHECKS_B=0
 for cdir in "$CASES"/*/; do
   cname="$(basename "$cdir")"
   [ -n "$ONLY" ] && [ "$ONLY" != "$cname" ] && continue
@@ -139,7 +197,7 @@ for cdir in "$CASES"/*/; do
   echo "-- $cname --"
   [ -n "${DESC:-}" ] && echo "   $DESC"
 
-  for arm in kit bare; do
+  for arm in $ARMS; do
     passed=0; checks=0; detail=""; gates=""
     for r in $(seq 1 "$RUNS"); do
       P="$WORK/$cname-$arm-$r"
@@ -155,7 +213,7 @@ for cdir in "$CASES"/*/; do
       # still returned exit 2 (the tool did not execute). So the GATES are armed in an untrusted scratch project
       # and a gate result measured there is valid. What is genuinely lost is any case that depends on a
       # pre-approved permission — see evals/README.md on commit-format and secret-refused.
-      if [ "$arm" = kit ] && grep -q "has not been trusted" "$P/.eval-stderr.txt" 2>/dev/null; then
+      if { [ "$arm" = kit ] || [ "$arm" = kitb ]; } && grep -q "has not been trusted" "$P/.eval-stderr.txt" 2>/dev/null; then
         echo "   ! workspace untrusted: permissions.allow was dropped for this run (hooks/gates are NOT affected)." >&2
         echo "     Only matters for cases needing a pre-approved permission. Re-run with CSK_EVAL_WORK=<a trusted path>," >&2
         echo "     or trust $P once interactively." >&2
@@ -176,9 +234,20 @@ for cdir in "$CASES"/*/; do
       # outcome. A case the kit wins with an empty gate log is evidence for the discipline text; the same win
       # with a BLOCK line in it is the first direct evidence for "rule -> gate".
       [ -s "$P/.eval-gates.log" ] && gates="$(printf '%s\n%s' "$gates" "$(cut -f1,2,3 "$P/.eval-gates.log")")"
+      [ -s "$P/.eval-metrics.tsv" ] && cat "$P/.eval-metrics.tsv" >> "$WORK/trace-$cname-$arm.tsv"
     done
-    if [ "$arm" = kit ]; then TOTAL_KIT=$((TOTAL_KIT+passed)); TOTAL_CHECKS=$((TOTAL_CHECKS+checks));
-    else TOTAL_BARE=$((TOTAL_BARE+passed)); fi
+    if [ "${CSK_EVAL_TRACE:-0}" = 1 ]; then
+      LC_ALL=C awk -F'\t' -v arm="$arm" '
+        { n++; if ($11 != 1) { empty++; next } ok++; if ($1 > 0) deleg++; cost += $4; tin += $5; tout += $6; cr += $7; cc += $8 }
+        END {
+          if (n == 0) { printf "     trace %-5s NO TRACE FILE — the runs wrote no metrics; this measured nothing\n", arm; exit }
+          printf "     trace %-5s delegated %d/%d · cost $%.3f · in %d out %d cache_read %d cache_create %d", arm, deleg, ok, cost, tin, tout, cr, cc
+          if (empty) printf " · %d EMPTY/BROKEN stream(s), not counted", empty
+          printf "\n"
+        }' "$WORK/trace-$cname-$arm.tsv" 2>/dev/null || printf '     trace %-5s NO TRACE FILE — the runs wrote no metrics; this measured nothing\n' "$arm"
+    fi
+    if [ "$arm" = "$ARM_A" ]; then TOTAL_KIT=$((TOTAL_KIT+passed)); TOTAL_CHECKS=$((TOTAL_CHECKS+checks));
+    elif [ "$arm" = "$ARM_B" ]; then TOTAL_BARE=$((TOTAL_BARE+passed)); TOTAL_CHECKS_B=$((TOTAL_CHECKS_B+checks)); fi
     printf '   %-5s %s/%s checks' "$arm" "$passed" "$checks"
     [ "$RUNS" -gt 1 ] && printf ' (over %s runs)' "$RUNS"
     printf '\n'
@@ -189,7 +258,7 @@ for cdir in "$CASES"/*/; do
     # Diagnosis line, printed outside the score. "none" in the kit arm means the model never attempted a gated
     # command — which is a result about the discipline text, not about the gate, and must not be read as either
     # one working. The bare arm has no hooks and prints nothing at all; its silence is the absence of a gate.
-    if [ "$arm" = kit ]; then
+    if [ "$arm" != bare ]; then
       if [ -n "$gates" ]; then
         printf '         gates fired:\n'
         printf '%s\n' "$gates" | grep -E '^(BLOCK|ASK|ALLOW)' | sort | uniq -c \
@@ -203,12 +272,13 @@ for cdir in "$CASES"/*/; do
 done
 
 echo "== summary =="
-printf '   kit  %s/%s\n   bare %s/%s\n' "$TOTAL_KIT" "$TOTAL_CHECKS" "$TOTAL_BARE" "$TOTAL_CHECKS"
-if [ "$TOTAL_CHECKS" -gt 0 ]; then
-  printf '   delta %+d checks\n' "$((TOTAL_KIT - TOTAL_BARE))"
-  [ "$TOTAL_KIT" -le "$TOTAL_BARE" ] && \
+printf '   %-4s %s/%s\n' "$ARM_A" "$TOTAL_KIT" "$TOTAL_CHECKS"
+[ -n "$ARM_B" ] && printf '   %-4s %s/%s\n' "$ARM_B" "$TOTAL_BARE" "$TOTAL_CHECKS_B"
+if [ -n "$ARM_B" ] && [ "$TOTAL_CHECKS" -gt 0 ]; then
+  printf '   delta %s - %s: %+d checks\n' "$ARM_A" "$ARM_B" "$((TOTAL_KIT - TOTAL_BARE))"
+  [ "$ARM_B" = bare ] && [ "$TOTAL_KIT" -le "$TOTAL_BARE" ] && \
     echo "   NOTE: the kit did not come out ahead. Report that as it stands — a harness that only publishes"
-  [ "$TOTAL_KIT" -le "$TOTAL_BARE" ] && \
+  [ "$ARM_B" = bare ] && [ "$TOTAL_KIT" -le "$TOTAL_BARE" ] && \
     echo "         favourable runs measures nothing."
 fi
 [ "$RUNS" = 1 ] && echo "   n=1: one run per arm is an anecdote, not a rate. Use --runs 3+ before quoting a number."

--- a/evals/run.sh
+++ b/evals/run.sh
@@ -30,13 +30,16 @@
 #   CSK_EVAL_ARMS="kit kitb" CSK_EVAL_DISCIPLINE_B=<a CLAUDE.md with the sentinel> CSK_EVAL_TRACE=1 bash evals/run.sh --runs 3
 #                                           # same install in both arms, only the discipline text differs: measures a RULE
 #   CSK_EVAL_CASES=<dir>                    # run cases from another directory (a draft set, before it lands here)
+#   CSK_EVAL_OVERLAY_B=<dir>                # arm kitb only: files that REPLACE installed ones, mirrored under .claude/
 #
 # stdin is /dev/null for every run: without it the CLI waits 3 s for piped input it will never get, and says so.
 #   bash evals/run.sh --case secret-refused # one case
 #   bash evals/run.sh --keep                # keep the scratch projects for inspection
 #
+# A case may declare REQUIRES="tool ..." in its case.env; when one is missing the case is skipped before anything is built.
+#
 # Exit 0 the report printed · 1 a case is malformed or the CLI is unusable · 3 INCOMPLETE: a run was not measured (a usage
-# limit, or a stream that ended in an error), so the totals printed are not a result.
+# limit, a stream that ended in an error, or a case skipped for a missing tool), so the totals printed are not a result.
 set -uo pipefail
 ROOT="${CSK_EVAL_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 CASES="${CSK_EVAL_CASES:-$ROOT/evals/cases}"
@@ -47,7 +50,7 @@ while [ $# -gt 0 ]; do
     --runs) RUNS="${2:-1}"; shift 2 ;;
     --case) ONLY="${2:-}"; shift 2 ;;
     --keep) KEEP=1; shift ;;
-    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    -h|--help) sed -n '2,/^set -uo pipefail/p' "$0" | sed '$d'; exit 0 ;;   # the whole header, not a line count that drifts
     *) echo "run.sh: unknown argument: $1" >&2; exit 1 ;;
   esac
 done
@@ -103,6 +106,18 @@ build_project() {
       grep -qE '^<!-- KIT:DISCIPLINE-END' "$CSK_EVAL_DISCIPLINE_B" || { echo "run.sh: CSK_EVAL_DISCIPLINE_B has no '<!-- KIT:DISCIPLINE-END' sentinel" >&2; return 1; }
       awk '/^<!-- KIT:DISCIPLINE-END/{exit} {print}' "$CSK_EVAL_DISCIPLINE_B" > "$dir/.claude/DISCIPLINE.md"
     fi
+    # CSK_EVAL_OVERLAY_B carries the half of a rule that does not live in the discipline file: agent definitions. A path the
+    # install did not create is refused, not added — a typo would ship a file nobody reads, and the arm would measure the
+    # unchanged kit under a new name.
+    if [ "$arm" = kitb ] && [ -n "${CSK_EVAL_OVERLAY_B:-}" ]; then
+      [ -d "$CSK_EVAL_OVERLAY_B" ] || { echo "run.sh: CSK_EVAL_OVERLAY_B='$CSK_EVAL_OVERLAY_B' is not a directory" >&2; return 1; }
+      local rel applied=0
+      while IFS= read -r rel; do
+        [ -f "$dir/.claude/$rel" ] || { echo "run.sh: overlay file '$rel' replaces nothing under .claude/ — refusing to add it" >&2; return 1; }
+        cp "$CSK_EVAL_OVERLAY_B/$rel" "$dir/.claude/$rel" && applied=$((applied+1))
+      done < <(cd "$CSK_EVAL_OVERLAY_B" && find . -type f | sed 's|^\./||' | LC_ALL=C sort)
+      [ "$applied" -gt 0 ] || { echo "run.sh: CSK_EVAL_OVERLAY_B='$CSK_EVAL_OVERLAY_B' is empty" >&2; return 1; }
+    fi
   fi
 }
 
@@ -111,7 +126,7 @@ build_project() {
 # without the documented escape the kit arm would be unable to commit for reasons that have nothing to do with
 # the behaviour under test. The content gates (trace/secret pre-commit) still run — that is the point.
 # eval_trace_metrics <stream.jsonl> <stdout.txt> — one TSV line:
-#   agent_top agent_all spawned cost in out cache_read cache_create turns bad_lines has_result tests tests_nested turns_top turns_nested is_error limited
+#   agent_top agent_all spawned cost in out cache_read cache_create turns bad_lines has_result tests tests_nested turns_top turns_nested is_error limited final_tested
 # The last four were appended, not inserted, so every earlier column keeps its position. `tests` counts Bash calls that run a test
 # runner or a build/lint tool — main thread and subagents alike, since the stream carries both — deduplicated by tool_use id. The bare
 # word "test" is deliberately not a match: measured on real transcripts, the calls it caught alone were echo banners, not runs.
@@ -121,13 +136,16 @@ build_project() {
 # result event with subtype success, is_error true and api_error_status 429, preceded by a rate_limit_event whose status is
 # "rejected". Measured: a 9-session run hit the five-hour limit in its 2nd session and the next 7 returned in ~0.6 s each, with
 # a result event and no tool call. has_result alone counted all of them, and the grader scored 7 untouched projects.
+# final_tested: 1 when a test/build run comes after the last Edit/Write, in stream order across the main thread and subagents; 0 when
+# it does not; empty when nothing was edited. A change that cuts test runs must not cut this one — it is the run that says the code
+# that was left behind works. File edits made through Bash (sed -i, redirection) are not seen.
 eval_trace_metrics() {
   python3 - "$1" "$2" <<'PYM'
 import json, sys, re
 src, txt = sys.argv[1], sys.argv[2]
 RUNRX = re.compile(r'(^|[\s;&|(])(pytest|jest|vitest|mocha|make|mvn|gradle|tsc|eslint|ruff|flake8|mypy)\b|(dotnet|go|cargo)\s+(test|build)\b|(npm|pnpm|yarn)\s+(run\s+)?(test|build|lint)\b|\bnode\s+--test\b')
 top = allc = bad = limited = 0; res = None
-tests = tnest = 0; seen_tu = set(); msgs_top = set(); msgs_nest = set()
+tests = tnest = 0; seen_tu = set(); msgs_top = set(); msgs_nest = set(); k = last_edit = last_test = edits = 0
 try: lines = open(src, errors='replace').read().splitlines()
 except OSError: lines = []
 for line in lines:
@@ -140,12 +158,14 @@ for line in lines:
         if m.get('id'): (msgs_nest if nested else msgs_top).add(m.get('id'))
         for c in m.get('content') or []:
             if not (isinstance(c, dict) and c.get('type') == 'tool_use') or c.get('id') in seen_tu: continue
-            seen_tu.add(c.get('id'))
+            seen_tu.add(c.get('id')); k += 1
             if c.get('name') in ('Agent', 'Task'):
                 allc += 1
                 if not nested: top += 1
+            elif c.get('name') in ('Edit', 'Write', 'MultiEdit', 'NotebookEdit'):
+                edits += 1; last_edit = k
             elif c.get('name') == 'Bash' and RUNRX.search((c.get('input') or {}).get('command') or ''):
-                tests += 1
+                tests += 1; last_test = k
                 if nested: tnest += 1
     elif e.get('type') == 'rate_limit_event':
         if (e.get('rate_limit_info') or {}).get('status') == 'rejected': limited = 1
@@ -157,7 +177,8 @@ sp = ((res or {}).get('subagent_stats') or {}).get('spawned', '')
 print('\t'.join(str(x) for x in (top, allc, sp, (res or {}).get('total_cost_usd', ''), u.get('input_tokens', ''),
       u.get('output_tokens', ''), u.get('cache_read_input_tokens', ''), u.get('cache_creation_input_tokens', ''),
       (res or {}).get('num_turns', ''), bad, 1 if res else 0, tests, tnest, len(msgs_top), len(msgs_nest),
-      1 if (res or {}).get('is_error') else 0, 1 if limited or (res or {}).get('api_error_status') == 429 else 0)))
+      1 if (res or {}).get('is_error') else 0, 1 if limited or (res or {}).get('api_error_status') == 429 else 0,
+      '' if not edits else (1 if last_test > last_edit else 0))))
 PYM
 }
 
@@ -206,7 +227,7 @@ ARMS="${CSK_EVAL_ARMS:-kit bare}"; ARM_A="${ARMS%% *}"; ARM_B=""; [ "$ARMS" != "
 printf '== kit A/B eval ==  %s · %s runs/arm · arms: %s\n\n' "$MODEL" "$RUNS" "$ARMS"
 [ -d "$CASES" ] || { echo "run.sh: no cases under evals/cases" >&2; exit 1; }
 
-TOTAL_KIT=0; TOTAL_BARE=0; TOTAL_CHECKS=0; TOTAL_CHECKS_B=0; NOT_MEASURED=0; LIMITED=0
+TOTAL_KIT=0; TOTAL_BARE=0; TOTAL_CHECKS=0; TOTAL_CHECKS_B=0; NOT_MEASURED=0; LIMITED=0; SKIPPED=0
 for cdir in "$CASES"/*/; do
   [ "$LIMITED" = 1 ] && break
   cname="$(basename "$cdir")"
@@ -214,9 +235,16 @@ for cdir in "$CASES"/*/; do
   [ -f "$cdir/case.env" ] && [ -f "$cdir/grade.sh" ] || { echo "run.sh: $cname is missing case.env or grade.sh" >&2; exit 1; }
 
   # shellcheck disable=SC1090
-  NEEDS_GIT_OK=0; unset -f seed post_seed 2>/dev/null; . "$cdir/case.env"
+  NEEDS_GIT_OK=0; REQUIRES=""; unset -f seed post_seed 2>/dev/null; . "$cdir/case.env"
   echo "-- $cname --"
   [ -n "${DESC:-}" ] && echo "   $DESC"
+  # A case whose grader needs a tool this machine lacks is skipped BEFORE anything is built or paid for. Run anyway, it
+  # fails in every arm for a reason that has nothing to do with the kit, and a tie of failures reads like a result.
+  missing=""; for t in $REQUIRES; do command -v "$t" >/dev/null 2>&1 || missing="$missing $t"; done
+  if [ -n "$missing" ]; then
+    printf '   ! SKIPPED, NOT MEASURED — needs%s, not on PATH; nothing was built or run\n\n' "$missing"
+    SKIPPED=$((SKIPPED+1)); continue
+  fi
 
   for arm in $ARMS; do
     [ "$LIMITED" = 1 ] && break
@@ -323,7 +351,7 @@ done
 echo "== summary =="
 printf '   %-4s %s/%s\n' "$ARM_A" "$TOTAL_KIT" "$TOTAL_CHECKS"
 [ -n "$ARM_B" ] && printf '   %-4s %s/%s\n' "$ARM_B" "$TOTAL_BARE" "$TOTAL_CHECKS_B"
-if [ -n "$ARM_B" ] && [ "$TOTAL_CHECKS" -gt 0 ] && [ "$NOT_MEASURED" = 0 ] && [ "$LIMITED" = 0 ]; then
+if [ -n "$ARM_B" ] && [ "$TOTAL_CHECKS" -gt 0 ] && [ "$NOT_MEASURED" = 0 ] && [ "$LIMITED" = 0 ] && [ "$SKIPPED" = 0 ]; then
   printf '   delta %s - %s: %+d checks\n' "$ARM_A" "$ARM_B" "$((TOTAL_KIT - TOTAL_BARE))"
   [ "$ARM_B" = bare ] && [ "$TOTAL_KIT" -le "$TOTAL_BARE" ] && \
     echo "   NOTE: the kit did not come out ahead. Report that as it stands — a harness that only publishes"
@@ -331,8 +359,9 @@ if [ -n "$ARM_B" ] && [ "$TOTAL_CHECKS" -gt 0 ] && [ "$NOT_MEASURED" = 0 ] && [ 
     echo "         favourable runs measures nothing."
 fi
 [ "$RUNS" = 1 ] && echo "   n=1: one run per arm is an anecdote, not a rate. Use --runs 3+ before quoting a number."
-if [ "$NOT_MEASURED" -gt 0 ] || [ "$LIMITED" = 1 ]; then
-  printf '   INCOMPLETE: %s run(s) NOT MEASURED%s. The totals above are not a result.\n' "$NOT_MEASURED" \
+if [ "$NOT_MEASURED" -gt 0 ] || [ "$LIMITED" = 1 ] || [ "$SKIPPED" -gt 0 ]; then
+  printf '   INCOMPLETE: %s run(s) NOT MEASURED%s%s. The totals above are not a result.\n' "$NOT_MEASURED" \
+    "$([ "$SKIPPED" -gt 0 ] && echo ", $SKIPPED case(s) SKIPPED for a missing tool")" \
     "$([ "$LIMITED" = 1 ] && echo ', and the usage limit stopped every later run before it started')"
   exit 3
 fi

--- a/evals/run.sh
+++ b/evals/run.sh
@@ -35,7 +35,8 @@
 #   bash evals/run.sh --case secret-refused # one case
 #   bash evals/run.sh --keep                # keep the scratch projects for inspection
 #
-# Exit 0 the report printed · 1 a case is malformed or the CLI is unusable.
+# Exit 0 the report printed · 1 a case is malformed or the CLI is unusable · 3 INCOMPLETE: a run was not measured (a usage
+# limit, or a stream that ended in an error), so the totals printed are not a result.
 set -uo pipefail
 ROOT="${CSK_EVAL_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 CASES="${CSK_EVAL_CASES:-$ROOT/evals/cases}"
@@ -110,18 +111,22 @@ build_project() {
 # without the documented escape the kit arm would be unable to commit for reasons that have nothing to do with
 # the behaviour under test. The content gates (trace/secret pre-commit) still run — that is the point.
 # eval_trace_metrics <stream.jsonl> <stdout.txt> — one TSV line:
-#   agent_top agent_all spawned cost in out cache_read cache_create turns bad_lines has_result tests tests_nested turns_top turns_nested
+#   agent_top agent_all spawned cost in out cache_read cache_create turns bad_lines has_result tests tests_nested turns_top turns_nested is_error limited
 # The last four were appended, not inserted, so every earlier column keeps its position. `tests` counts Bash calls that run a test
 # runner or a build/lint tool — main thread and subagents alike, since the stream carries both — deduplicated by tool_use id. The bare
 # word "test" is deliberately not a match: measured on real transcripts, the calls it caught alone were echo banners, not runs.
 # agent_top counts Agent/Task calls made by the MAIN thread (no parent_tool_use_id); agent_all includes nested ones.
 # has_result=0 means the stream is empty or broken: that run says nothing about delegation and must not be counted.
+# is_error=1 and limited=1 mean the same thing for a stream that DID end in a result. A usage-limit rejection is exactly that: a
+# result event with subtype success, is_error true and api_error_status 429, preceded by a rate_limit_event whose status is
+# "rejected". Measured: a 9-session run hit the five-hour limit in its 2nd session and the next 7 returned in ~0.6 s each, with
+# a result event and no tool call. has_result alone counted all of them, and the grader scored 7 untouched projects.
 eval_trace_metrics() {
   python3 - "$1" "$2" <<'PYM'
 import json, sys, re
 src, txt = sys.argv[1], sys.argv[2]
 RUNRX = re.compile(r'(^|[\s;&|(])(pytest|jest|vitest|mocha|make|mvn|gradle|tsc|eslint|ruff|flake8|mypy)\b|(dotnet|go|cargo)\s+(test|build)\b|(npm|pnpm|yarn)\s+(run\s+)?(test|build|lint)\b|\bnode\s+--test\b')
-top = allc = bad = 0; res = None
+top = allc = bad = limited = 0; res = None
 tests = tnest = 0; seen_tu = set(); msgs_top = set(); msgs_nest = set()
 try: lines = open(src, errors='replace').read().splitlines()
 except OSError: lines = []
@@ -142,6 +147,8 @@ for line in lines:
             elif c.get('name') == 'Bash' and RUNRX.search((c.get('input') or {}).get('command') or ''):
                 tests += 1
                 if nested: tnest += 1
+    elif e.get('type') == 'rate_limit_event':
+        if (e.get('rate_limit_info') or {}).get('status') == 'rejected': limited = 1
     elif e.get('type') == 'result':
         res = e
 open(txt, 'w').write((res or {}).get('result') or '')
@@ -149,7 +156,8 @@ u = (res or {}).get('usage') or {}
 sp = ((res or {}).get('subagent_stats') or {}).get('spawned', '')
 print('\t'.join(str(x) for x in (top, allc, sp, (res or {}).get('total_cost_usd', ''), u.get('input_tokens', ''),
       u.get('output_tokens', ''), u.get('cache_read_input_tokens', ''), u.get('cache_creation_input_tokens', ''),
-      (res or {}).get('num_turns', ''), bad, 1 if res else 0, tests, tnest, len(msgs_top), len(msgs_nest))))
+      (res or {}).get('num_turns', ''), bad, 1 if res else 0, tests, tnest, len(msgs_top), len(msgs_nest),
+      1 if (res or {}).get('is_error') else 0, 1 if limited or (res or {}).get('api_error_status') == 429 else 0)))
 PYM
 }
 
@@ -198,8 +206,9 @@ ARMS="${CSK_EVAL_ARMS:-kit bare}"; ARM_A="${ARMS%% *}"; ARM_B=""; [ "$ARMS" != "
 printf '== kit A/B eval ==  %s · %s runs/arm · arms: %s\n\n' "$MODEL" "$RUNS" "$ARMS"
 [ -d "$CASES" ] || { echo "run.sh: no cases under evals/cases" >&2; exit 1; }
 
-TOTAL_KIT=0; TOTAL_BARE=0; TOTAL_CHECKS=0; TOTAL_CHECKS_B=0
+TOTAL_KIT=0; TOTAL_BARE=0; TOTAL_CHECKS=0; TOTAL_CHECKS_B=0; NOT_MEASURED=0; LIMITED=0
 for cdir in "$CASES"/*/; do
+  [ "$LIMITED" = 1 ] && break
   cname="$(basename "$cdir")"
   [ -n "$ONLY" ] && [ "$ONLY" != "$cname" ] && continue
   [ -f "$cdir/case.env" ] && [ -f "$cdir/grade.sh" ] || { echo "run.sh: $cname is missing case.env or grade.sh" >&2; exit 1; }
@@ -210,8 +219,10 @@ for cdir in "$CASES"/*/; do
   [ -n "${DESC:-}" ] && echo "   $DESC"
 
   for arm in $ARMS; do
-    passed=0; checks=0; detail=""; gates=""
+    [ "$LIMITED" = 1 ] && break
+    passed=0; checks=0; detail=""; gates=""; arm_nm=0; arm_graded=0
     for r in $(seq 1 "$RUNS"); do
+      [ "$LIMITED" = 1 ] && break
       P="$WORK/$cname-$arm-$r"
       # A failed install must never degrade into "the kit arm behaved like the bare one" — that is the single
       # result this harness could produce that looks like a finding and is actually a bug in itself.
@@ -230,6 +241,31 @@ for cdir in "$CASES"/*/; do
         echo "     Only matters for cases needing a pre-approved permission. Re-run with CSK_EVAL_WORK=<a trusted path>," >&2
         echo "     or trust $P once interactively." >&2
       fi
+      # A run that never happened must not be graded. A usage-limit rejection leaves the seed project untouched, and an
+      # untouched project passes every "was not changed" check: measured, 7 rejected runs scored 2 checks each. So a run is
+      # graded only on evidence that it ran. In trace mode that is a result that is neither an error nor limited. Without the
+      # stream it is a reply that is not the limit message, in the one form seen so far, the result text of a rejected run:
+      # "You've hit your session limit · resets …".
+      nm=""
+      if [ "${CSK_EVAL_TRACE:-0}" = 1 ]; then
+        m_has=""; m_err=""; m_lim=""
+        read -r m_has m_err m_lim < <(LC_ALL=C awk -F'\t' '{print ($11==""?0:$11), ($16==""?0:$16), ($17==""?0:$17)}' "$P/.eval-metrics.tsv" 2>/dev/null)
+        if [ "${m_has:-0}" != 1 ]; then nm="the stream is empty or broken"
+        elif [ "${m_err:-0}" = 1 ] || [ "${m_lim:-0}" = 1 ]; then
+          nm="the run ended in an error or hit the usage limit: $(head -1 "$P/.eval-stdout.txt" 2>/dev/null | cut -c1-160)"
+        fi
+        [ "${m_lim:-0}" = 1 ] && LIMITED=1
+      elif head -1 "$P/.eval-stdout.txt" 2>/dev/null | grep -qiE "^you.ve hit your .*limit"; then
+        nm="$(head -1 "$P/.eval-stdout.txt" | cut -c1-160)"; LIMITED=1
+      fi
+      if [ -n "$nm" ]; then
+        NOT_MEASURED=$((NOT_MEASURED+1)); arm_nm=$((arm_nm+1))
+        printf '   ! %s run %s NOT MEASURED, not graded — %s\n' "$arm" "$r" "$nm"
+        [ -s "$P/.eval-metrics.tsv" ] && cat "$P/.eval-metrics.tsv" >> "$WORK/trace-$cname-$arm.tsv"
+        [ "$LIMITED" = 1 ] && { printf '   ! usage limit reached — no further run is started\n'; break; }
+        continue
+      fi
+      arm_graded=$((arm_graded+1))
       # KIT_ROOT lets a grader reuse the kit's own pattern files. It must come from the RUNNER, not be
       # discovered inside the project: the bare arm has no .claude/, so a grader that looked there would score
       # "cannot grade" as a failure and quietly penalise the arm for being the control.
@@ -250,18 +286,19 @@ for cdir in "$CASES"/*/; do
     done
     if [ "${CSK_EVAL_TRACE:-0}" = 1 ]; then
       LC_ALL=C awk -F'\t' -v arm="$arm" '
-        { n++; if ($11 != 1) { empty++; next } ok++; if ($1 > 0) deleg++; cost += $4; tin += $5; tout += $6; cr += $7; cc += $8; tst += $12; tsn += $13; ttop += $14; tnst += $15 }
+        { n++; if ($11 != 1 || $16 == 1 || $17 == 1) { empty++; next } ok++; if ($1 > 0) deleg++; cost += $4; tin += $5; tout += $6; cr += $7; cc += $8; tst += $12; tsn += $13; ttop += $14; tnst += $15 }
         END {
           if (n == 0) { printf "     trace %-5s NO TRACE FILE — the runs wrote no metrics; this measured nothing\n", arm; exit }
           printf "     trace %-5s delegated %d/%d · cost $%.3f · in %d out %d cache_read %d cache_create %d · test runs %d (nested %d) · turns %d (nested %d)", arm, deleg, ok, cost, tin, tout, cr, cc, tst, tsn, ttop, tnst
-          if (empty) printf " · %d EMPTY/BROKEN stream(s), not counted", empty
+          if (empty) printf " · %d EMPTY/BROKEN/ERROR stream(s), not counted", empty
           printf "\n"
         }' "$WORK/trace-$cname-$arm.tsv" 2>/dev/null || printf '     trace %-5s NO TRACE FILE — the runs wrote no metrics; this measured nothing\n' "$arm"
     fi
     if [ "$arm" = "$ARM_A" ]; then TOTAL_KIT=$((TOTAL_KIT+passed)); TOTAL_CHECKS=$((TOTAL_CHECKS+checks));
     elif [ "$arm" = "$ARM_B" ]; then TOTAL_BARE=$((TOTAL_BARE+passed)); TOTAL_CHECKS_B=$((TOTAL_CHECKS_B+checks)); fi
     printf '   %-5s %s/%s checks' "$arm" "$passed" "$checks"
-    [ "$RUNS" -gt 1 ] && printf ' (over %s runs)' "$RUNS"
+    if [ "$arm_graded" -lt "$RUNS" ]; then printf ' (%s of %s runs graded · %s NOT MEASURED)' "$arm_graded" "$RUNS" "$arm_nm"
+    elif [ "$RUNS" -gt 1 ]; then printf ' (over %s runs)' "$RUNS"; fi
     printf '\n'
     # Tally each distinct check across the runs instead of printing them N times.
     printf '%s\n' "$detail" | grep -E '^(PASS|FAIL) ' \
@@ -286,7 +323,7 @@ done
 echo "== summary =="
 printf '   %-4s %s/%s\n' "$ARM_A" "$TOTAL_KIT" "$TOTAL_CHECKS"
 [ -n "$ARM_B" ] && printf '   %-4s %s/%s\n' "$ARM_B" "$TOTAL_BARE" "$TOTAL_CHECKS_B"
-if [ -n "$ARM_B" ] && [ "$TOTAL_CHECKS" -gt 0 ]; then
+if [ -n "$ARM_B" ] && [ "$TOTAL_CHECKS" -gt 0 ] && [ "$NOT_MEASURED" = 0 ] && [ "$LIMITED" = 0 ]; then
   printf '   delta %s - %s: %+d checks\n' "$ARM_A" "$ARM_B" "$((TOTAL_KIT - TOTAL_BARE))"
   [ "$ARM_B" = bare ] && [ "$TOTAL_KIT" -le "$TOTAL_BARE" ] && \
     echo "   NOTE: the kit did not come out ahead. Report that as it stands — a harness that only publishes"
@@ -294,4 +331,9 @@ if [ -n "$ARM_B" ] && [ "$TOTAL_CHECKS" -gt 0 ]; then
     echo "         favourable runs measures nothing."
 fi
 [ "$RUNS" = 1 ] && echo "   n=1: one run per arm is an anecdote, not a rate. Use --runs 3+ before quoting a number."
+if [ "$NOT_MEASURED" -gt 0 ] || [ "$LIMITED" = 1 ]; then
+  printf '   INCOMPLETE: %s run(s) NOT MEASURED%s. The totals above are not a result.\n' "$NOT_MEASURED" \
+    "$([ "$LIMITED" = 1 ] && echo ', and the usage limit stopped every later run before it started')"
+  exit 3
+fi
 exit 0


### PR DESCRIPTION
Three limits kept the eval harness from answering what a discipline change has to answer. It could only compare the
kit with a bare project. It could not see delegation or test runs — it grades files, and a subagent leaves the same
files behind as the main thread. And, as a paid run found, it graded runs that never happened.

## What changes

- **Arms.** `CSK_EVAL_ARMS` (default `kit bare`, unchanged). Arm `kitb` is the same install with the rule under test
  swapped in: the discipline half of `CSK_EVAL_DISCIPLINE_B`, and, for a rule that also lives in agent definitions,
  `CSK_EVAL_OVERLAY_B` — files that replace installed ones under `.claude/`. An overlay path the install did not create
  is refused, not added.
- **Trace.** `CSK_EVAL_TRACE=1` captures `--output-format stream-json` and records per run: main-thread and nested
  `Agent`/`Task` calls, `subagent_stats`, cost, tokens, turns per thread, **test and build runs** in both threads
  (deduplicated by tool-use id; the bare word `test` is not a match) and **`final_tested`** — whether a test or build
  run came after the last `Edit`/`Write`. Columns are only ever appended. Grading still reads only the disk.
- **A run that did not happen is not graded.** An empty stream, a stream with no `result`, an error result or a
  usage-limit rejection is printed NOT MEASURED and left out of the score. The limit stops the run — no later session
  starts — and the runner exits 3, INCOMPLETE, with no delta.
- **`REQUIRES`** in `case.env`: a case whose tool is missing is skipped before anything is built or paid for.
- **Cases from elsewhere** (`CSK_EVAL_CASES`) · **stdin is `/dev/null`**, so the CLI no longer waits three seconds per
  run · **`--help`** prints the whole header instead of a fixed 30 lines that stopped in the middle of the usage block.
- **Nine cases:** three low-risk (a comment typo, a README typo, an in-file rename), three high-risk (a one-line auth
  comparison, a behaviour change across code and test, a migration on stored data), and three Node test-run cases (a
  bug pinned by a failing test, a single-file refactor under existing tests, a small rule change in code and its test).

## The defect a paid run found

A nine-session run hit the five-hour usage limit in its second session. The next seven came back in about 0.6 s each
with a well-formed `result` event — `is_error: true`, `api_error_status: 429` — and no tool call. The runner counted
them, graded the untouched projects and printed **19 of 33**, because an untouched project passes every "was not
changed" check; it also kept starting sessions the limit had refused. Fixed in e2e5394.

## How it was checked

| check | result |
|---|---|
| every risk-case grader in four states — untouched fails · intended fix passes · over-broad change fails · intended fix plus install and runner leftovers passes | 6 / 6 |
| stand-in CLI reading the installed discipline: `kit` delegates, `kitb` does not · default `kit bare` with trace off behaves as before | ✓ · ✓ |
| fake CLI replaying the real rejected streams: clean · the incident's order · an error without a limit (not graded, the run continues) · the limit message in text mode | 23 / 23 |
| the previous runner, given the incident's order | reproduces 19 of 33 |
| overlay: the arms differ in exactly the overlaid file and the discipline · a mistyped path aborts and names it · an edit after the last test reads `final_tested` 0 · limit scenarios unchanged | 15 / 15 |
| `REQUIRES`: a missing tool skips its case with nothing built · names the tool · does not leak into the next case · limit answer unchanged | 6 / 6 |
| `bash packaging/verify.sh` on c0aebb6 | 7 steps passed · smoke 658 graded, 0 skipped¹ |

¹ 659 in a checkout whose directory has a Claude Code transcript: the smoke test's by-hand `context-usage.sh` check is a
note rather than a graded check where there is none.

## Measurements taken with it

### 1. A risk-based delegation threshold

Recorded in `evals/README.md`. A risk-based delegation threshold — inline only for one file, no behaviour change and no
test to change — was measured against the current discipline: six cases × two arms × three runs, with the criteria, the
cases, the runner and the analysis hashed before the first counted run.

| class | arm | delegated | checks |
|---|---|---|---|
| low risk | kit | 0/9 | 27/27 |
| low risk | kitb | 0/9 | 27/27 |
| high risk | kit | 9/9 | 22/24 |
| high risk | kitb | 9/9 | 23/24 |

**The draft does not ship.** The low-risk criterion failed on a floor — the current discipline already delegated none of
the low-risk tasks, so no wording could have passed — while the draft opened no escape hatch on high-risk work. No
discipline text changes in this PR.

### 2. How many test runs a small change costs today

The current kit, three Node cases × three runs, CLI 2.1.268, with the go/no-go rule for a reduction experiment written
and hashed first (at least 7 of 9 sessions counted, and a median of at least 4 test or build runs per session):

| case | test/build runs per session | of them in subagents | checks |
|---|---|---|---|
| a bug pinned by a failing test | 4 · 3 · 6 | 2 · 2 · 5 | 9 / 9 |
| a single-file refactor | 5 · 8 · 4 | 3 · 6 · 3 | 12 / 12 |
| a small rule change | 3 · 6 · 6 | 2 · 4 · 5 | 12 / 12 |

9 of 9 counted, median **5**, 32 of 45 runs in subagents, and the final code was tested in 9 of 9 sessions. Of the 45:
backend-expert 17, main thread 13, review-agent 11, test-expert 3, security-expert 1 — the same unchanged code verified
again at each layer. A first attempt at this run measured nothing: it is the one the usage limit cut short, above.
A pre-registered reduction experiment built on this baseline is reported separately.
