### PR TITLE
feat(discipline): "tests green" is one run of the suite on the final code

### DIFF
--- a/claude-starter/CLAUDE.md
+++ b/claude-starter/CLAUDE.md
@@ -54,7 +54,10 @@ and report. Commit/push and destructive commands are gated (§4.4/§4.5).
 ## Definition of Done
 - Ambiguous scope goes to **planner-csk** first, so the acceptance criterion is explicit before coding.
 - `/simplify` + tests green + **review-agent-csk** clean + triggered skills + nothing deferred.
-- Quality gate: 0 build warnings/errors + a real analysis clean (`sonarqube-check`). A green linter is a
+- **Tests green = one run of the suite on the final code.** Whoever makes the last edit runs it and reports the command,
+  the exit code and the pass/fail counts; that report is the evidence the main thread and the reviewer cite. Run the suite
+  again only after a further edit, or when a report has no exit code — a second run on code nobody touched verifies nothing new.
+- Quality gate: 0 build warnings/errors (a test run that compiles is that build) + a real analysis clean (`sonarqube-check`). A green linter is a
   pre-check, not a verdict — no analysis, no rating.
 - Personal data / dependencies / translations touched → **privacy · dependency-audit · i18n-integrity** clean.
 

--- a/claude-starter/agents-optional/backend-expert-generic.md
+++ b/claude-starter/agents-optional/backend-expert-generic.md
@@ -48,7 +48,7 @@ This profile has no single "how" skill; the pattern in the source repo is author
 - At closure, report findings to **review-agent-csk**.
 
 ## DoD (this agent's responsibility)
-- Tests green with `test-expert-csk`.
+- Tests green with `test-expert-csk`: one suite run after your last edit, reported as command + exit code + pass/fail counts.
 - `dependency-audit` clean (if a package was added/updated).
 - `/simplify` applied.
 - Decisions asked of the user with EXPLICIT OPTIONS (recommendation + rationale for each option).

--- a/claude-starter/agents/backend-expert-csk.md
+++ b/claude-starter/agents/backend-expert-csk.md
@@ -51,7 +51,7 @@ a project on another pattern follows its own skill instead, and these DevArch sp
 - At closure, report findings to **review-agent-csk**.
 
 ## DoD (this agent's responsibility)
-- Tests green with `test-expert-csk`.
+- Tests green with `test-expert-csk`: one suite run after your last edit, reported as command + exit code + pass/fail counts.
 - Build 0 warnings / 0 errors, and `sonarqube-check` applied — the skill defines what counts as clean (a green
   build is a pre-check, not a verdict). Restating a number here is how the two drifted apart.
 - `/simplify` applied.

--- a/claude-starter/agents/database-expert-csk.md
+++ b/claude-starter/agents/database-expert-csk.md
@@ -46,7 +46,7 @@ On changes to the data model, migrations, indexes, or the cache layer.
 ## DoD
 - Migration verified locally with up→down→up.
 - (On projects using SonarQube) `sonarqube-check` green.
-- Repo/handler tests green with `test-expert-csk`.
+- Repo/handler tests green with `test-expert-csk`: one suite run after the last edit, reported as command + exit code + pass/fail counts.
 
 ## Constraints
 - Do NOT run commands that touch prod data; leave those to the user.

--- a/claude-starter/agents/frontend-expert-csk.md
+++ b/claude-starter/agents/frontend-expert-csk.md
@@ -44,7 +44,7 @@ On UI, component/page, navigation/routing, state, i18n interface, responsive, or
 4. **Also apply:** `frontend-design` (visual/UX quality — hierarchy, spacing, type, states) · `a11y` (accessibility gate) · `i18n-integrity` (translation integrity) · `observability` (client log/error) · `performance` (render/bundle) · `dependency-audit` (packages).
 
 ## DoD
-- `/simplify` + tests green + `review-agent-csk` clean.
+- `/simplify` + tests green (one suite run after the last edit, reported as command + exit code + counts) + `review-agent-csk` clean.
 - Responsive/accessible; works across the project's target device/browser matrix.
 
 ## Coordination (cross-agent)

--- a/claude-starter/agents/review-agent-csk.md
+++ b/claude-starter/agents/review-agent-csk.md
@@ -38,7 +38,9 @@ Before a work package closes (pre-commit), on the changed diff.
 - **Verify before you report (two-stage):** a first-pass finding is a *candidate*. Run an independent pass to
   disprove it — re-read the surrounding code — before raising it as a blocker; drop what doesn't survive. Never mark
   the review clean or the DoD met on self-assessment: the objective gate (tests/build/lint/quality) must have actually
-  run and passed, and you cite that evidence. "It looks fixed" is not a verifier.
+  run and passed, and you cite that evidence. "It looks fixed" is not a verifier. A run reported with its command and
+  exit code on the code under review IS that evidence — cite it; run the suite yourself only if the code changed after
+  that run, or the report has no exit code.
 
 ## Output
 `file:line · label · observation · suggestion`; with a blocker/suggestion split, and a **disposition** for each

--- a/claude-starter/agents/test-expert-csk.md
+++ b/claude-starter/agents/test-expert-csk.md
@@ -28,7 +28,8 @@ The "how" lives in the `testing` skill; this agent applies it.
 - Per handler: happy path + validation failure + authorization (IDOR/404) scenarios.
 - Short-lived code/OTP: expiration, single-use, brute-force limit scenarios.
 - Deterministic tests; external dependencies mocked/faked.
-- Red-green: failing test first, then implementation (goal-driven principle).
+- Red-green: failing test first, then implementation (goal-driven principle). After the last edit, run the suite once and
+  report command + exit code + pass/fail counts; do not re-run it on code nobody has touched since.
 
 ## Coordination (cross-agent)
 - Source of the tested behavior → align with **backend-expert-csk** / **frontend-expert-csk**.

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -1614,7 +1614,14 @@ echo "== 6f) always-on token budget =="
 # for that cost, and a gate rather than a reminder — a verbose new description fails the suite instead of
 # quietly taxing every future session. Budgets sit just above the current sizes: raising one is allowed, but
 # only as a deliberate edit here.
-BUDGET_DISC=11800    # DISCIPLINE.md (the discipline half of CLAUDE.md); currently 11755 (2.5.0: +75 B, the
+BUDGET_DISC=12250    # DISCIPLINE.md (the discipline half of CLAUDE.md); currently 12200 (2026-09-11: +416 B — "tests green"
+                     # is ONE run of the suite on the final code, reported as command + exit code + counts, and the main
+                     # thread and the reviewer cite that report instead of running the suite again. Measured and
+                     # pre-registered, 18 sessions on three Node cases (evals/README.md): test and build runs per session
+                     # 4.44 -> 2.22, the final code tested in 9 of 9 sessions in both arms, checks 33 of 33 in both, cost
+                     # $6.54 -> $6.77. About 175 tokens a session, paid because the runs it removes were the same
+                     # unchanged code verified again at each layer; the matching agent lines sit in agent bodies, which
+                     # carry no always-on bytes.) (2.5.0: +75 B, the
                      # automode-policy row in the trigger map — routing it is what keeps it from being idle);
                      # was 11680 / (2.3.0: +62 B for the
                      # `teamboard` trigger row. A multi-person repo has no other always-on place to learn that a

--- a/evals/README.md
+++ b/evals/README.md
@@ -402,6 +402,57 @@ already shown 0 of 1.
 Then point `CSK_EVAL_CASES` at a directory holding only the six cases (or run each with `--case`) and use
 `CSK_EVAL_ARMS="kit kitb" CSK_EVAL_DISCIPLINE_B=<that file> CSK_EVAL_TRACE=1 bash evals/run.sh --runs 3 --keep`.
 
+## Measured with `CSK_EVAL_TRACE`: how many times does a small change run its tests?
+
+**Question.** "Tests green" was written into the discipline's Definition of Done, into three agents' DoD, into
+test-expert's red-green line and into the reviewer's "verify before you report", and nothing said who runs the suite.
+So every layer could run it again on code nobody had touched. How often did that happen, and can one reported run
+replace the repeats without losing the run that proves the final code works?
+
+**Baseline first**, because the previous experiment failed its reduction criterion on a floor. The current kit, the
+three Node cases `tests-bugfix-failing-test`, `tests-single-file-refactor` and `tests-small-rule-change`, three runs
+each, CLI 2.1.268, with a go/no-go rule hashed before the runs: at least 7 of 9 sessions counted and a median of at least
+4 test or build runs per session. Result: 9 of 9 counted; runs per session 4 · 3 · 6, 5 · 8 · 4, 3 · 6 · 6, median 5. Of
+the 45 runs the implementing agent made 17, the main thread 13, the reviewer 11, test-expert 3 and security-expert 1;
+every session ran 2 to 5 of them after its last edit, and every session tested its final code. The repeats were
+re-verification across layers, not red-green. A first attempt measured nothing — the usage limit rejected seven of its
+nine sessions, which is where the NOT MEASURED rule above comes from.
+
+**The change.** "Tests green" became one run of the suite after the last edit, reported with the command, the exit code
+and the pass/fail counts; the main thread and the reviewer cite that report and run the suite again only after a
+further edit, or when the report has no exit code. Red-green was kept. Arm `kitb` carried it in the discipline file
+and, through `CSK_EVAL_OVERLAY_B`, in five agent definitions taken from an installed project. The two arms' `.claude/`
+trees differed in exactly those six files, checked afterwards in every one of the 18 projects.
+
+**Setup.** Arms `kit` and `kitb`, the same three cases, three runs each, 18 sessions, CLI 2.1.268 at the start and at the
+end, and the kit tree hash equal to the baseline's. The criteria, cases, runner, overlay and analysis were hashed before
+the first run.
+
+| arm | test/build runs per session | final code tested | checks | cost |
+|---|---|---|---|---|
+| `kit` | 4.44 (median 4) | 9 / 9 | 33 / 33 | $6.54 |
+| `kitb` | 2.22 (median 2) | 9 / 9 | 33 / 33 | $6.77 |
+
+**Pre-registered criteria.** S1, fewer runs: `kitb` at most 0.70 × `kit` and a lower median — **passed** (0.50; 4 → 2).
+S2, safety: every `kitb` session that edited ran a test after its last edit — **passed** (9 of 9). S3, quality: no more
+failed checks than `kit` and no session leaving the tests failing — **passed** (0 and 0). **Decision: ship.** The text in
+`claude-starter/CLAUDE.md` and the agent definitions is the text measured, byte for byte.
+
+**What moved, and what did not.** Who ran the tests: in `kit`, backend-expert 15, the main thread 12, review-agent 11,
+security-expert 2; in `kitb`, backend-expert 17 and the main thread 3. The reviewer was still delegated in every `kitb`
+session (8 of 9 in `kit`) — it stopped re-running a suite that had just passed. Runs after the last edit fell from 2–5
+to 1–2. Cost did not move ($6.54 → $6.77): with a sub-second suite a test run is cheap, so the saving here is runs, not
+dollars; a slow suite would turn it into time, and that was not measured. The Definition of Done grew by 416 bytes,
+about 175 tokens a session, and the always-on budget in `smoke-test §6f` was raised with that reason beside it. `kitb`
+already carried those bytes, so they are inside its $6.77. Three single-prompt Node cases are not a real session, and
+file edits made through `Bash` are invisible to S2.
+
+**To re-run it,** remember that arm `kit` is now the shipped text: build arm B from the previous one. Take
+`claude-starter/CLAUDE.md` from the commit before this change as `CSK_EVAL_DISCIPLINE_B`, and the five agent files from
+the `.claude/agents/` of a project installed from that commit as `CSK_EVAL_OVERLAY_B` (a `--generic` install writes
+`backend-expert-csk.md` from the generic source). Then point `CSK_EVAL_CASES` at the three `tests-*` cases and run
+`CSK_EVAL_ARMS="kit kitb" CSK_EVAL_TRACE=1 bash evals/run.sh --runs 3 --keep`.
+
 ## When `claude plugin eval` opens
 
 `claude plugin eval --ablation with-without` is the purpose-built version of this and would replace `run.sh`

--- a/plugin/agents/backend-expert-csk.md
+++ b/plugin/agents/backend-expert-csk.md
@@ -51,7 +51,7 @@ a project on another pattern follows its own skill instead, and these DevArch sp
 - At closure, report findings to **review-agent-csk**.
 
 ## DoD (this agent's responsibility)
-- Tests green with `test-expert-csk`.
+- Tests green with `test-expert-csk`: one suite run after your last edit, reported as command + exit code + pass/fail counts.
 - Build 0 warnings / 0 errors, and `sonarqube-check` applied — the skill defines what counts as clean (a green
   build is a pre-check, not a verdict). Restating a number here is how the two drifted apart.
 - `/simplify` applied.

--- a/plugin/agents/database-expert-csk.md
+++ b/plugin/agents/database-expert-csk.md
@@ -46,7 +46,7 @@ On changes to the data model, migrations, indexes, or the cache layer.
 ## DoD
 - Migration verified locally with up→down→up.
 - (On projects using SonarQube) `sonarqube-check` green.
-- Repo/handler tests green with `test-expert-csk`.
+- Repo/handler tests green with `test-expert-csk`: one suite run after the last edit, reported as command + exit code + pass/fail counts.
 
 ## Constraints
 - Do NOT run commands that touch prod data; leave those to the user.

--- a/plugin/agents/frontend-expert-csk.md
+++ b/plugin/agents/frontend-expert-csk.md
@@ -44,7 +44,7 @@ On UI, component/page, navigation/routing, state, i18n interface, responsive, or
 4. **Also apply:** `frontend-design` (visual/UX quality — hierarchy, spacing, type, states) · `a11y` (accessibility gate) · `i18n-integrity` (translation integrity) · `observability` (client log/error) · `performance` (render/bundle) · `dependency-audit` (packages).
 
 ## DoD
-- `/simplify` + tests green + `review-agent-csk` clean.
+- `/simplify` + tests green (one suite run after the last edit, reported as command + exit code + counts) + `review-agent-csk` clean.
 - Responsive/accessible; works across the project's target device/browser matrix.
 
 ## Coordination (cross-agent)

--- a/plugin/agents/review-agent-csk.md
+++ b/plugin/agents/review-agent-csk.md
@@ -38,7 +38,9 @@ Before a work package closes (pre-commit), on the changed diff.
 - **Verify before you report (two-stage):** a first-pass finding is a *candidate*. Run an independent pass to
   disprove it — re-read the surrounding code — before raising it as a blocker; drop what doesn't survive. Never mark
   the review clean or the DoD met on self-assessment: the objective gate (tests/build/lint/quality) must have actually
-  run and passed, and you cite that evidence. "It looks fixed" is not a verifier.
+  run and passed, and you cite that evidence. "It looks fixed" is not a verifier. A run reported with its command and
+  exit code on the code under review IS that evidence — cite it; run the suite yourself only if the code changed after
+  that run, or the report has no exit code.
 
 ## Output
 `file:line · label · observation · suggestion`; with a blocker/suggestion split, and a **disposition** for each

--- a/plugin/agents/test-expert-csk.md
+++ b/plugin/agents/test-expert-csk.md
@@ -28,7 +28,8 @@ The "how" lives in the `testing` skill; this agent applies it.
 - Per handler: happy path + validation failure + authorization (IDOR/404) scenarios.
 - Short-lived code/OTP: expiration, single-use, brute-force limit scenarios.
 - Deterministic tests; external dependencies mocked/faked.
-- Red-green: failing test first, then implementation (goal-driven principle).
+- Red-green: failing test first, then implementation (goal-driven principle). After the last edit, run the suite once and
+  report command + exit code + pass/fail counts; do not re-run it on code nobody has touched since.
 
 ## Coordination (cross-agent)
 - Source of the tested behavior → align with **backend-expert-csk** / **frontend-expert-csk**.


### PR DESCRIPTION
"Tests green" was written into the Definition of Done, into three agents' DoD, into test-expert's red-green line and
into the reviewer's "verify before you report", and nothing said who runs the suite. So every layer ran it again on
code nobody had touched.

## What changes

- **Definition of Done** (`claude-starter/CLAUDE.md`, discipline half): "tests green" is one run of the suite on the
  final code, reported with the command, the exit code and the pass/fail counts. The main thread and the reviewer cite
  that report and run the suite again only after a further edit, or when the report has no exit code. The quality gate
  notes that a test run that compiles is that build.
- **Agent definitions** carry the same rule where they state it: the DoD line of backend-expert (default and `--generic`
  variant), database-expert and frontend-expert, test-expert's red-green line and review-agent's "verify before you
  report". Red-green itself is unchanged.
- **`smoke-test §6f`:** `BUDGET_DISC` 11800 → 12250. The discipline half grows 11784 → 12200 bytes (+416, about 175
  tokens a session by §6f's own bytes-to-tokens measurement). The reason sits beside the number, as the section requires
  for a raise.
- **`plugin/agents`** rebuilt by `build-plugin.sh`.
- **`evals/README.md`:** the baseline and the A/B below, and how to re-run it now that arm `kit` is the new text.

## Measured before it shipped

The criteria, cases, runner, overlay and analysis were hashed before the first run. CLI 2.1.268 at the start and at the
end of both runs; the kit tree hash identical between the baseline and the A/B.

**Baseline** — the current kit, 9 sessions, with a go/no-go rule written first (at least 7 of 9 counted and a median of
at least 4): test/build runs per session 4 · 3 · 6, 5 · 8 · 4, 3 · 6 · 6, median 5. Of the 45 runs: backend-expert 17,
main thread 13, review-agent 11, test-expert 3, security-expert 1. Final code tested in 9 of 9.

**A/B** — three Node cases × three runs × two arms:

| arm | test/build runs per session | final code tested | checks | cost |
|---|---|---|---|---|
| `kit` | 4.44 (median 4) | 9 / 9 | 33 / 33 | $6.54 |
| `kitb` | 2.22 (median 2) | 9 / 9 | 33 / 33 | $6.77 |

S1, ratio ≤ 0.70 and a lower median — passed (0.50). S2, every edited session tested its final code — passed. S3, no
more failed checks and no broken tests — passed. **Decision: ship.**

Checked afterwards in the run's own projects: the new text was present in all six files of every `kitb` project and in
none of the `kit` projects. The reviewer was delegated in 9 of 9 `kitb` sessions (8 of 9 in `kit`); what stopped was
re-running a suite that had just passed.

**Not claimed:** a cost saving — cost did not move on these cases, and `kitb` already carried the extra 416 bytes; a time
saving on slow suites, which was not measured; anything beyond three single-prompt Node cases.

## Verification

| check | result |
|---|---|
| shipped text vs measured text | byte-identical: the discipline cut by `cmp`, the five installed agents by their added lines |
| `bash packaging/build-plugin.sh` | `plugin/agents` regenerated and in sync |
| `bash packaging/verify.sh` on e58afcc | 7 steps passed · smoke 659 graded, 0 skipped · §6f discipline 12200 ≤ 12250 bytes, always-on total 26956 ≤ 27650 · routing passed · catalogue in sync |
| this description, the commit messages and the README addition through `claude-starter/hooks/commit-msg` | clean — the hook was calibrated first: an authorship trailer and a tool-attribution line were both rejected, a plain message accepted |
