### PR TITLE
fix(smoke): a CRLF checkout failed the budget gate as if prose had been added

### DIFF
--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -1704,10 +1704,27 @@ SB=0; for f in "$SKILLS"/*/SKILL.md; do [ -e "$f" ] && SB=$((SB + $(fm_bytes "$f
 # The budget GATES the kit's payload (kit repo, IS_KIT). In an INSTALLED project the user's own agents/skills —
 # including the ones adopt imports from a taken-over agent — legitimately add to the always-on cost (their choice),
 # so there we REPORT the numbers instead of failing the suite.
-bud(){ if [ "$2" -le "$3" ]; then pass "$1 within budget ($2 ≤ $3 bytes)"
-       elif [ "$IS_KIT" = 1 ]; then fail "$1 over budget: $2 > $3 bytes"
+# A budget is a cost ratchet, so when it trips the message has to say WHAT grew. CRLF grows every one of
+# these by a byte per line without a word of prose being added, and the discipline half is 175 lines against
+# a 50-byte margin — so a CRLF checkout fails the gate by 3x the margin and the reader is told "over budget",
+# which sends them looking for text that was never written. Measured on Windows: every .md in a fresh clone
+# carries CR=0 today because .gitattributes pins them, so this is a diagnosis, not a live failure — but the
+# gate that only reports the right verdict for the wrong reason is the gate nobody trusts the second time.
+#
+# `crlf_lines` counts the CR-terminated lines in the same text the budget was measured on, so the two numbers
+# always describe the same bytes. A real overrun still says "over budget"; only a CRLF one is renamed.
+crlf_lines(){ [ -f "$1" ] || { printf '0'; return; }; tr -dc '\r' < "$1" | wc -c | tr -d ' '; }
+bud(){ # $1 name  $2 measured  $3 budget  $4 (optional) the file the bytes came from
+       if [ "$2" -le "$3" ]; then pass "$1 within budget ($2 ≤ $3 bytes)"
+       elif [ "$IS_KIT" = 1 ]; then
+         local cr=0; [ -n "${4:-}" ] && cr="$(crlf_lines "$4")"
+         if [ "$cr" -gt 0 ] && [ $(( $2 - cr )) -le "$3" ]; then
+           fail "$1 over budget ONLY because this checkout is CRLF: $2 > $3 bytes, and $cr of those bytes are carriage returns ($(( $2 - cr )) with LF endings, which is within budget). Re-check out the file rather than editing the budget."
+         else
+           fail "$1 over budget: $2 > $3 bytes"
+         fi
        else pass "$1 $2 bytes (over the kit's $3 baseline — your project's own additions, not gated in an install)"; fi; }
-bud "discipline"         "$DB" "$BUDGET_DISC"
+bud "discipline"         "$DB" "$BUDGET_DISC" "$ROOT/CLAUDE.md"
 bud "agent descriptions" "$AB" "$BUDGET_AGENTS"
 bud "skill descriptions" "$SB" "$BUDGET_SKILLS"
 echo "   always-on total: $((DB+AB+SB)) bytes (budget $((BUDGET_DISC+BUDGET_AGENTS+BUDGET_SKILLS)))"


### PR DESCRIPTION
The always-on budgets are a cost ratchet — they trip when the text that reaches every session grows. CRLF
grows all three of them without a word being written, one byte per line, and the discipline half is 176 lines
against a 50-byte margin. So a CRLF checkout misses by three times the margin and the message sends the reader
looking for prose nobody added. Worse, the obvious response to "over budget" is to raise the budget, which is
the one edit that must never be made to get past it.

Left open after 2.10.0; this closes it. No version carrier is touched.

## What the failure says now

```
over budget ONLY because this checkout is CRLF: 12376 > 12250 bytes, and 176 of those bytes are
carriage returns (12200 with LF endings, which is within budget). Re-check out the file rather than
editing the budget.
```

The CR bytes are counted in the same text the budget was measured on, so the two numbers always describe the
same bytes.

## Four states, against the real discipline half

A synthetic three-line fixture was tried first and the CRLF branch could not be reached with it — the
arithmetic on a 3-CR file never explains a 126-byte overrun. That read as a bug in the code and was a bug in
the test, so the states below use the real text in both line endings:

| | measured | result |
|:--|--:|:--|
| LF, within budget | 12200 ≤ 12250 | passes |
| CRLF checkout | 12376 > 12250 | fails, **and names CRLF** |
| a real overrun, LF file | 12600 > 12250 | plain `over budget` |
| a real overrun **and** CRLF | 12776 > 12250 | plain `over budget` |

The last row is the one that matters: with the CR bytes removed it still exceeds, so genuine growth is never
explained away as line endings.

`crlf_lines` is calibrated the same way — 0 on a known-LF file, 176 on a known-CRLF one, which is the line
count.

## Reachability, stated plainly

Not reachable today. Every `.md` in a fresh clone carries CR=0, measured on Windows with
`core.autocrlf=true`, because `.gitattributes` pins them. This is the diagnosis for the day a pin is missing
or a file arrives from somewhere else. A gate that reaches the right verdict by naming the wrong cause is the
gate nobody trusts the second time.

## Verification

```
smoke   631 graded · 3 skipped · 0 failed   (Windows, Git Bash 5.3.15, no jq, python3 = Store stub)
        discipline within budget (12200 ≤ 12250 bytes)
        agent descriptions within budget (5165 ≤ 5800 bytes)
        skill descriptions within budget (9591 ≤ 9600 bytes)
```
