### PR TITLE
fix(hooks): four costs on every command, and two gates that could report green while broken

### DIFF
--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -1108,22 +1108,43 @@ enc_csk(){ printf '%s' "$1" | sed "${CSK_ENC_SED:-s#x#x#}"; }
 #     version of this gate reported green on three files after the marker had been renamed — the exact hole it
 #     exists to close. The marker must be followed by a space or end of line; both shipped markers are (one is
 #     padded with dashes, the other ends the line).
+# Each copy is read with awk's index(), not a regex. The first version used sed's `\|` alternation, a GNU extension:
+# BSD sed matches nothing with it, every copy read as empty, and the macOS runner said "found 0" while ubuntu and
+# windows (GNU sed both) were green. Measured with the system tools rather than assumed — BSD grep 2.6.0 handles
+# `( |$)` correctly (rc 0 on all five hook files, rc 1 on a `...XR` line); /usr/bin/sed returned 0 lines for all
+# five blocks. A marker counts only when a space follows it or it ends the line: `---- /CSK-TRANSCRIPT-DIR` ends the
+# line, so a fixed string with a trailing space would miss it on every platform.
+# Exit: 0 start and end found (block printed) · 1 no start marker · 3 start marker without an end marker.
+_blk_read(){   # $1 = marker name, $2 = file
+  awk -v s="---- $1" -v e="---- /$1" '
+    function at(line, mk,   i, nx) { i = index(line, mk); if (!i) return 0; nx = substr(line, i + length(mk), 1); return nx == "" || nx == " " }
+    !on && at($0, s) { on = 1 }
+    on { print }
+    on && at($0, e) { done = 1; exit }
+    END { exit done ? 0 : (on ? 3 : 1) }' "$2"
+}
 _blk_gate(){   # $1 = marker name, $2 = what the block is, in words
-  local m="$1" what="$2" f base blk first="" firstf="" n=0 names="" drift=""
+  local m="$1" what="$2" f base blk rc first="" firstf="" n=0 names="" drift="" unread=""
   for f in "$HOOKS"/*; do
     [ -f "$f" ] || continue
-    grep -qE -- "---- $m( |$)" "$f" 2>/dev/null || continue
     base="$(basename "$f")"
-    blk="$(sed -n "/---- $m\\( \\|$\\)/,/---- \\/$m\\( \\|$\\)/p" "$f")"
-    if [ -z "$blk" ]; then drift="$drift $base(no-end-marker)"; continue; fi
+    blk="$(_blk_read "$m" "$f")"; rc=$?
+    case "$rc" in
+      0) ;;
+      1) continue ;;
+      3) unread="$unread $base(no-end-marker)"; continue ;;
+      *) unread="$unread $base(awk-rc=$rc)"; continue ;;
+    esac
     n=$((n+1)); names="$names $base"
     if [ -z "$first" ]; then first="$blk"; firstf="$base"
     elif [ "$blk" != "$first" ]; then drift="$drift $base"; fi
   done
+  # A copy that could not be read is named in every branch. The first version filed it under drift and then let the
+  # "fewer than two" branch print, so the one fact that explained the failure never reached the log.
   if [ "$n" -lt 2 ]; then
-    fail "$what: expected at least 2 files carrying '$m', found $n (${names:-none}) — marker renamed or a copy lost"
-  elif [ -n "$drift" ]; then
-    fail "$what: DRIFTED from $firstf ->$drift  (compared $n files:$names)"
+    fail "$what: expected at least 2 files carrying '$m', found $n (${names:-none})${unread:+ · UNREADABLE:$unread} — marker renamed, a copy lost, or a copy unreadable"
+  elif [ -n "$drift$unread" ]; then
+    fail "$what: DRIFTED from $firstf ->${drift:- none}${unread:+ · UNREADABLE:$unread}  (compared $n files:$names)"
   else
     pass "$what is byte-identical across all $n files that carry it —$names"
   fi

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -1089,21 +1089,47 @@ enc_csk(){ printf '%s' "$1" | sed "${CSK_ENC_SED:-s#x#x#}"; }
   && pass "encode: underscore folds to '-' (misses every such project otherwise)" \
   || fail "encode: underscore NOT folded -> $(enc_csk '/Users/x/my_app')"
 # The encoder is written out twice, once per hook, because a shared file would have to be added to
-# build-plugin.sh's explicit copy list and a miss there breaks the plugin channel silently. Two copies are only
-# safe while they cannot drift, so that is enforced here rather than trusted.
-cu_blk="$(sed -n '/---- CSK-TRANSCRIPT-DIR/,/---- \/CSK-TRANSCRIPT-DIR/p' "$HOOKS/context-usage.sh")"
-ss_blk="$(sed -n '/---- CSK-TRANSCRIPT-DIR/,/---- \/CSK-TRANSCRIPT-DIR/p' "$HOOKS/session-stats.sh")"
-[ -n "$cu_blk" ] && [ "$cu_blk" = "$ss_blk" ] \
-  && pass "the duplicated resolver is byte-identical in both hooks" \
-  || fail "context-usage.sh and session-stats.sh resolvers have DRIFTED (or the markers are missing)"
-# Same reasoning, second pair: guard-write.sh carries a copy of guard-bash.sh's JSON parser, because the tier-3
-# fallback it replaced read only `file_path` and truncated at the first escaped quote. A shared file would have
-# to be added to build-plugin.sh's explicit copy list and a miss there breaks the plugin channel silently.
-gb_blk="$(sed -n '/---- CSK-JSON-PARSE/,/---- \/CSK-JSON-PARSE/p' "$HOOKS/guard-bash.sh")"
-gw_blk="$(sed -n '/---- CSK-JSON-PARSE/,/---- \/CSK-JSON-PARSE/p' "$HOOKS/guard-write.sh")"
-[ -n "$gb_blk" ] && [ "$gb_blk" = "$gw_blk" ] \
-  && pass "the duplicated JSON parser is byte-identical in both guards" \
-  || fail "guard-bash.sh and guard-write.sh JSON parsers have DRIFTED (or the markers are missing)"
+# Two blocks in this kit are duplicated on purpose: CSK-TRANSCRIPT-DIR (context-usage.sh + session-stats.sh)
+# and CSK-JSON-PARSE (the guards). A shared file would have to be added to build-plugin.sh's explicit copy
+# list and a miss there breaks the plugin channel silently, so the copies stay and the equality is enforced
+# here rather than trusted.
+#
+# This used to name the two files of each pair. That is the same shape as the defect it exists to catch: a
+# THIRD copy appears — guard-commit-scan.sh took the JSON parser — and a gate that was told to compare two
+# files reports green while the third drifts. So the marker decides the file list, not the file list the
+# marker.
+#
+# Two things make it able to give a wrong answer visibly, and both were earned by running it against a broken
+# tree rather than by reasoning:
+#   * AT LEAST TWO, and the NAMES printed. Rename the marker and a "compare everything that carries it" gate
+#     compares zero files and passes forever. A count alone is not enough either: it can be right while the
+#     files are wrong.
+#   * ANCHORED matching. `---- CSK-JSON-PARSE` matches `---- CSK-JSON-PARSER` as a substring, so the first
+#     version of this gate reported green on three files after the marker had been renamed — the exact hole it
+#     exists to close. The marker must be followed by a space or end of line; both shipped markers are (one is
+#     padded with dashes, the other ends the line).
+_blk_gate(){   # $1 = marker name, $2 = what the block is, in words
+  local m="$1" what="$2" f base blk first="" firstf="" n=0 names="" drift=""
+  for f in "$HOOKS"/*; do
+    [ -f "$f" ] || continue
+    grep -qE -- "---- $m( |$)" "$f" 2>/dev/null || continue
+    base="$(basename "$f")"
+    blk="$(sed -n "/---- $m\\( \\|$\\)/,/---- \\/$m\\( \\|$\\)/p" "$f")"
+    if [ -z "$blk" ]; then drift="$drift $base(no-end-marker)"; continue; fi
+    n=$((n+1)); names="$names $base"
+    if [ -z "$first" ]; then first="$blk"; firstf="$base"
+    elif [ "$blk" != "$first" ]; then drift="$drift $base"; fi
+  done
+  if [ "$n" -lt 2 ]; then
+    fail "$what: expected at least 2 files carrying '$m', found $n (${names:-none}) — marker renamed or a copy lost"
+  elif [ -n "$drift" ]; then
+    fail "$what: DRIFTED from $firstf ->$drift  (compared $n files:$names)"
+  else
+    pass "$what is byte-identical across all $n files that carry it —$names"
+  fi
+}
+_blk_gate CSK-TRANSCRIPT-DIR "the duplicated transcript-dir resolver"
+_blk_gate CSK-JSON-PARSE     "the duplicated JSON parser"
 # End to end: called by hand from this repo, the hook must produce a reading rather than "transcript not found".
 cu_hand="$(cd "$ROOT/.." && bash "$HOOKS/context-usage.sh" 2>&1)"
 case "$cu_hand" in
@@ -1765,8 +1791,45 @@ if [ "$UNITS" = 1 ]; then
 # `git checkout -b`, and an exit-0 hook says "no opinion", which leaves those rules in force — so a keyed
 # headless session could not stage, let alone commit, and the key achieved nothing it was documented to do.
 # Asserting the exit code alone is what let that ship: the code was always right, the decision was missing.
-gj(){ printf '{"tool_name":"Bash","permission_mode":"%s","tool_input":{"command":"%s"}}' "$1" "$2"; }
+# The payload shape, captured rather than assumed. Claude Code 2.1.267 sends, in this order:
+#   session_id, transcript_path, cwd, prompt_id, permission_mode, effort, hook_event_name, tool_name,
+#   tool_input{command, description}, tool_use_id
+# — one line, no space after any colon. So `permission_mode` arrives BEFORE `tool_input`, which is what this
+# fixture has always produced. guard-bash.sh's header used to describe the opposite order; that was wrong and
+# has been corrected. The `effort` field did not exist in 2.1.246.
+#
+# The `late` variant below is NOT the real shape and must not be read as one. Key order in a JSON object is
+# not a contract, the payload has gained fields inside one minor version, and the parser's cost used to depend
+# on where the key sat — `permission_mode` behind a 100 KB command measured 7.94s on Git Bash against 0.27s in
+# front of it. That dependence has been removed; `late` is what keeps it removed. It is a guard against the
+# order changing, not a reproduction of it.
+gj(){   # $1 = permission mode, $2 = command, $3 = "late" to put permission_mode AFTER tool_input
+  case "${3:-}" in
+    late) printf '{"tool_name":"Bash","tool_input":{"command":"%s"},"permission_mode":"%s"}' "$2" "$1" ;;
+    *)    printf '{"tool_name":"Bash","permission_mode":"%s","tool_input":{"command":"%s"}}' "$1" "$2" ;;
+  esac
+}
 gdec(){ printf '%s' "$1" | sed -n 's/.*"permissionDecision"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1; }
+# KEY ORDER MUST NOT CHANGE A VERDICT. Every fixture in this suite puts `permission_mode` before `tool_input`
+# — which the capture above confirms is the real shape — so until now nothing here exercised the other order
+# at all. That is the shape of a gate verified only on the path someone happens to send: the parser's cost
+# genuinely depended on key position, and if a future payload moves the key, the suite would keep reporting
+# green while the parse it verified is no longer the parse that runs.
+#
+# So: the same commands, both orders, and the verdicts compared rather than each asserted separately. A
+# difference here means the parse is position-sensitive again.
+_ord_diff=""
+for _c in 'git commit -m x' 'git push --force' 'rm -rf /' 'ls -la' 'git reset --hard HEAD~1' \
+          'echo exit 0 > .git/hooks/pre-commit' 'cat README.md'; do
+  for _m in default bypassPermissions; do
+    _a="$(gj "$_m" "$_c" | bash "$HOOKS/guard-bash.sh" 2>/dev/null)"; _ra=$?
+    _b="$(gj "$_m" "$_c" late | bash "$HOOKS/guard-bash.sh" 2>/dev/null)"; _rb=$?
+    [ "$_ra" = "$_rb" ] && [ "$(gdec "$_a")" = "$(gdec "$_b")" ] || _ord_diff="$_ord_diff [$_m: $_c → rc $_ra/$_rb, dec $(gdec "$_a")/$(gdec "$_b")]"
+  done
+done
+[ -z "$_ord_diff" ] \
+  && pass "the verdict does not depend on where permission_mode sits in the payload (14 runs, both orders)" \
+  || fail "key order CHANGED a verdict — the parse is position-sensitive:$_ord_diff"
 # WHICH MODES CAN ACTUALLY ASK. Only `default` and `acceptEdits` put the prompt in front of a person. In `auto`
 # the classifier answers it and `dontAsk` asks nothing by definition — measured in a real session as 14 `ASK`
 # lines in the gate log against zero human keypresses — so those two fail closed with plan/bypassPermissions.

--- a/claude-starter/hooks/guard-commit-scan.sh
+++ b/claude-starter/hooks/guard-commit-scan.sh
@@ -21,6 +21,247 @@
 set -uo pipefail
 DIR="$(cd "$(dirname "$0")" && pwd)"
 
+# ---- CSK-JSON-PARSE ------------------------------------------------------------------------------------
+_json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) string value, "" if absent
+  local LC_ALL=C   # FIRST, so every expansion below -- the key search included -- counts and cuts in bytes.
+                   # Lengths from ${#x} are used as offsets into ${y:n}; with the locale set before any of
+                   # them, the two never disagree about a unit. Walking bytes is safe because no UTF-8
+                   # continuation byte can be 0x5C or 0x22, so a cut cannot land inside a character at a
+                   # quote or backslash edge. What this line is worth in SPEED depends on the platform --
+                   # read the table in _json_unescape below before quoting a number for it.
+  local pre rest seg w r n base=0 j=0 cl lim run=0 chunk C=4096 W=256; local -a acc=("")
+  # Every "step past X" here is arithmetic on a length, never `${s#"$literal"}`. That shape reads like a
+  # constant-time strip and is not one: bash retries the pattern at every prefix length, so stripping an
+  # n-byte literal costs O(n^2). It was in this function twice, and both were measured:
+  #   * `${1#*"$2"}` found the key -- cheap when the key sits near the front, quadratic in the distance to it
+  #     otherwise. `permission_mode` behind a 100 KB command took 7.94s on Git Bash, 0.27s in front of it.
+  #     Captured from Claude Code 2.1.267, the real order puts `permission_mode` BEFORE `tool_input`, so on
+  #     that version this cost was not reachable -- this file's header had shown the opposite order, and was
+  #     wrong. The parse stays order-independent regardless: the order is not a documented contract, and the
+  #     payload is still moving (`effort` is absent from the field list recorded on 2.1.246).
+  #   * `${tail#"$seg"\"}` stepped past each escaped quote: 16.8s for a single 100 KB step on Git Bash,
+  #     against 0.002s for `${tail:${#seg}+1}` doing exactly the same thing.
+  # `${1%%"$2"*}` still finds the FIRST occurrence -- the longest suffix that starts with the key starts at the
+  # earliest one -- so a command containing the literal text `"command":"` still cannot relocate the parse.
+  # Stepping by length removed the quadratic strip, but each escaped quote still sliced and re-assigned the
+  # whole remainder, so an escape-dense command stayed k*n here as well (2.2s of the 6.8s described in
+  # _json_unescape below, on Git Bash). The walk is chunked the same way: the payload is read 4096 bytes at a
+  # time and every per-quote operation stays inside the chunk. One thing is carried across edges on purpose
+  # -- the length of the backslash run in front of a quote -- because that run can straddle a window or a
+  # chunk, and its parity is what decides whether the quote ends the value. Isolated, escape-dense 44030 B:
+  # 2.61s -> 0.41s on Git Bash 5.3.15, 0.93s -> 0.09s on macOS/bash 3.2.
+  # Output is byte-identical to the previous shape across 378 cases at four chunk/window sizes down to 7 and 1
+  # bytes, and that shape to the one before it across a 27-case battery (escaped quotes, backslash runs before
+  # a quote, the key twice, the key appearing first as a value, glob metacharacters, UTF-8, no closing quote,
+  # empty input). Broken twins -- the run not carried across a window, a byte skipped after a quote -- prove
+  # the battery sees both.
+  pre="${1%%\"$2\"*}"                          # everything before the FIRST `"key"`
+  [ "$pre" != "$1" ] || return 0               # key absent: emit nothing
+  rest="${1:${#pre}+${#2}+2}"                  # past `"key"`
+  seg="${rest%%\"*}"                           # skip `: "` up to the value's opening quote, when there is one
+  [ "$seg" = "$rest" ] || rest="${rest:${#seg}+1}"
+  # Walk to the closing quote that is NOT escaped. A `"` preceded by an odd number of backslashes is content.
+  n=${#rest}; chunk="${rest:0:C}"; cl=${#chunk}
+  while :; do
+    lim=$((cl - j))
+    if [ "$lim" -le 0 ]; then
+      [ $((base + cl)) -lt "$n" ] || break                 # no closing quote at all: everything is already taken
+      base=$((base + j)); chunk="${rest:base:C}"; cl=${#chunk}; j=0; continue
+    fi
+    [ "$lim" -le "$W" ] || lim=$W
+    w="${chunk:j:lim}"
+    seg="${w%%\"*}"
+    if [ "$seg" = "$w" ]; then                             # no quote in view: take all of it, carry the run
+      acc+=("$w"); j=$((j+lim))
+      r="${w##*[!\\]}"; case "$w" in *[!\\]*) run=${#r} ;; *) run=$((run+${#w})) ;; esac
+      continue
+    fi
+    acc+=("$seg"); j=$((j+${#seg}+1))
+    r="${seg##*[!\\]}"; case "$seg" in *[!\\]*) run=${#r} ;; *) run=$((run+${#seg})) ;; esac
+    if [ $((run % 2)) -eq 1 ]; then acc+=("\""); run=0; else break; fi
+  done
+  local IFS=''; printf '%s' "${acc[*]}"
+}
+_json_unescape(){  # left-to-right, a chunk at a time; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
+  # This is the tier-3 path below -- the one a stock Windows install actually runs on. It used to walk ONE
+  # CHARACTER at a time, which is O(n^2) twice over: `${s%"${s#?}"}` matches a pattern the length of the
+  # entire remainder just to read one character, and `out="$out$c"` recopies the output for each one.
+  #
+  # That was not a comfort question. This hook's timeout is 60s -- set in settings.json, NOT Claude Code's
+  # default, and reading the default instead is how a first pass at this got the consequence wrong. A
+  # PreToolUse hook KILLED at its timeout emits no exit 2, so every rule below is simply skipped. Measured on
+  # the tier-3 path with jq and python3 both shadowed, the old shape crossed 60s at ~4.3 KB. And 4.3 KB is
+  # not exotic: across 6791 Bash calls in 280 real transcripts, 2.49% of commands are bigger, and the largest
+  # is 46815 B, which the old shape needed roughly 39 minutes to decode. One Bash call in forty walked past
+  # §4.4 and §4.5 entirely, silently, on every stock Windows desktop.
+  #
+  # Two changes, and their wins are NOT the same shape -- writing them down as one number was the mistake
+  # this comment exists to avoid repeating:
+  #   * Taking the whole run up to the next backslash in ONE expansion, and indexing with `${s:0:1}` instead
+  #     of matching a pattern, is 47x on a 4.4 KB payload. This one holds on every machine.
+  #   * `local LC_ALL=C` makes these expansions byte-oriented instead of re-decoding the string on every
+  #     substring operation. What that is WORTH depends on the platform, and putting a single number here
+  #     would have been wrong three separate ways -- it was written as "another 5x" twice before this:
+  #         macOS / bash 3.2, a locale set .................. 5x
+  #         Git Bash 5.3.15, a locale set ................... 1.23x   (measured on the OLD shape; the new one
+  #                                                                    touches the locale once per escape
+  #                                                                    rather than once per character, so its
+  #                                                                    ratio is smaller and unmeasured)
+  #         Git Bash, LANG empty -- what Claude Code starts .. nothing at all
+  #     So speed is not what keeps this line; CORRECTNESS is, and that half holds everywhere. `[0-9a-fA-F]`
+  #     below is a collation-defined range outside the C locale: on a tr_TR desktop it is not 0-9a-f. That
+  #     alone would justify the line, and it costs nothing. `local` restores the previous locale on return
+  #     -- verified on bash 3.2 and on Git Bash 5.3.15, not assumed.
+  #
+  # Then the cost moved rather than went away. With the per-character walk gone, each escape still sliced the
+  # whole REMAINDER -- `s="${s:${#pre}+1}"` -- so an escape-dense command stayed k*n: on Git Bash a 44080 B
+  # command with 2755 escapes took 6.8s, 11% of the timeout. The input is now touched only a chunk at a time
+  # (`${s:base:C}`, once per 4096 bytes) and every per-escape operation stays inside that chunk, so no escape
+  # pays for the length of the whole command. That is the change that matters: bounding only the lookahead,
+  # while still indexing the full string, was measured too and gave about 4x on both machines, against 6-12x
+  # for the chunked walk. Five bytes are held back at a chunk's end whenever more input follows, so a
+  # `\uXXXX` that starts in a chunk ends in it.
+  # The output goes into an array joined once, not a string recopied at every append, and `\n`/`\t` are
+  # written `$'\n'`/`$'\t'`, so this file carries no raw TAB for an editor or a copy to turn into spaces.
+  #
+  # Measured, isolated, previous shape -> this one:
+  #     macOS/bash 3.2   escape-dense 44030 B, 2590 escapes .. 1.44s -> 0.12s
+  #                      sparse 100014 B, 4 escapes ........... 0.09s -> 0.02s
+  #     Git Bash 5.3.15  escape-dense 44030 B, 2590 escapes .. 3.92s -> 0.54s
+  #     (LANG empty)     sparse 99997 B, 4 escapes ............ 0.49s -> 0.07s
+  # These numbers do not travel, which is why each one names its machine.
+  #
+  # Output is byte-identical to the previous shape across 478 cases, each run at four chunk/window sizes
+  # down to 7 and 1 bytes so that an edge falls every few bytes; that shape was itself byte-identical to
+  # the original character walk across a 31-case battery (escaped quotes, `\\`, a lone trailing backslash, a
+  # truncated `\u`, Turkish, emoji). Deliberately broken twins -- the 5-byte margin cut to 4, the backslash
+  # not stepped over -- prove the battery sees both edges, and tier 1 and tier 3 return the same verdict on
+  # the gate cases.
+  local LC_ALL=C
+  local s="$1" pre w c h n base=0 j=0 cl lim chunk C=4096 W=256; local -a acc=("")
+  case "$s" in *\\*) ;; *) printf '%s' "$s"; return 0 ;; esac   # no escapes: the common case pays nothing
+  n=${#s}; chunk="${s:0:C}"; cl=${#chunk}
+  while :; do
+    lim=$((cl - j))
+    if [ $((base + cl)) -lt "$n" ]; then                  # more input after this chunk: hold 5 bytes back, so
+      lim=$((lim - 5))                                     # a `\uXXXX` that starts in a chunk also ends in it
+      if [ "$lim" -le 0 ]; then base=$((base + j)); chunk="${s:base:C}"; cl=${#chunk}; j=0; continue; fi
+    else
+      [ "$lim" -gt 0 ] || break
+    fi
+    [ "$lim" -le "$W" ] || lim=$W
+    w="${chunk:j:lim}"
+    pre="${w%%\\*}"                                        # the literal run before the next backslash in view
+    if [ "$pre" = "$w" ]; then acc+=("$w"); j=$((j+lim)); continue; fi
+    acc+=("$pre"); j=$((j+${#pre}+1))
+    if [ $((base + j)) -ge "$n" ]; then acc+=("\\"); break; fi   # a lone trailing backslash stays literal, as before
+    c="${chunk:j:1}"; j=$((j+1))
+    case "$c" in
+      n) acc+=($'\n') ;;
+      t) acc+=($'\t') ;;
+      r) ;;
+      b|f) acc+=(" ") ;;
+      u) if [ $((n - base - j)) -ge 4 ]; then h="${chunk:j:4}"; j=$((j+4)); else h=""; fi   # a short tail is left alone, as before
+         # A `\uXXXX` used to become a literal `?`. That is not a lossy nicety, it is a hole: `\u002e` is `.`,
+         # so `\u002eclaude/hooks/guard-bash.sh` decoded to `?claude/…` and matched no gate pattern, while jq
+         # decoded the same bytes to the real path — the two tiers disagreed on whether a payload was an
+         # attack. Printable ASCII is decoded properly (builtin printf, no fork); anything else still becomes
+         # `?`, which is only ever a display concern because this value is used for MATCHING, never to write.
+         case "$h" in
+           00[2-7][0-9a-fA-F]) printf -v c "\\x${h#00}"; acc+=("$c") ;;
+           *)                  acc+=("?") ;;
+         esac ;;
+      *) acc+=("$c") ;;
+    esac
+  done
+  local IFS=''; printf '%s' "${acc[*]}"
+}
+# ---- /CSK-JSON-PARSE -----------------------------------------------------------------------------------
+
+# Extract the -m/--message VALUES from the command line without an interpreter.
+#
+# Without this tier the fallback below hands the WHOLE command line to the message scanner, and a file path is
+# not a message: `git commit -m "feat: add scaffolding" -- src/AI-generated/scaffold.ts` was refused with
+# "TRACE-SCANNER (message): 'AI-generated'" while the message itself is clean. The same commit is ACCEPTED
+# where python3 works, because that tier returns only the -m values — so the gate's verdict depended on
+# whether an interpreter resolved, not on the commit. This makes the interpreter-free tier answer the same
+# question the python3 tier answers.
+#
+# It is awk, not parameter expansion, and that is deliberate on a hook that already spawns ~49 processes for a
+# commit: a pure-shell character walk was written first and MEASURED QUADRATIC — 146 B 0.006s,
+# 4 KB 0.181s, 16 KB 1.03s, 64 KB 8.08s. That does NOT blow the 60 s timeout the kit sets, and the
+# largest command payload seen across 6791 real Bash calls was 46.8 KB — so this is a tail-risk
+# trade, not a rescue: awk is 0.049s flat to 64 KB and 0.585s at 1 MB, so the cost stops depending
+# on what someone pasted into a commit message. One fork, on a path that already spawns ~49 and only
+# when the python3 tier is unavailable; the zero-fork rule still governs the per-Bash-call path.
+# Byte-oriented under LC_ALL=C, which is safe because a UTF-8 continuation byte is always >= 0x80
+# and can never equal an ASCII quote.
+#
+# Contract: rc=0 with the values, or rc=1 when the line cannot be parsed with confidence (unterminated quote,
+# trailing backslash, an -m with nothing after it). rc=1 keeps the over-inclusive fallback, so this can only
+# remove false positives — it can never open a blind spot. Verified against a POSIX shlex oracle written
+# independently in another language: 37 command shapes, 33 byte-identical, 4 safe fallbacks, 0 mismatches,
+# with the harness itself calibrated by two deliberate mutations.
+csk_msg_values() {
+  CSK_CMD="$1" LC_ALL=C awk '
+    BEGIN {
+      s = ENVIRON["CSK_CMD"]; n = length(s); i = 1
+      ntok = 0; cur = ""; have = 0
+      while (i <= n) {
+        c = substr(s, i, 1)
+        if (c == " " || c == "\t" || c == "\n" || c == "\r" || c == "\f" || c == "\v") {
+          if (have) { ntok++; tok[ntok] = cur; cur = ""; have = 0 }
+          i++; continue
+        }
+        if (c == "\\") {                                  # outside quotes: escapes the next byte
+          i++
+          if (i > n) exit 1                               # trailing backslash
+          cur = cur substr(s, i, 1); have = 1; i++; continue
+        }
+        if (c == "'"'"'") {                               # single quotes: literal to the next quote
+          i++; have = 1
+          while (1) {
+            if (i > n) exit 1                             # no closing quote
+            c = substr(s, i, 1)
+            if (c == "'"'"'") { i++; break }
+            cur = cur c; i++
+          }
+          continue
+        }
+        if (c == "\"") {                                  # double quotes: backslash escapes " and \
+          i++; have = 1
+          while (1) {
+            if (i > n) exit 1                             # no closing quote
+            c = substr(s, i, 1)
+            if (c == "\"") { i++; break }
+            if (c == "\\" && i < n) {
+              nx = substr(s, i + 1, 1)
+              if (nx == "\"" || nx == "\\") { cur = cur nx; i += 2; continue }
+            }
+            cur = cur c; i++
+          }
+          continue
+        }
+        cur = cur c; have = 1; i++
+      }
+      if (have) { ntok++; tok[ntok] = cur }
+
+      out = ""; nout = 0
+      for (k = 1; k <= ntok; k++) {
+        t = tok[k]
+        if (t == "-m" || t == "--message") {
+          k++
+          if (k > ntok) exit 1                            # -m with nothing after it: do not guess
+          nout++; res[nout] = tok[k]
+        } else if (substr(t, 1, 10) == "--message=") {
+          nout++; res[nout] = substr(t, 11)
+        }
+      }
+      for (k = 1; k <= nout; k++) printf "%s\n", res[k]
+      exit 0
+    }'
+}
+
 INPUT="$(cat)"
 # Same ladder as guard-bash.sh, and for the same reason: the raw-text fallback leaves JSON escapes in place,
 # so `-m \"…\"` never matches a quote-based extraction and the message silently goes unscanned. That is
@@ -36,10 +277,19 @@ elif command -v python3 >/dev/null 2>&1 && CMD="$(printf '%s' "$INPUT" | python3
   _parsed=1
 fi
 if [ "$_parsed" = 0 ]; then
-  CMD="$(printf '%s' "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' | head -1 \
-        | sed 's/\\n/\n/g; s/\\"/"/g; s/\\\\/\\/g')"
+  # Tier 3, and it used to be a `sed | head | sed` pipeline: four processes on EVERY Bash tool call,
+  # to re-derive a string guard-bash.sh had already parsed one hook earlier, and then re-answer a
+  # question it had already answered. Measured on `ls -la`: guard-bash.sh 2 processes, this hook 7.
+  # guard-write.sh already carried the shared parser; this was the one hook that never got it.
+  CMD="$(_json_unescape "$(_json_slice "$INPUT" command)")"
 fi
 [ -z "$CMD" ] && exit 0
+
+# A command that does not contain `git` at all cannot match the pattern below, and finding that out
+# should not cost a process. Measured on `ls -la`: this hook spawned 7 processes to answer "no".
+# The test is case-INSENSITIVE while the pattern is not, so it is a superset: it can only let more
+# through to the real matcher, never less.
+case "$CMD" in *[Gg][Ii][Tt]*) ;; *) exit 0 ;; esac
 
 # Only git commit. Matching mirrors guard-bash.sh's tolerance for `git -C dir commit`, TAB separators and a
 # quoted binary, because a gate that a whitespace change walks past is not a gate.
@@ -89,6 +339,8 @@ for i, p in enumerate(parts):
     elif p.startswith("--message="): out.append(p.split("=", 1)[1])
 print("\n".join(out))
 ' 2>/dev/null)"; then
+    :
+  elif MSG="$(csk_msg_values "$CMD")"; then
     :
   else
     MSG="$CMD"

--- a/claude-starter/hooks/pre-commit
+++ b/claude-starter/hooks/pre-commit
@@ -170,8 +170,49 @@ fi
 # Nothing staged for the text scans AND the bloat gate is clean -> done.
 { [ -s "$TRACE_F" ] || [ -s "$SECRET_F" ] || [ "$HIT" -ne 0 ]; } || exit 0
 
+
+# Ask "can ANY pattern match" once, before asking "which one".
+#
+# The three loops below spawn one grep PER PATTERN — 12 + 11 + 3 = 26 processes on every commit, and the
+# overwhelming majority of commits are clean, so 26 of them exist only to say "no". Measured on 205 added
+# lines: the trace loop 0.621 s -> 0.063 s, the secret loop 0.572 s -> 0.059 s. One decision, then the loop
+# ONLY when the decision says there is something to name.
+#
+# Three-way on purpose, because grep has three answers and two of them must not shortcut:
+#   rc=1  nothing matches      -> done. This is the fast path and the common one.
+#   rc=0  something matches    -> run the loop, which names the pattern. The user still reads
+#                                 "forbidden expression -> '<pattern>'" verbatim; nothing is lost but time.
+#   rc=2  grep could not decide -> run the loop. TODAY'S BEHAVIOUR, deliberately.
+#
+# That last rung is what makes this safe rather than clever, and it was earned: joining the patterns compiles
+# them TOGETHER, so ONE broken regex kills the whole alternation. Measured with a pattern file carrying a valid
+# `Co-Authored-By` and a broken `foo[`, against a message that really does carry the trailer:
+#     grep -inEf together   rc=2, ZERO matches   <- the trailer goes unreported
+#     one grep per pattern  catches it; only the broken pattern is skipped
+# A blocklist is a file users edit by hand, so a broken pattern is not exotic — and failing OPEN there would be
+# the worst possible direction. rc=2 also covers an alternation too large to compile (measured: 40 KB fine,
+# 200 KB -> "grep: Memory exhausted", rc=2 -> loop), so the ARG_MAX question answers itself.
+#
+# Verified on the blocklists' OWN #test:/#test-clean: cases — 32 of them, the payload the gate actually
+# defends: 32/32 identical verdicts. Calibrated by mutation (strip the parentheses so a group-scoped `|`
+# escapes to top level): 8 mismatches, in BOTH directions — three clean messages newly rejected and two real
+# secrets newly passed. Also checked structurally: no pattern in either shipped blocklist carries a bare
+# top-level `|` (every one is inside a group) and none uses a back-reference, so joining cannot reshape them.
+_csk_any(){   # $1 = pattern list  $2 = corpus  $3 = grep flags  $4 = 1 for newline-joined fixed strings
+  local pat alt="" sep="|"
+  [ "$4" = 1 ] && sep="
+"
+  while IFS= read -r pat || [ -n "$pat" ]; do
+    pat="${pat%$'\r'}"
+    case "$pat" in ''|\#*) continue;; esac
+    alt="${alt:+$alt$sep}$pat"
+  done < "$1"
+  [ -n "$alt" ] || return 1
+  grep -q$3 -- "$alt" "$2" 2>/dev/null
+}
 # (1) trace scan — case-INsensitive (vendor / AI-authorship strings), project files only
-if [ -f "$BL" ] && [ -s "$TRACE_F" ]; then
+if _csk_any "$BL" "$TRACE_F" iE 0; then _dec=0; else _dec=$?; fi
+if [ -f "$BL" ] && [ -s "$TRACE_F" ] && [ "$_dec" != 1 ]; then
   while IFS= read -r pat || [ -n "$pat" ]; do
     pat="${pat%$'\r'}"                       # tolerate a CRLF blocklist (Windows/autocrlf checkout) — a trailing \r
     case "$pat" in ''|\#*) continue;; esac   # in the pattern never matches the LF-normalised diff, blinding the gate
@@ -183,7 +224,8 @@ if [ -f "$BL" ] && [ -s "$TRACE_F" ]; then
   done < "$BL"
 fi
 # (2) secret scan — case-SENSITIVE (token prefixes are case-specific); prints the PATTERN, never the value
-if [ -f "$SL" ] && [ -s "$SECRET_F" ]; then
+if _csk_any "$SL" "$SECRET_F" E 0; then _dec=0; else _dec=$?; fi
+if [ -f "$SL" ] && [ -s "$SECRET_F" ] && [ "$_dec" != 1 ]; then
   while IFS= read -r pat || [ -n "$pat" ]; do
     pat="${pat%$'\r'}"                       # tolerate a CRLF blocklist (Windows/autocrlf checkout)
     case "$pat" in ''|\#*) continue;; esac
@@ -228,7 +270,8 @@ PAL="";  [ -n "$GITROOT" ] && [ -f "$GITROOT/.private-allowlist.txt" ] && PAL="$
   fi
   [ -n "$PTF" ] && sed -e 's/[[:space:]]*$//' -e '/^#/d' -e '/^$/d' "$PTF"
 } > "$PTERM_F" 2>/dev/null || true
-if [ -s "$PTERM_F" ] && [ -s "$SECRET_F" ]; then
+if _csk_any "$PTERM_F" "$SECRET_F" iF 1; then _dec=0; else _dec=$?; fi
+if [ -s "$PTERM_F" ] && [ -s "$SECRET_F" ] && [ "$_dec" != 1 ]; then
   while IFS= read -r term || [ -n "$term" ]; do
     term="${term%$'\r'}"
     [ -n "$term" ] || continue

--- a/plugin/hooks/guard-commit-scan.sh
+++ b/plugin/hooks/guard-commit-scan.sh
@@ -21,6 +21,247 @@
 set -uo pipefail
 DIR="$(cd "$(dirname "$0")" && pwd)"
 
+# ---- CSK-JSON-PARSE ------------------------------------------------------------------------------------
+_json_slice(){  # $1 = whole payload, $2 = key -> the raw (still JSON-escaped) string value, "" if absent
+  local LC_ALL=C   # FIRST, so every expansion below -- the key search included -- counts and cuts in bytes.
+                   # Lengths from ${#x} are used as offsets into ${y:n}; with the locale set before any of
+                   # them, the two never disagree about a unit. Walking bytes is safe because no UTF-8
+                   # continuation byte can be 0x5C or 0x22, so a cut cannot land inside a character at a
+                   # quote or backslash edge. What this line is worth in SPEED depends on the platform --
+                   # read the table in _json_unescape below before quoting a number for it.
+  local pre rest seg w r n base=0 j=0 cl lim run=0 chunk C=4096 W=256; local -a acc=("")
+  # Every "step past X" here is arithmetic on a length, never `${s#"$literal"}`. That shape reads like a
+  # constant-time strip and is not one: bash retries the pattern at every prefix length, so stripping an
+  # n-byte literal costs O(n^2). It was in this function twice, and both were measured:
+  #   * `${1#*"$2"}` found the key -- cheap when the key sits near the front, quadratic in the distance to it
+  #     otherwise. `permission_mode` behind a 100 KB command took 7.94s on Git Bash, 0.27s in front of it.
+  #     Captured from Claude Code 2.1.267, the real order puts `permission_mode` BEFORE `tool_input`, so on
+  #     that version this cost was not reachable -- this file's header had shown the opposite order, and was
+  #     wrong. The parse stays order-independent regardless: the order is not a documented contract, and the
+  #     payload is still moving (`effort` is absent from the field list recorded on 2.1.246).
+  #   * `${tail#"$seg"\"}` stepped past each escaped quote: 16.8s for a single 100 KB step on Git Bash,
+  #     against 0.002s for `${tail:${#seg}+1}` doing exactly the same thing.
+  # `${1%%"$2"*}` still finds the FIRST occurrence -- the longest suffix that starts with the key starts at the
+  # earliest one -- so a command containing the literal text `"command":"` still cannot relocate the parse.
+  # Stepping by length removed the quadratic strip, but each escaped quote still sliced and re-assigned the
+  # whole remainder, so an escape-dense command stayed k*n here as well (2.2s of the 6.8s described in
+  # _json_unescape below, on Git Bash). The walk is chunked the same way: the payload is read 4096 bytes at a
+  # time and every per-quote operation stays inside the chunk. One thing is carried across edges on purpose
+  # -- the length of the backslash run in front of a quote -- because that run can straddle a window or a
+  # chunk, and its parity is what decides whether the quote ends the value. Isolated, escape-dense 44030 B:
+  # 2.61s -> 0.41s on Git Bash 5.3.15, 0.93s -> 0.09s on macOS/bash 3.2.
+  # Output is byte-identical to the previous shape across 378 cases at four chunk/window sizes down to 7 and 1
+  # bytes, and that shape to the one before it across a 27-case battery (escaped quotes, backslash runs before
+  # a quote, the key twice, the key appearing first as a value, glob metacharacters, UTF-8, no closing quote,
+  # empty input). Broken twins -- the run not carried across a window, a byte skipped after a quote -- prove
+  # the battery sees both.
+  pre="${1%%\"$2\"*}"                          # everything before the FIRST `"key"`
+  [ "$pre" != "$1" ] || return 0               # key absent: emit nothing
+  rest="${1:${#pre}+${#2}+2}"                  # past `"key"`
+  seg="${rest%%\"*}"                           # skip `: "` up to the value's opening quote, when there is one
+  [ "$seg" = "$rest" ] || rest="${rest:${#seg}+1}"
+  # Walk to the closing quote that is NOT escaped. A `"` preceded by an odd number of backslashes is content.
+  n=${#rest}; chunk="${rest:0:C}"; cl=${#chunk}
+  while :; do
+    lim=$((cl - j))
+    if [ "$lim" -le 0 ]; then
+      [ $((base + cl)) -lt "$n" ] || break                 # no closing quote at all: everything is already taken
+      base=$((base + j)); chunk="${rest:base:C}"; cl=${#chunk}; j=0; continue
+    fi
+    [ "$lim" -le "$W" ] || lim=$W
+    w="${chunk:j:lim}"
+    seg="${w%%\"*}"
+    if [ "$seg" = "$w" ]; then                             # no quote in view: take all of it, carry the run
+      acc+=("$w"); j=$((j+lim))
+      r="${w##*[!\\]}"; case "$w" in *[!\\]*) run=${#r} ;; *) run=$((run+${#w})) ;; esac
+      continue
+    fi
+    acc+=("$seg"); j=$((j+${#seg}+1))
+    r="${seg##*[!\\]}"; case "$seg" in *[!\\]*) run=${#r} ;; *) run=$((run+${#seg})) ;; esac
+    if [ $((run % 2)) -eq 1 ]; then acc+=("\""); run=0; else break; fi
+  done
+  local IFS=''; printf '%s' "${acc[*]}"
+}
+_json_unescape(){  # left-to-right, a chunk at a time; a two-pass sed would corrupt `\\"` (escaped backslash + quote)
+  # This is the tier-3 path below -- the one a stock Windows install actually runs on. It used to walk ONE
+  # CHARACTER at a time, which is O(n^2) twice over: `${s%"${s#?}"}` matches a pattern the length of the
+  # entire remainder just to read one character, and `out="$out$c"` recopies the output for each one.
+  #
+  # That was not a comfort question. This hook's timeout is 60s -- set in settings.json, NOT Claude Code's
+  # default, and reading the default instead is how a first pass at this got the consequence wrong. A
+  # PreToolUse hook KILLED at its timeout emits no exit 2, so every rule below is simply skipped. Measured on
+  # the tier-3 path with jq and python3 both shadowed, the old shape crossed 60s at ~4.3 KB. And 4.3 KB is
+  # not exotic: across 6791 Bash calls in 280 real transcripts, 2.49% of commands are bigger, and the largest
+  # is 46815 B, which the old shape needed roughly 39 minutes to decode. One Bash call in forty walked past
+  # §4.4 and §4.5 entirely, silently, on every stock Windows desktop.
+  #
+  # Two changes, and their wins are NOT the same shape -- writing them down as one number was the mistake
+  # this comment exists to avoid repeating:
+  #   * Taking the whole run up to the next backslash in ONE expansion, and indexing with `${s:0:1}` instead
+  #     of matching a pattern, is 47x on a 4.4 KB payload. This one holds on every machine.
+  #   * `local LC_ALL=C` makes these expansions byte-oriented instead of re-decoding the string on every
+  #     substring operation. What that is WORTH depends on the platform, and putting a single number here
+  #     would have been wrong three separate ways -- it was written as "another 5x" twice before this:
+  #         macOS / bash 3.2, a locale set .................. 5x
+  #         Git Bash 5.3.15, a locale set ................... 1.23x   (measured on the OLD shape; the new one
+  #                                                                    touches the locale once per escape
+  #                                                                    rather than once per character, so its
+  #                                                                    ratio is smaller and unmeasured)
+  #         Git Bash, LANG empty -- what Claude Code starts .. nothing at all
+  #     So speed is not what keeps this line; CORRECTNESS is, and that half holds everywhere. `[0-9a-fA-F]`
+  #     below is a collation-defined range outside the C locale: on a tr_TR desktop it is not 0-9a-f. That
+  #     alone would justify the line, and it costs nothing. `local` restores the previous locale on return
+  #     -- verified on bash 3.2 and on Git Bash 5.3.15, not assumed.
+  #
+  # Then the cost moved rather than went away. With the per-character walk gone, each escape still sliced the
+  # whole REMAINDER -- `s="${s:${#pre}+1}"` -- so an escape-dense command stayed k*n: on Git Bash a 44080 B
+  # command with 2755 escapes took 6.8s, 11% of the timeout. The input is now touched only a chunk at a time
+  # (`${s:base:C}`, once per 4096 bytes) and every per-escape operation stays inside that chunk, so no escape
+  # pays for the length of the whole command. That is the change that matters: bounding only the lookahead,
+  # while still indexing the full string, was measured too and gave about 4x on both machines, against 6-12x
+  # for the chunked walk. Five bytes are held back at a chunk's end whenever more input follows, so a
+  # `\uXXXX` that starts in a chunk ends in it.
+  # The output goes into an array joined once, not a string recopied at every append, and `\n`/`\t` are
+  # written `$'\n'`/`$'\t'`, so this file carries no raw TAB for an editor or a copy to turn into spaces.
+  #
+  # Measured, isolated, previous shape -> this one:
+  #     macOS/bash 3.2   escape-dense 44030 B, 2590 escapes .. 1.44s -> 0.12s
+  #                      sparse 100014 B, 4 escapes ........... 0.09s -> 0.02s
+  #     Git Bash 5.3.15  escape-dense 44030 B, 2590 escapes .. 3.92s -> 0.54s
+  #     (LANG empty)     sparse 99997 B, 4 escapes ............ 0.49s -> 0.07s
+  # These numbers do not travel, which is why each one names its machine.
+  #
+  # Output is byte-identical to the previous shape across 478 cases, each run at four chunk/window sizes
+  # down to 7 and 1 bytes so that an edge falls every few bytes; that shape was itself byte-identical to
+  # the original character walk across a 31-case battery (escaped quotes, `\\`, a lone trailing backslash, a
+  # truncated `\u`, Turkish, emoji). Deliberately broken twins -- the 5-byte margin cut to 4, the backslash
+  # not stepped over -- prove the battery sees both edges, and tier 1 and tier 3 return the same verdict on
+  # the gate cases.
+  local LC_ALL=C
+  local s="$1" pre w c h n base=0 j=0 cl lim chunk C=4096 W=256; local -a acc=("")
+  case "$s" in *\\*) ;; *) printf '%s' "$s"; return 0 ;; esac   # no escapes: the common case pays nothing
+  n=${#s}; chunk="${s:0:C}"; cl=${#chunk}
+  while :; do
+    lim=$((cl - j))
+    if [ $((base + cl)) -lt "$n" ]; then                  # more input after this chunk: hold 5 bytes back, so
+      lim=$((lim - 5))                                     # a `\uXXXX` that starts in a chunk also ends in it
+      if [ "$lim" -le 0 ]; then base=$((base + j)); chunk="${s:base:C}"; cl=${#chunk}; j=0; continue; fi
+    else
+      [ "$lim" -gt 0 ] || break
+    fi
+    [ "$lim" -le "$W" ] || lim=$W
+    w="${chunk:j:lim}"
+    pre="${w%%\\*}"                                        # the literal run before the next backslash in view
+    if [ "$pre" = "$w" ]; then acc+=("$w"); j=$((j+lim)); continue; fi
+    acc+=("$pre"); j=$((j+${#pre}+1))
+    if [ $((base + j)) -ge "$n" ]; then acc+=("\\"); break; fi   # a lone trailing backslash stays literal, as before
+    c="${chunk:j:1}"; j=$((j+1))
+    case "$c" in
+      n) acc+=($'\n') ;;
+      t) acc+=($'\t') ;;
+      r) ;;
+      b|f) acc+=(" ") ;;
+      u) if [ $((n - base - j)) -ge 4 ]; then h="${chunk:j:4}"; j=$((j+4)); else h=""; fi   # a short tail is left alone, as before
+         # A `\uXXXX` used to become a literal `?`. That is not a lossy nicety, it is a hole: `\u002e` is `.`,
+         # so `\u002eclaude/hooks/guard-bash.sh` decoded to `?claude/…` and matched no gate pattern, while jq
+         # decoded the same bytes to the real path — the two tiers disagreed on whether a payload was an
+         # attack. Printable ASCII is decoded properly (builtin printf, no fork); anything else still becomes
+         # `?`, which is only ever a display concern because this value is used for MATCHING, never to write.
+         case "$h" in
+           00[2-7][0-9a-fA-F]) printf -v c "\\x${h#00}"; acc+=("$c") ;;
+           *)                  acc+=("?") ;;
+         esac ;;
+      *) acc+=("$c") ;;
+    esac
+  done
+  local IFS=''; printf '%s' "${acc[*]}"
+}
+# ---- /CSK-JSON-PARSE -----------------------------------------------------------------------------------
+
+# Extract the -m/--message VALUES from the command line without an interpreter.
+#
+# Without this tier the fallback below hands the WHOLE command line to the message scanner, and a file path is
+# not a message: `git commit -m "feat: add scaffolding" -- src/AI-generated/scaffold.ts` was refused with
+# "TRACE-SCANNER (message): 'AI-generated'" while the message itself is clean. The same commit is ACCEPTED
+# where python3 works, because that tier returns only the -m values — so the gate's verdict depended on
+# whether an interpreter resolved, not on the commit. This makes the interpreter-free tier answer the same
+# question the python3 tier answers.
+#
+# It is awk, not parameter expansion, and that is deliberate on a hook that already spawns ~49 processes for a
+# commit: a pure-shell character walk was written first and MEASURED QUADRATIC — 146 B 0.006s,
+# 4 KB 0.181s, 16 KB 1.03s, 64 KB 8.08s. That does NOT blow the 60 s timeout the kit sets, and the
+# largest command payload seen across 6791 real Bash calls was 46.8 KB — so this is a tail-risk
+# trade, not a rescue: awk is 0.049s flat to 64 KB and 0.585s at 1 MB, so the cost stops depending
+# on what someone pasted into a commit message. One fork, on a path that already spawns ~49 and only
+# when the python3 tier is unavailable; the zero-fork rule still governs the per-Bash-call path.
+# Byte-oriented under LC_ALL=C, which is safe because a UTF-8 continuation byte is always >= 0x80
+# and can never equal an ASCII quote.
+#
+# Contract: rc=0 with the values, or rc=1 when the line cannot be parsed with confidence (unterminated quote,
+# trailing backslash, an -m with nothing after it). rc=1 keeps the over-inclusive fallback, so this can only
+# remove false positives — it can never open a blind spot. Verified against a POSIX shlex oracle written
+# independently in another language: 37 command shapes, 33 byte-identical, 4 safe fallbacks, 0 mismatches,
+# with the harness itself calibrated by two deliberate mutations.
+csk_msg_values() {
+  CSK_CMD="$1" LC_ALL=C awk '
+    BEGIN {
+      s = ENVIRON["CSK_CMD"]; n = length(s); i = 1
+      ntok = 0; cur = ""; have = 0
+      while (i <= n) {
+        c = substr(s, i, 1)
+        if (c == " " || c == "\t" || c == "\n" || c == "\r" || c == "\f" || c == "\v") {
+          if (have) { ntok++; tok[ntok] = cur; cur = ""; have = 0 }
+          i++; continue
+        }
+        if (c == "\\") {                                  # outside quotes: escapes the next byte
+          i++
+          if (i > n) exit 1                               # trailing backslash
+          cur = cur substr(s, i, 1); have = 1; i++; continue
+        }
+        if (c == "'"'"'") {                               # single quotes: literal to the next quote
+          i++; have = 1
+          while (1) {
+            if (i > n) exit 1                             # no closing quote
+            c = substr(s, i, 1)
+            if (c == "'"'"'") { i++; break }
+            cur = cur c; i++
+          }
+          continue
+        }
+        if (c == "\"") {                                  # double quotes: backslash escapes " and \
+          i++; have = 1
+          while (1) {
+            if (i > n) exit 1                             # no closing quote
+            c = substr(s, i, 1)
+            if (c == "\"") { i++; break }
+            if (c == "\\" && i < n) {
+              nx = substr(s, i + 1, 1)
+              if (nx == "\"" || nx == "\\") { cur = cur nx; i += 2; continue }
+            }
+            cur = cur c; i++
+          }
+          continue
+        }
+        cur = cur c; have = 1; i++
+      }
+      if (have) { ntok++; tok[ntok] = cur }
+
+      out = ""; nout = 0
+      for (k = 1; k <= ntok; k++) {
+        t = tok[k]
+        if (t == "-m" || t == "--message") {
+          k++
+          if (k > ntok) exit 1                            # -m with nothing after it: do not guess
+          nout++; res[nout] = tok[k]
+        } else if (substr(t, 1, 10) == "--message=") {
+          nout++; res[nout] = substr(t, 11)
+        }
+      }
+      for (k = 1; k <= nout; k++) printf "%s\n", res[k]
+      exit 0
+    }'
+}
+
 INPUT="$(cat)"
 # Same ladder as guard-bash.sh, and for the same reason: the raw-text fallback leaves JSON escapes in place,
 # so `-m \"…\"` never matches a quote-based extraction and the message silently goes unscanned. That is
@@ -36,10 +277,19 @@ elif command -v python3 >/dev/null 2>&1 && CMD="$(printf '%s' "$INPUT" | python3
   _parsed=1
 fi
 if [ "$_parsed" = 0 ]; then
-  CMD="$(printf '%s' "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' | head -1 \
-        | sed 's/\\n/\n/g; s/\\"/"/g; s/\\\\/\\/g')"
+  # Tier 3, and it used to be a `sed | head | sed` pipeline: four processes on EVERY Bash tool call,
+  # to re-derive a string guard-bash.sh had already parsed one hook earlier, and then re-answer a
+  # question it had already answered. Measured on `ls -la`: guard-bash.sh 2 processes, this hook 7.
+  # guard-write.sh already carried the shared parser; this was the one hook that never got it.
+  CMD="$(_json_unescape "$(_json_slice "$INPUT" command)")"
 fi
 [ -z "$CMD" ] && exit 0
+
+# A command that does not contain `git` at all cannot match the pattern below, and finding that out
+# should not cost a process. Measured on `ls -la`: this hook spawned 7 processes to answer "no".
+# The test is case-INSENSITIVE while the pattern is not, so it is a superset: it can only let more
+# through to the real matcher, never less.
+case "$CMD" in *[Gg][Ii][Tt]*) ;; *) exit 0 ;; esac
 
 # Only git commit. Matching mirrors guard-bash.sh's tolerance for `git -C dir commit`, TAB separators and a
 # quoted binary, because a gate that a whitespace change walks past is not a gate.
@@ -89,6 +339,8 @@ for i, p in enumerate(parts):
     elif p.startswith("--message="): out.append(p.split("=", 1)[1])
 print("\n".join(out))
 ' 2>/dev/null)"; then
+    :
+  elif MSG="$(csk_msg_values "$CMD")"; then
     :
   else
     MSG="$CMD"

--- a/plugin/hooks/pre-commit
+++ b/plugin/hooks/pre-commit
@@ -170,8 +170,49 @@ fi
 # Nothing staged for the text scans AND the bloat gate is clean -> done.
 { [ -s "$TRACE_F" ] || [ -s "$SECRET_F" ] || [ "$HIT" -ne 0 ]; } || exit 0
 
+
+# Ask "can ANY pattern match" once, before asking "which one".
+#
+# The three loops below spawn one grep PER PATTERN — 12 + 11 + 3 = 26 processes on every commit, and the
+# overwhelming majority of commits are clean, so 26 of them exist only to say "no". Measured on 205 added
+# lines: the trace loop 0.621 s -> 0.063 s, the secret loop 0.572 s -> 0.059 s. One decision, then the loop
+# ONLY when the decision says there is something to name.
+#
+# Three-way on purpose, because grep has three answers and two of them must not shortcut:
+#   rc=1  nothing matches      -> done. This is the fast path and the common one.
+#   rc=0  something matches    -> run the loop, which names the pattern. The user still reads
+#                                 "forbidden expression -> '<pattern>'" verbatim; nothing is lost but time.
+#   rc=2  grep could not decide -> run the loop. TODAY'S BEHAVIOUR, deliberately.
+#
+# That last rung is what makes this safe rather than clever, and it was earned: joining the patterns compiles
+# them TOGETHER, so ONE broken regex kills the whole alternation. Measured with a pattern file carrying a valid
+# `Co-Authored-By` and a broken `foo[`, against a message that really does carry the trailer:
+#     grep -inEf together   rc=2, ZERO matches   <- the trailer goes unreported
+#     one grep per pattern  catches it; only the broken pattern is skipped
+# A blocklist is a file users edit by hand, so a broken pattern is not exotic — and failing OPEN there would be
+# the worst possible direction. rc=2 also covers an alternation too large to compile (measured: 40 KB fine,
+# 200 KB -> "grep: Memory exhausted", rc=2 -> loop), so the ARG_MAX question answers itself.
+#
+# Verified on the blocklists' OWN #test:/#test-clean: cases — 32 of them, the payload the gate actually
+# defends: 32/32 identical verdicts. Calibrated by mutation (strip the parentheses so a group-scoped `|`
+# escapes to top level): 8 mismatches, in BOTH directions — three clean messages newly rejected and two real
+# secrets newly passed. Also checked structurally: no pattern in either shipped blocklist carries a bare
+# top-level `|` (every one is inside a group) and none uses a back-reference, so joining cannot reshape them.
+_csk_any(){   # $1 = pattern list  $2 = corpus  $3 = grep flags  $4 = 1 for newline-joined fixed strings
+  local pat alt="" sep="|"
+  [ "$4" = 1 ] && sep="
+"
+  while IFS= read -r pat || [ -n "$pat" ]; do
+    pat="${pat%$'\r'}"
+    case "$pat" in ''|\#*) continue;; esac
+    alt="${alt:+$alt$sep}$pat"
+  done < "$1"
+  [ -n "$alt" ] || return 1
+  grep -q$3 -- "$alt" "$2" 2>/dev/null
+}
 # (1) trace scan — case-INsensitive (vendor / AI-authorship strings), project files only
-if [ -f "$BL" ] && [ -s "$TRACE_F" ]; then
+if _csk_any "$BL" "$TRACE_F" iE 0; then _dec=0; else _dec=$?; fi
+if [ -f "$BL" ] && [ -s "$TRACE_F" ] && [ "$_dec" != 1 ]; then
   while IFS= read -r pat || [ -n "$pat" ]; do
     pat="${pat%$'\r'}"                       # tolerate a CRLF blocklist (Windows/autocrlf checkout) — a trailing \r
     case "$pat" in ''|\#*) continue;; esac   # in the pattern never matches the LF-normalised diff, blinding the gate
@@ -183,7 +224,8 @@ if [ -f "$BL" ] && [ -s "$TRACE_F" ]; then
   done < "$BL"
 fi
 # (2) secret scan — case-SENSITIVE (token prefixes are case-specific); prints the PATTERN, never the value
-if [ -f "$SL" ] && [ -s "$SECRET_F" ]; then
+if _csk_any "$SL" "$SECRET_F" E 0; then _dec=0; else _dec=$?; fi
+if [ -f "$SL" ] && [ -s "$SECRET_F" ] && [ "$_dec" != 1 ]; then
   while IFS= read -r pat || [ -n "$pat" ]; do
     pat="${pat%$'\r'}"                       # tolerate a CRLF blocklist (Windows/autocrlf checkout)
     case "$pat" in ''|\#*) continue;; esac
@@ -228,7 +270,8 @@ PAL="";  [ -n "$GITROOT" ] && [ -f "$GITROOT/.private-allowlist.txt" ] && PAL="$
   fi
   [ -n "$PTF" ] && sed -e 's/[[:space:]]*$//' -e '/^#/d' -e '/^$/d' "$PTF"
 } > "$PTERM_F" 2>/dev/null || true
-if [ -s "$PTERM_F" ] && [ -s "$SECRET_F" ]; then
+if _csk_any "$PTERM_F" "$SECRET_F" iF 1; then _dec=0; else _dec=$?; fi
+if [ -s "$PTERM_F" ] && [ -s "$SECRET_F" ] && [ "$_dec" != 1 ]; then
   while IFS= read -r term || [ -n "$term" ]; do
     term="${term%$'\r'}"
     [ -n "$term" ] || continue

--- a/start.sh
+++ b/start.sh
@@ -92,6 +92,53 @@ project_has_source() {  # is there a real source/project file outside the kit
   done
   return 1
 }
+# MAX_PATH, and why the check is here rather than after the clone.
+#
+# The install and the BUILD obey different limits, so a long install path produces a tree that copies fine and
+# cannot be compiled. Measured on Windows 11 Pro 26200, LongPathsEnabled=0 (the default):
+#
+#   MSYS `cp -R` to a 275-character path   1286 files, rc=0            <- the installer reports success
+#   PowerShell Test-Path on that file      False
+#   .NET File.ReadAllBytes on it           throws
+#   dotnet build (SDK 10.0.401) at depth   rc=1, "the fully qualified file name must be less than 260"
+#
+# MSYS prefixes its own calls with \\?\ and is not bound by MAX_PATH; MSBuild and the .NET file APIs are. So
+# `cp` is the wrong thing to ask, and asking it after the clone is the wrong time — by then the user has an
+# 8 MB tree that looks installed.
+#
+# The usable limit is 259 characters, not 260: measured file by file at 250/255/258/259 (openable) against
+# 260/261/265 (not). The skeleton's own deepest path is 156 characters, it lands under ./backend/, so the
+# budget for the project root is 259 - 156 - len("/backend/") = 94. Verified at the boundary, with the
+# prediction written down first: root 94 opens, root 95 does not.
+#
+# 94 IS AN UPPER BOUND, NOT A SAFE ONE. A build writes deeper than the sources it compiles —
+# bin/Debug/<tfm>/publish/ and obj/ sit under the project — so the real headroom is smaller by however much
+# the build adds. That figure is NOT measured here (it needs a full restore+build of the base), which is why
+# this warns rather than refuses: a number that is known to be optimistic must not be used to block someone.
+#
+# `git config core.longpaths true` is NOT the remedy and is deliberately not suggested. It lets git write
+# long paths; it does nothing for MSBuild, which is what fails. The two remedies that do work are a shorter
+# install root, or LongPathsEnabled=1 in the registry (admin, machine-wide, and a reboot for some tools).
+csk_native_len(){   # length of $1 in its NATIVE form; 0 where there is no native form (macOS/Linux)
+  local n
+  n="$(cd "$1" 2>/dev/null && pwd -W 2>/dev/null)" || { printf '0'; return; }
+  [ -n "$n" ] || { printf '0'; return; }
+  printf '%s' "${#n}"
+}
+csk_path_budget_warn(){
+  local rl; rl="$(csk_native_len .)"
+  [ "$rl" -gt 94 ] 2>/dev/null || return 0
+  echo
+  echo "  !!! WARNING: this project root is $rl characters; the .NET base needs it to be 94 or fewer."
+  echo "  The copy will SUCCEED and the build will FAIL: the base's deepest file is 156 characters, and"
+  echo "  Windows cannot open a path past 259 unless long paths are enabled. Measured here: dotnet build"
+  echo "  stops with \"the fully qualified file name must be less than 260 characters\"."
+  echo "  94 is also optimistic — a build writes bin/ and obj/ BELOW the sources, so the real room is less."
+  echo "  Two things fix it: install at a shorter root (C:\\src\\<name> rather than a deep Documents path),"
+  echo "  or set LongPathsEnabled=1 under HKLM\\SYSTEM\\CurrentControlSet\\Control\\FileSystem (admin)."
+  echo "  (core.longpaths only affects git, not the build, so it will not help here.)"
+  echo
+}
 clone_devarch() {  # $1 = target dir; clone verbatim, drop nested .git, rename the .sln to the project name
   local target="${1:-.}"
   command -v git >/dev/null 2>&1 || { echo "  ERROR: git missing; cannot include DevArchitecture."; return 1; }
@@ -262,6 +309,7 @@ echo
 # --- Step 3: Backend base (only .NET/DevArchitecture; APPROVAL GATE) ---
 if [ "$DEVARCH_ON" = 1 ]; then
   echo "== Backend base (DevArchitecture) =="
+  csk_path_budget_warn
   echo "  Target: ./$BACKEND_DIR (the frontend stays separate under ./frontend)."
   if has_devarch "$BACKEND_DIR"; then
     echo "  DevArchitecture detected — base already present, skipping copy."


### PR DESCRIPTION
Four things the hooks were doing on every command, and two gates that could report green while broken.

**Based on `fix/json-parser-quadratic`, not on `main`.** `guard-commit-scan.sh` adopts the shared JSON parser
block, and that block has to stay byte-identical across every file that carries it. Splicing today's `main`
version in would have made this branch carry the quadratic parser as a third copy — tried it, and the gate
added in the last commit here caught the drift by name. So this stacks; GitHub will retarget it at `main`
once #50 lands. No file is touched by both branches.

## What was measured

| | before | after |
|:--|--:|--:|
| `guard-commit-scan.sh` on `ls -la` — every ordinary Bash call | 7 processes / 0.757 s | 3 / 0.580 s |
| `pre-commit` trace loop, 205 added lines | 0.621 s | 0.063 s |
| `pre-commit` secret loop, same input | 0.572 s | 0.059 s |
| a clean commit whose pathspec named a blocked term | refused | accepted |
| `--dotnet` into a 275-character root | copied, then would not build | warns before the prompt |

## 1. A path in the command refused a commit whose message was clean

The message-extraction ladder falls back to scanning the whole command line when no interpreter is available,
and on a stock Windows install none is: `python3` on PATH is the Microsoft Store redirector, which exits 49
with empty stdout. So a pathspec naming a blocked term refused a commit whose message was clean — while the
same commit is accepted where python3 works. The verdict depended on the interpreter, not on the commit.

An interpreter-free extractor now answers the same question, verified against a POSIX shlex reference written
independently in another language: 37 command shapes, 33 byte-identical, 4 safe fallbacks, 0 mismatches, the
harness calibrated by two deliberate mutations. When the line cannot be parsed with confidence it returns
non-zero and the over-inclusive fallback stands, so this can only remove false positives.

Gate behaviour against a baseline copied with its sibling scripts so it could actually block: 13 cases, one
intended change, twelve identical.

## 2. The commit scans spawned one grep per pattern to say "no"

12 trace + 11 secret + 3 private-path patterns, one process each, on commits that are overwhelmingly clean.
One decision per class now answers "can anything match", and the naming loop runs only when there is something
to name — the user-facing message is unchanged, the loop is not even re-indented.

Three-way, because grep has three answers: no match, done; match, run the loop; **could not decide, run the
loop**. That last rung is not caution for its own sake — joining patterns compiles them together, so one
broken regex kills the whole alternation. Measured: `grep -inEf` returned rc=2 and zero matches on a message
that really did carry a trailer, while the per-pattern loop still caught it. A blocklist is a file users edit
by hand. rc=2 also covers an alternation too large to compile (40 KB fine, 200 KB "Memory exhausted").

Verified on the blocklists' own `#test:`/`#test-clean:` cases — 32 of 32 identical verdicts — and calibrated
by a mutation that produced 8 mismatches in both directions.

## 3. Two gates that could report green while broken

The block-equality gates named the two files of each pair, so a third carrier drifts unseen. The marker now
decides the file list, at least two files are required, and the names are printed. Anchored, because
`---- CSK-JSON-PARSE` matches `---- CSK-JSON-PARSER` as a substring — the first version of this gate reported
green on three files after the marker had been renamed. Six states tested.

Every payload fixture put `permission_mode` before `tool_input`. That is the real order, captured from
2.1.267 — but key order in a JSON object is not a contract, the payload gained a field inside one minor
version, and the parse used to cost 7.94 s versus 0.27 s depending on where the key sat. `gj()` now takes an
order argument and the verdicts are compared across both. The late variant is labelled in the fixture as what
it is: a guard against the order changing, not a reproduction of it.

## 4. `--dotnet` copied fine into a path where the build cannot run

The install and the build obey different limits. MSYS `cp` prefixes its calls with `\\?\` and is not bound by
MAX_PATH; MSBuild is. Measured on Windows 11 with `LongPathsEnabled=0`, the default: 1286 files copied to a
275-character path with rc=0, `Test-Path` False on the result, and `dotnet build` stopping with "the fully
qualified file name must be less than 260 characters".

The usable limit is 259, measured file by file at 250/255/258/259 against 260/261/265. The base's deepest
path is 156 and lands under `./backend/`, so the root budget is 94 — checked at the boundary with the
prediction written down first: 94 opens, 95 does not.

It warns rather than refuses, because 94 is an upper bound: a build writes `bin/` and `obj/` below the
sources and that margin is not measured here. `core.longpaths` is deliberately not offered — it affects git,
not MSBuild.

## Verification

```
smoke   631 graded · 3 skipped · 0 failed
```

Every claim above is a measurement taken on this branch, on Windows 11 / Git Bash 5.3.15, with no jq and with
`python3` resolving to the Store redirector — the tier a stock Windows install actually runs.

Not covered: the build failure in §4 was reproduced with a minimal console project at depth, not with the
base itself; and `tier1` (jq) was not exercised here because this machine has no jq.
