### PR TITLE
Close the open items from the 2.10.0 report

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,12 @@
   "plugins": [
     {
       "name": "claude-starter-kit",
-      "source": "./plugin",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/byerlikaya/claude-starter-kit.git",
+        "path": "plugin",
+        "ref": "plugin-stable"
+      },
       "description": "Agentic Working Kit — disciplined agents, skills, slash commands, and a team board whose claim is an atomic git-ref lock, so two people cannot start the same work item (lite edition; for the full scaffolding use start.sh / adopt.sh)."
     }
   ]

--- a/.gitattributes
+++ b/.gitattributes
@@ -48,3 +48,12 @@ VERSION text eol=lf
 # Measured by building it both ways; the build without it reproduces the published v2.9.0 SHA exactly.
 *.md text eol=lf
 LICENSE text eol=lf
+# The Studio panel and the npm wrapper are JavaScript, Python, HTML and CSS, and none of those types had a pin.
+# Measured at 2.10.0: `git -c core.autocrlf=true archive` changed the release tarball in 22 files (tar 1,679,360 →
+# 1,689,600 bytes), the same 22 a real Windows clone produced, while the Linux build that publishes reproduced the
+# published SHA. Nothing parses these files line by line, so this is about bytes, like the *.md pin: the tarball must
+# not depend on the machine that builds it. smoke-test §14 keeps every text file in a shipped path pinned.
+*.js text eol=lf
+*.py text eol=lf
+*.html text eol=lf
+*.css text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -43,9 +43,9 @@ VERSION text eol=lf
 # bytes against the published 507.410, and the 1.594-byte difference was CRLF in unpinned files, of which
 # claude-starter/CLAUDE.md alone carried 198. The tarball's SHA is what the Homebrew formula pins, and a
 # SHA that depends on the build machine is the class of defect that took a release down once already.
-# This pin takes the Markdown out of that difference and nothing more: the Studio's .js, .py, .html and
-# .css are not pinned, and an archive built with core.autocrlf=true still differs in every one of them.
-# Measured by building it both ways; the build without it reproduces the published v2.9.0 SHA exactly.
+# This pin takes the Markdown out of that difference; the rest of it was the Studio's .js, .py, .html and .css,
+# pinned below. Measured by building the archive both ways: the build without autocrlf reproduces the published
+# v2.9.0 SHA exactly.
 *.md text eol=lf
 LICENSE text eol=lf
 # The Studio panel and the npm wrapper are JavaScript, Python, HTML and CSS, and none of those types had a pin.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,11 @@ jobs:
           git fetch --no-tags --depth=1 origin gh-pages:refs/remotes/origin/gh-pages
           bash packaging/check-gh-pages.sh
 
-      # The full verify suite runs BEFORE anything is published, so a release can never ship on top of a red
-      # check. (This is the gate that was missing: release used to skip smoke/routing/e2e, so a green publish
-      # could sit on a red CI.)
+      # These gates run BEFORE anything is published, so a release cannot ship on top of a red smoke, routing or
+      # e2e run. (This was the gate that was missing: release used to skip smoke/routing/e2e, so a green publish
+      # could sit on a red CI.) They are not verify.sh's full set: syntax, manifests and studio run only in ci.yml.
+      # And `environment: release` is job-level, so the approval is asked before any step of this job runs; once
+      # approved, a run whose gates pass publishes with no further stop.
       - name: Verify — smoke test + routing eval
         run: |
           bash claude-starter/eval/smoke-test.sh
@@ -106,7 +108,14 @@ jobs:
       # the npm page. Swap in the lean, npm-focused README for the published tarball ONLY (the commit is untouched).
       - name: Use the npm-flavoured README for the package
         run: |
-          if [ -f README.npm.md ]; then cp README.npm.md README.md && echo "npm README staged for publish"; fi
+          # The package must carry exactly one README. npm packs every root README.*, and with README.npm.md and
+          # README.tr.md still beside README.md it chose README.tr.md for the npm page, which is what 2.10.0's page
+          # showed. Its pick among several depends on directory order, so a single file is the only stable answer.
+          if [ -f README.npm.md ]; then
+            cp README.npm.md README.md
+            rm -f README.npm.md README.tr.md
+            echo "npm README staged for publish; README.npm.md and README.tr.md left out of the package"
+          fi
 
       - name: Publish to npm
         run: npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,21 @@ jobs:
             gh release create "$GITHUB_REF_NAME" "$TGZ" --title "$GITHUB_REF_NAME" --notes-file release-notes.md
           fi
 
+      # The plugin marketplace installs from the plugin-stable branch (.claude-plugin/marketplace.json), so the plugin
+      # edition goes live here, inside the approved job and after its gates, not the moment the release PR merges.
+      # Fast-forward only: pointing the branch at an older commit moves installed users back (measured: an update
+      # from a ref at v2.9.0 took an installed 2.10.0 down to 2.9.0), and the branch's ruleset refuses it anyway.
+      # Before npm on purpose: re-running a release whose npm publish already went through fails at npm, since the
+      # version exists, so a step after it would never run.
+      - name: Publish the plugin edition (advance plugin-stable)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/plugin-stable" -f sha="${GITHUB_SHA}" -F force=false >/dev/null
+          now="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/plugin-stable" --jq .object.sha)"
+          [ "$now" = "${GITHUB_SHA}" ] || { echo "::error::plugin-stable is $now, not ${GITHUB_SHA}"; exit 1; }
+          echo "plugin-stable advanced to ${GITHUB_SHA}"
+
       - uses: actions/setup-node@v5
         with:
           node-version: '20'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,12 +99,12 @@ versioning follows [SemVer](https://semver.org/).
 - `/api/projects` awaited the update feed before listing local data: ~350 ms → ~15 ms steady, and against a feed that
   accepts and never answers, 8.37 s → 0.25 s.
 
-### Fixed — Studio: one slow file open stopped the whole panel
+### Fixed — Studio: a slow transcript read blocked the event loop
 
-- The panel read transcript tails synchronously on the request path. On a Windows machine whose security layer
-  inspects file opens, one open took ~31 s and the whole event loop waited with it: `/api/health` on its own
-  connection went unanswered for 312 of 324 pings. The transcript reads are asynchronous now; the slow request still
-  waits for its file, but `/api/health` answered 195 of 195 meanwhile.
+- The panel read transcript tails synchronously on the request path. On one Windows machine a single 128 KiB tail
+  read took 31,209 ms and the whole event loop waited with it: `/api/health` on its own connection went unanswered
+  for 312 of 324 pings. The transcript reads are asynchronous now; the slow request still waits for its file, but
+  `/api/health` answered 195 of 195 meanwhile.
 
 ### Added — evals: rules in agent definitions, test runs, and no score for a run that did not happen
 
@@ -239,8 +239,9 @@ panel from. It does not need one — `palette.js` resolves the kit's agents with
   shipped with the panel absent and the gate green. It asks `git status` now.
 
 The honest gap is stated up front rather than left to be discovered: a plugin user's kit-telemetry panes
-read the project the panel was opened from, and a plugin install writes nothing into a project, so they
-report "not measured" with the reason instead of a misleading zero.
+read the project the panel was opened from, and a plugin install puts no kit files into a project, so they
+report "not measured" with the reason instead of a misleading zero. The gate log is the exception: the
+plugin's guards can append to it too, and the panel lists what it observed.
 
 ### Fixed — the Stop gate failed on every session that had not been compacted
 

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ An installed plugin stays on the version you installed until you ask for a newer
 ### New project
 
 ```bash
-bash start.sh [--dotnet|--generic] [-h]
+bash start.sh [--dotnet|--generic] [--version] [-h]
 ```
 
 Two steps: backend pattern, then a summary you approve before anything is written.

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ bash adopt.sh               # existing project (re-run it to update)
 
 **Windows:** Claude Starter Kit is bash-based. Run it in **Git Bash** ([git-scm.com](https://git-scm.com)); WSL works as a fallback. The gate hooks are shell scripts, so **Git Bash (or WSL) is what makes them run** — on a Windows machine with neither, Claude Code enables its PowerShell tool automatically and the hooks cannot execute, which means no gates. That configuration is not supported by the gate layer, and the installers cannot run there either. With Git Bash present the gates cover **both** shells: the PowerShell tool is on by default for claude.ai and Console accounts, and its commands go through the same rules (`Remove-Item -Recurse -Force`, `… | iex`, `Get-Content .env`, and the rest).
 
-**Plugin edition** — just the agents, skills and gate hooks inside your existing Claude Code, no scaffolding:
+**Plugin edition** — the agents, skills, commands, gate hooks and Studio inside your existing Claude Code, no scaffolding:
 
 ```bash
 /plugin marketplace add byerlikaya/claude-starter-kit

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Does it actually change anything? The same prompt was run in a Claude Starter Ki
 
 The gates stop accidents, not determined attempts. On a command line there is always a way around a pattern; if you need a real boundary, run Claude Code in a devcontainer or a VM. `/doctor-csk` tells you whether you have one.
 
-**Watching a gate fire.** Set `CSK_GATE_LOG=<path>` and every guard appends one line per decision: `BLOCK` / `ASK` / `ALLOW`, the rule, and the command. It is off unless you ask for it, write-only, and written after the verdict, so it cannot change one. Useful when you need to know whether a gate stopped something or the model simply never went there — those two leave identical traces.
+**Watching a gate fire.** The Bash guard appends a line to `.claude/gate-log.tsv` for each block, approval prompt and `CLAUDE_GIT_OK` pre-authorisation (`BLOCK` / `ASK` / `ALLOW`), and the gate-file write guard one for each block, with the section and the rule; the command is recorded only with `CSK_GATE_LOG_CMD=1`. It is on by default when the project's `.claude/` directory exists and the file is git-ignored or the project is not a repo; `CSK_GATE_LOG=<path>` sends it elsewhere and `/dev/null` turns it off. The commit scan and the board gate refuse without writing a line. It is write-only and written after the verdict, so it cannot change one. Useful when you need to know whether a gate stopped something or the model simply never went there — those two leave identical traces.
 
 ---
 
@@ -256,7 +256,7 @@ node .claude/studio/server/index.js --enable-pty  # plus raw shells — those by
 | `npx @byerlikaya/claude-starter-kit` · Homebrew · release tarball · git clone | installed to `.claude/studio/` |
 | Claude Code plugin | shipped inside the plugin, opened with `/claude-starter-kit:studio-csk` (plugin commands are namespaced) |
 
-All four channels carry it. One command file serves both editions: Claude Code substitutes the plugin's own install path into it, so the panel is found wherever it actually is. The panel behaves identically in both, with one honest gap — its kit-telemetry panes read the project you opened it from, and a plugin install writes nothing into a project, so they report "not measured" with the reason rather than a misleading zero.
+All four channels carry it. One command file serves both editions: Claude Code substitutes the plugin's own install path into it, so the panel is found wherever it actually is. The panel behaves identically in both, with one honest gap — its kit-telemetry tabs read the project you opened it from, and a plugin install puts no kit files into a project, so the gates, stats and board tabs report "not measured" with the reason rather than a misleading zero. The gates tab still lists the gate decisions the plugin's guards logged to that project's `.claude/gate-log.tsv`.
 
 It reads `~/.claude/projects`, which holds **every** Claude Code session on the machine. Starting it from a project root only decides which project it opens on.
 

--- a/README.npm.md
+++ b/README.npm.md
@@ -11,6 +11,7 @@
 npx @byerlikaya/claude-starter-kit          # new project — setup wizard
 npx @byerlikaya/claude-starter-kit adopt    # existing project — handover on a branch
 npx @byerlikaya/claude-starter-kit update   # refresh an installed kit
+npx @byerlikaya/claude-starter-kit --version # print the kit version
 ```
 
 Then open Claude Code and run `/doctor-csk` to confirm the install is wired.

--- a/README.tr.md
+++ b/README.tr.md
@@ -220,7 +220,7 @@ Peki gerçekten bir şey değiştiriyor mu? Aynı istek hem Claude Starter Kit'l
 
 Yaptırımlar kazaları durdurur, kararlı denemeleri değil. Komut satırında bir desenin etrafından dolaşmanın bir yolu her zaman bulunur; gerçek bir sınır gerekiyorsa Claude Code'u devcontainer veya sanal makine içinde koşturun. `/doctor-csk` böyle bir sınırınız olup olmadığını söyler.
 
-**Bir yaptırımın ateşlendiğini görmek.** `CSK_GATE_LOG=<yol>` verirseniz her guard, aldığı her karar için tek satır ekler: `BLOCK` / `ASK` / `ALLOW`, kural ve komut. Siz istemedikçe kapalıdır, yalnızca yazar ve karardan **sonra** yazılır, dolayısıyla kararı değiştiremez. Bir şeyi yaptırımın mı durdurduğunu yoksa modelin o yola hiç girmediğini mi bilmeniz gerektiğinde işe yarar, çünkü ikisi geriye tıpatıp aynı izi bırakır.
+**Bir yaptırımın ateşlendiğini görmek.** Bash guard'ı her blok, onay istemi ve `CLAUDE_GIT_OK` ön onayı için (`BLOCK` / `ASK` / `ALLOW`), gate dosyası yazma guard'ı da her blok için `.claude/gate-log.tsv` dosyasına bölüm ve kuralla birlikte bir satır ekler; komut yalnızca `CSK_GATE_LOG_CMD=1` verilirse yazılır. Projenin `.claude/` dizini varsa ve dosya git'te yok sayılıyorsa ya da proje bir repo değilse varsayılan olarak açıktır; `CSK_GATE_LOG=<yol>` kaydı başka yere gönderir, `/dev/null` kapatır. Commit taraması ve pano kapısı satır yazmadan reddeder. Yalnızca yazar ve karardan **sonra** yazılır, dolayısıyla kararı değiştiremez. Bir şeyi yaptırımın mı durdurduğunu yoksa modelin o yola hiç girmediğini mi bilmeniz gerektiğinde işe yarar, çünkü ikisi geriye tıpatıp aynı izi bırakır.
 
 ---
 
@@ -256,7 +256,7 @@ node .claude/studio/server/index.js --enable-pty  # artı ham kabuklar: onlar yu
 | `npx @byerlikaya/claude-starter-kit` · Homebrew · sürüm arşivi · git clone | `.claude/studio/` altına kuruluyor |
 | Claude Code plugin | plugin'in içinde geliyor; `/claude-starter-kit:studio-csk` ile açılıyor (plugin komutları ad alanlı) |
 
-Dört kanal da paneli taşıyor. Tek bir komut dosyası iki edisyona birden hizmet ediyor: Claude Code plugin'in kendi kurulum yolunu o metnin içine yazıyor, dolayısıyla panel gerçekte neredeyse orada bulunuyor. Davranış iki edisyonda aynı; tek dürüst boşluk şu: panelin kit telemetri panoları, açıldığı projeyi okuyor ve plugin kurulumu projeye bir şey yazmıyor. O yüzden o panolar yanıltıcı bir sıfır yerine "ölçülmedi" diyor, sebebiyle birlikte.
+Dört kanal da paneli taşıyor. Tek bir komut dosyası iki edisyona birden hizmet ediyor: Claude Code plugin'in kendi kurulum yolunu o metnin içine yazıyor, dolayısıyla panel gerçekte neredeyse orada bulunuyor. Davranış iki edisyonda aynı; tek dürüst boşluk şu: panelin kit telemetri sekmeleri açıldığı projeyi okuyor ve plugin kurulumu projeye kit dosyası koymuyor. O yüzden gates, stats ve board sekmeleri yanıltıcı bir sıfır yerine "ölçülmedi" diyor, sebebiyle birlikte. Gates sekmesi yine de plugin'in kapılarının o projenin `.claude/gate-log.tsv` dosyasına kaydettiği kapı kararlarını listeliyor.
 
 Panel `~/.claude/projects` dizinini okuyor; orada bu makinedeki **her** Claude Code oturumu duruyor. Proje kökünden başlatmak yalnızca hangi projeyle açılacağını belirliyor.
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -304,7 +304,7 @@ Kurulu bir plugin, siz yenisini istemedikçe kurduğunuz sürümde kalır; bu y�
 ### Yeni proje
 
 ```bash
-bash start.sh [--dotnet|--generic] [-h]
+bash start.sh [--dotnet|--generic] [--version] [-h]
 ```
 
 İki adım: önce backend deseni, sonra hiçbir şey yazılmadan önce onaylayacağınız bir özet.

--- a/README.tr.md
+++ b/README.tr.md
@@ -292,7 +292,7 @@ bash adopt.sh               # mevcut proje (tazelemek için tekrar çalıştır�
 
 **Windows:** Claude Starter Kit bash tabanlıdır. **Git Bash** içinde çalıştırın ([git-scm.com](https://git-scm.com)); WSL de alternatif olur. Yaptırım hook'ları birer kabuk script'i olduğundan **onları çalıştıran şey Git Bash'tir (ya da WSL)**. İkisi de yoksa Claude Code PowerShell aracını kendiliğinden açar, hook'lar çalışamaz ve ortada yaptırım kalmaz. Bu yapılandırma yaptırım katmanınca desteklenmiyor; kurulum script'leri de orada zaten koşamaz. Git Bash varsa yaptırımlar **iki kabuğu birden** kapsar: PowerShell aracı claude.ai ve Console hesaplarında varsayılan olarak açıktır ve onun komutları da aynı kurallardan geçer (`Remove-Item -Recurse -Force`, `… | iex`, `Get-Content .env` ve diğerleri).
 
-**Plugin sürümü:** iskele kurmadan, yalnızca agent'lar, skill'ler ve yaptırım hook'ları mevcut Claude Code'unuzun içine:
+**Plugin sürümü:** iskele kurmadan; agent'lar, skill'ler, komutlar, yaptırım hook'ları ve Studio, mevcut Claude Code'unuzun içine:
 
 ```bash
 /plugin marketplace add byerlikaya/claude-starter-kit

--- a/adopt.sh
+++ b/adopt.sh
@@ -9,7 +9,17 @@
 #
 # Usage: at the target project root (same directory as claude-starter/):  bash adopt.sh
 set -uo pipefail
-HERE="$(cd "$(dirname "$0")" && pwd)"
+HERE="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+
+# --version (or -v) is answered first, before the payload check below: it reads only VERSION, so it works
+# wherever adopt.sh sits. `npx … adopt --version` and `update --version` reach it through bin/cli.js.
+for _a in "$@"; do
+  if [ "$_a" = "--version" ] || [ "$_a" = "-v" ]; then
+    if [ -f "$HERE/VERSION" ]; then head -1 "$HERE/VERSION" | tr -d '\r'; else echo unknown; fi
+    exit 0
+  fi
+done
+
 SRC="$HERE/claude-starter"
 [ -d "$SRC" ] || { echo "ERROR: claude-starter/ not found (must be in the same directory as adopt.sh)."; exit 1; }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -28,8 +28,20 @@ Usage:
       keeps the backend pattern recorded there, and restores anything missing. Your CLAUDE.md
       is never touched.
 
+  npx @byerlikaya/claude-starter-kit --version
+      Print the kit version and exit.
+
 Run any of them at the root of your target project.
 On Windows, run inside Git Bash for the smoothest experience (WSL works as a fallback).`);
+  process.exit(0);
+}
+
+// Answered here, before anything is staged. It used to fall through to start.sh, which cost a copy of the whole
+// payload into a temp dir and then refused the flag as an unknown parameter.
+if (sub === '--version' || sub === '-v') {
+  let version = 'unknown';
+  try { version = fs.readFileSync(path.join(pkgDir, 'VERSION'), 'utf8').split(/\r?\n/)[0].trim() || 'unknown'; } catch (_) { /* no VERSION shipped */ }
+  console.log(version);
   process.exit(0);
 }
 

--- a/claude-starter/commands/doctor-csk.md
+++ b/claude-starter/commands/doctor-csk.md
@@ -30,5 +30,11 @@ running as a **plugin**, whose hooks are managed by Claude Code itself; there's 
 scripts are developer instruments: they inspect an installation from outside it, and the plugin edition has no
 installation to inspect. Say this plainly when someone asks why `/doctor-csk` reports nothing on a plugin install,
 rather than treating it as a defect. The Studio panel is not in that group: both editions carry it, and
-`/studio-csk` finds it in either. On a plugin install its kit-telemetry panes report "not measured": a plugin
-install writes none of the files they read (`.claude/VERSION`, `kit.conf`, the gate scripts) into the project.
+`/studio-csk` finds it in either. A plugin install puts no `.claude/VERSION`, `kit.conf` or kit scripts into a
+project, so that project's row in the panel has no kit badge, and for the project the panel was opened from, the
+inspector's gates, stats and board tabs say "Not measured" with the reason. The gates tab can still list observed
+entries below that. The plugin's Bash guard logs its blocks, approval prompts and `CLAUDE_GIT_OK` pre-authorised
+git actions, and its gate-file write guard logs its blocks, to `.claude/gate-log.tsv` when the project has a
+`.claude/` directory and the file is git-ignored or the project is not a repo. With `CSK_GATE_LOG` set they write
+wherever it points instead, and the panel reads only the project's own `.claude/gate-log.tsv`, so a log sent
+anywhere else does not show. The commit scan and the board gate refuse without writing a line.

--- a/claude-starter/commands/doctor-csk.md
+++ b/claude-starter/commands/doctor-csk.md
@@ -30,5 +30,5 @@ running as a **plugin**, whose hooks are managed by Claude Code itself; there's 
 scripts are developer instruments: they inspect an installation from outside it, and the plugin edition has no
 installation to inspect. Say this plainly when someone asks why `/doctor-csk` reports nothing on a plugin install,
 rather than treating it as a defect. The Studio panel is not in that group: both editions carry it, and
-`/studio-csk` finds it in either. On a plugin install its kit-telemetry panes report "not measured", for the same
-reason this command has nothing to check there: a plugin install writes no kit files into the project.
+`/studio-csk` finds it in either. On a plugin install its kit-telemetry panes report "not measured": a plugin
+install writes none of the files they read (`.claude/VERSION`, `kit.conf`, the gate scripts) into the project.

--- a/claude-starter/commands/doctor-csk.md
+++ b/claude-starter/commands/doctor-csk.md
@@ -25,10 +25,10 @@ Verify the kit is actually *active* in this project (not just present on disk):
 If `.claude/eval/doctor.sh` doesn't exist, this is not a full (start.sh / adopt.sh) install — the kit is likely
 running as a **plugin**, whose hooks are managed by Claude Code itself; there's nothing for the doctor to check.
 
-**The eval scripts and the Studio panel are installer-only, by decision.** `eval/` — `doctor.sh`,
-`smoke-test.sh`, `routing-eval.sh`, `scan-skill.sh`, `utilization.sh` — and `studio/` ship with `start.sh` and
-`adopt.sh` and NOT with the plugin edition. The eval scripts are developer instruments: they inspect an
-installation from outside it, and the plugin edition has no installation to inspect. The panel is the same
-boundary from the other side: it needs a place on disk to be launched from, and a plugin install has no
-`.claude/studio/`. Say this plainly when someone asks why `/doctor-csk` reports nothing or why `/studio-csk`
-declines on a plugin install, rather than treating either as a defect.
+**The eval scripts are installer-only, by decision.** `eval/` — `doctor.sh`, `smoke-test.sh`, `routing-eval.sh`,
+`scan-skill.sh`, `utilization.sh` — ships with `start.sh` and `adopt.sh` and NOT with the plugin edition. The eval
+scripts are developer instruments: they inspect an installation from outside it, and the plugin edition has no
+installation to inspect. Say this plainly when someone asks why `/doctor-csk` reports nothing on a plugin install,
+rather than treating it as a defect. The Studio panel is not in that group: both editions carry it, and
+`/studio-csk` finds it in either. On a plugin install its kit-telemetry panes report "not measured", for the same
+reason this command has nothing to check there: a plugin install writes no kit files into the project.

--- a/claude-starter/commands/studio-csk.md
+++ b/claude-starter/commands/studio-csk.md
@@ -30,11 +30,18 @@ fails, say which one and stop — do not improvise a different launch.
    `npx @byerlikaya/claude-starter-kit@latest update --here --yes` at the project root, or `/update-csk`.
    Then stop. Do not go hunting for the panel anywhere else on disk.
 
-   **What the plugin edition cannot show.** The panel reads the *project you opened it from* for kit
-   telemetry — `.claude/VERSION`, `kit.conf`, the gate scripts. A plugin install writes none of those into
-   a project, so the kit panes report "not measured" with the reason, rather than zero. Say that once when
-   you hand over the URL, so an honest blank is not read as a broken panel. Everything else — the live
-   agent graph, owned sessions, the permission bridge, the terminals — works the same in both editions.
+   **What the plugin edition cannot show.** A plugin install puts no `.claude/VERSION`, `kit.conf` or kit
+   scripts into a project. So that project's row in the list has no kit badge (each row reads its own
+   project), and for the project you opened the panel from, the inspector's gates, stats and board tabs
+   say "Not measured" with the reason, rather than zero. The gates tab can still list observed entries
+   below that. The plugin's Bash guard logs its blocks, approval prompts and `CLAUDE_GIT_OK` pre-authorised
+   git actions, and its gate-file write guard logs its blocks, to `.claude/gate-log.tsv` when the project
+   has a `.claude/` directory and the file is git-ignored or the project is not a repo. With `CSK_GATE_LOG`
+   set they write wherever it points instead, and the panel reads only the project's own
+   `.claude/gate-log.tsv`, so a log sent anywhere else does not show. The commit scan and the board gate
+   refuse without writing a line. Say this once when you hand over the URL, so an honest blank is not
+   read as a broken panel. Everything else — the live agent graph, owned sessions, the permission bridge,
+   the terminals — works the same in both editions.
 
 2. **Resolve a runtime — do not ask whether a name resolves.** `ensure-node.sh` sits beside the panel, so
    use whichever root step 1 settled on:

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -1297,6 +1297,47 @@ if [ "$IS_KIT" = 1 ]; then
       pass "bin/cli.js --help matches the current install shape"
     fi
   fi
+  # `--version` printed no version: cli.js staged the whole payload into a temp dir and handed the flag to start.sh,
+  # which refused it as an unknown parameter. Both entry points now answer it before any side effect, and each
+  # assertion is built so a pass cannot happen by accident. cli.js runs with its temp dir pointed at a path that does
+  # not exist: staging there throws, so a pass proves nothing was staged (an empty temp dir proved nothing, since cli.js
+  # removes its own stage). start.sh runs from a directory holding only itself and VERSION, which its payload check
+  # refuses, so a pass proves --version is answered before that check. The unknown-flag probe gets the payload, so
+  # its refusal comes from the flag loop it is meant to test and not from the missing payload.
+  KV="$(head -1 "$KR/VERSION" 2>/dev/null | tr -d '\r')"
+  if [ -f "$KR/bin/cli.js" ] && [ -n "$KV" ]; then
+    if command -v node >/dev/null 2>&1 && node --version >/dev/null 2>&1; then
+      VT="$(mktemp -d)"; VTX="$VT/does-not-exist"
+      vout="$(TMPDIR="$VTX" TEMP="$VTX" TMP="$VTX" node "$KR/bin/cli.js" --version 2>&1)"; vrc=$?
+      if [ "$vrc" = 0 ] && [ "$vout" = "$KV" ]; then
+        pass "npx … --version prints $KV without staging the payload"
+      else
+        fail "npx … --version: rc=$vrc, output '$(printf '%s' "$vout" | head -1)' (want '$KV')"
+      fi
+      rm -rf "$VT"
+    else
+      skip tool "bin/cli.js --version not run (no working node)"
+    fi
+  fi
+  if [ -f "$KR/start.sh" ] && [ -n "$KV" ]; then
+    VS="$(mktemp -d)"; cp "$KR/start.sh" "$KR/VERSION" "$VS/"
+    vout="$(cd "$VS" && bash start.sh --version 2>&1)"; vrc=$?
+    if [ "$vrc" = 0 ] && [ "$vout" = "$KV" ] && [ "$(ls -A "$VS" | wc -l | tr -d ' ')" = 2 ]; then
+      pass "start.sh --version prints $KV before its payload check, and writes nothing"
+    else
+      fail "start.sh --version: rc=$vrc, output '$(printf '%s' "$vout" | head -1)' (want '$KV'), $(ls -A "$VS" | wc -l | tr -d ' ') entries"
+    fi
+    if [ -d "$KR/claude-starter" ]; then
+      cp -R "$KR/claude-starter" "$VS/"
+      vout="$(cd "$VS" && bash start.sh --no-such-flag 2>&1)"; vrc=$?
+      if [ "$vrc" = 1 ] && printf '%s' "$vout" | grep -q 'Unknown parameter: --no-such-flag'; then
+        pass "start.sh still refuses an unknown flag"
+      else
+        fail "start.sh --no-such-flag: rc=$vrc, output '$(printf '%s' "$vout" | head -1)'"
+      fi
+    fi
+    rm -rf "$VS"
+  fi
   # The hook TABLE is hand-written and nothing tied it to the directory it describes. session-stats.sh was on
   # disk, wired into two skills, and absent from the README — the same class as the picture that drew eleven of
   # twelve agents and the site that advertised eight commands. Every shipped hook must be documented somewhere

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -3143,7 +3143,7 @@ else
   fail "guard-commit-scan.sh missing or not executable — the plugin edition has no commit content gate"
 fi
 
-echo "== 7k) gate observability (CSK_GATE_LOG) — off by default, and never changes the verdict =="
+echo "== 7k) gate observability (CSK_GATE_LOG) — the log never changes the verdict =="
 # Why this exists: a gate that cannot be observed firing cannot be measured. "The model never reached for the
 # command" and "the gate stopped it" leave behind exactly the same artifacts, so evals/permission-pressure had
 # to report "guard-bash never fired" as an INFERENCE rather than a reading. This channel makes it a reading.
@@ -3160,7 +3160,7 @@ blocks2(){ gj auto "$1" | env "${2:-IGNORE=1}" bash "$HOOKS/guard-bash.sh" >/dev
 # 1. Unset: no file appears, and the block still happens (rc=2, not merely non-zero).
 ( cd "$GLD" && unset CSK_GATE_LOG && blocks2 'git reset --hard' ) \
   && pass "log unset: reset --hard still BLOCKED (rc=2)" || fail "log unset: reset --hard not blocked with rc=2 (fail-open or died)"
-[ ! -e "$GLOG" ] && pass "log unset: nothing is written (silent by default)" || fail "log unset: a log file appeared anyway"
+[ ! -e "$GLOG" ] && pass "log unset: nothing is written to that path (no .claude/ here for the default log)" || fail "log unset: a log file appeared anyway"
 # 2. Set: one line, carrying verdict + section + rule. The COMMAND field is empty unless CSK_GATE_LOG_CMD=1
 #    (2.5.0): recording became the default, and the command is the one field that can carry a path or a token
 #    while /gates-csk never prints it. Both halves are cased, because "opt-in" that quietly records anyway is

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -3745,6 +3745,19 @@ if [ -n "$SGR" ] && [ -f "$SGR/.gitattributes" ]; then
   done
   [ -z "$NOEOL" ] && pass "every extensionless shipped hook is pinned to LF in .gitattributes" \
                   || fail "not pinned to LF — a Windows/WSL checkout gets CRLF and the hook dies on its shebang:$NOEOL"
+  # The release tarball's bytes depended on the machine that built it: 22 Studio files (.js .py .html .css) had no
+  # eol pin, so `git -c core.autocrlf=true archive` and a real Windows clone produced CRLF copies of them while the
+  # Linux build that publishes did not. Every text file in a shipped path is pinned now, and this keeps it so — a new
+  # file type added to a shipped path would arrive unpinned and let the build machine decide its bytes again.
+  # Binary files have no line endings to pin; git's own per-file eol report says which ones those are.
+  if [ -d "$SGR/claude-starter" ] && [ -f "$SGR/packaging/build-plugin.sh" ]; then
+    UNPIN="$(git -C "$SGR" ls-files --eol -- start.sh adopt.sh VERSION LICENSE README.md bin claude-starter plugin 2>/dev/null \
+      | awk -F'\t' '{ split($1, f, " "); if (f[1] != "i/-text" && f[1] != "i/none" && $1 !~ /eol=/) print $2 }')"
+    [ -z "$UNPIN" ] && pass "every text file in a shipped path has an eol pin, so the tarball's bytes do not depend on the build machine" \
+                    || fail "text files in shipped paths with no eol pin in .gitattributes — a CRLF build changes their bytes: $(printf '%s\n' "$UNPIN" | head -5 | tr '\n' ' ')($(printf '%s\n' "$UNPIN" | wc -l | tr -d ' ') in all)"
+  else
+    skip scope "shipped-file eol pins not checked (not the kit's source checkout — they are a property of the kit repo)"
+  fi
   # The two editions ship the same hooks; a divergence means one of them was updated and the other was not.
   SDIV=""
   for f in $(git -C "$SGR" ls-files 2>/dev/null | grep -E '^claude-starter/hooks/'); do

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -3794,10 +3794,17 @@ if [ -n "$SGR" ] && [ -f "$SGR/.gitattributes" ]; then
   # file type added to a shipped path would arrive unpinned and let the build machine decide its bytes again.
   # Binary files have no line endings to pin; git's own per-file eol report says which ones those are.
   if [ -d "$SGR/claude-starter" ] && [ -f "$SGR/packaging/build-plugin.sh" ]; then
+    # An empty answer must mean "nothing unpinned", never "git listed nothing": two files every checkout has must
+    # be in the listing first. Symlinks and submodules are not regular files; git leaves their i/ field empty.
+    SLIST="$(git -C "$SGR" ls-files -- start.sh adopt.sh VERSION LICENSE README.md bin claude-starter plugin 2>/dev/null)"
+    if ! printf '%s\n' "$SLIST" | grep -qx 'start.sh' || ! printf '%s\n' "$SLIST" | grep -qx 'claude-starter/CLAUDE.md'; then
+      fail "git did not list the kit's shipped files (start.sh and claude-starter/CLAUDE.md are missing), so the eol pin check measured nothing"
+    else
     UNPIN="$(git -C "$SGR" ls-files --eol -- start.sh adopt.sh VERSION LICENSE README.md bin claude-starter plugin 2>/dev/null \
-      | awk -F'\t' '{ split($1, f, " "); if (f[1] != "i/-text" && f[1] != "i/none" && $1 !~ /eol=/) print $2 }')"
+      | awk -F'\t' '{ split($1, f, " "); if (f[1] != "i/-text" && f[1] != "i/none" && f[1] != "i/" && $1 !~ /eol=/) print $2 }')"
     [ -z "$UNPIN" ] && pass "every text file in a shipped path has an eol pin, so the tarball's bytes do not depend on the build machine" \
                     || fail "text files in shipped paths with no eol pin in .gitattributes — a CRLF build changes their bytes: $(printf '%s\n' "$UNPIN" | head -5 | tr '\n' ' ')($(printf '%s\n' "$UNPIN" | wc -l | tr -d ' ') in all)"
+    fi
   else
     skip scope "shipped-file eol pins not checked (not the kit's source checkout — they are a property of the kit repo)"
   fi

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -1338,6 +1338,25 @@ if [ "$IS_KIT" = 1 ]; then
     fi
     rm -rf "$VS"
   fi
+  # The npm page showed the Turkish README for 2.10.0. The swap step copied README.npm.md over README.md but left
+  # README.npm.md and README.tr.md in the package, and npm chose README.tr.md among them — reproduced with npm
+  # 10.8.2's own selection code, which returns the registry's exact file; its pick depends on directory order. The
+  # step is run here as written, on copies of the three READMEs, and must leave exactly one: the npm README.
+  RY="$KR/.github/workflows/release.yml"
+  if [ -f "$RY" ] && [ -f "$KR/README.npm.md" ]; then
+    RS="$(awk '/- name: Use the npm-flavoured README for the package/{f=1;next} f&&/^      - name:/{exit} f&&/^        run: \|/{r=1;next} f&&r{sub(/^          /,""); print}' "$RY")"
+    RD="$(mktemp -d)"; cp "$KR/README.md" "$KR/README.npm.md" "$RD/"; [ -f "$KR/README.tr.md" ] && cp "$KR/README.tr.md" "$RD/"
+    ( cd "$RD" && bash -c "$RS" >/dev/null 2>&1 )
+    RN="$(ls "$RD" | grep -c -i '^readme')"
+    if [ -z "$RS" ]; then
+      fail "release.yml: the 'Use the npm-flavoured README for the package' step was not found — it moved; update this check"
+    elif [ "$RN" = 1 ] && cmp -s "$RD/README.md" "$KR/README.npm.md"; then
+      pass "the npm package ends up with exactly one README, the npm one"
+    else
+      fail "after release.yml's README step the package holds $RN README file(s) ($(ls "$RD" | tr '\n' ' ')) — npm can pick the wrong one for its page"
+    fi
+    rm -rf "$RD"
+  fi
   # The hook TABLE is hand-written and nothing tied it to the directory it describes. session-stats.sh was on
   # disk, wired into two skills, and absent from the README — the same class as the picture that drew eleven of
   # twelve agents and the site that advertised eight commands. Every shipped hook must be documented somewhere

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -1327,6 +1327,13 @@ if [ "$IS_KIT" = 1 ]; then
     else
       fail "start.sh --version: rc=$vrc, output '$(printf '%s' "$vout" | head -1)' (want '$KV'), $(ls -A "$VS" | wc -l | tr -d ' ') entries"
     fi
+    vout="$(cd "$VS" && bash start.sh -v 2>&1)"; vrc=$?
+    [ "$vrc" = 0 ] && [ "$vout" = "$KV" ] && pass "start.sh -v prints $KV, as npx … -v does" \
+      || fail "start.sh -v: rc=$vrc, output '$(printf '%s' "$vout" | head -1)' (want '$KV')"
+    # An exported CDPATH makes `cd` print the directory it moved to, and HERE then held two lines.
+    vout="$(cd "$(dirname "$VS")" && CDPATH=. bash "$(basename "$VS")/start.sh" --version 2>&1)"; vrc=$?
+    [ "$vrc" = 0 ] && [ "$vout" = "$KV" ] && pass "start.sh finds its own directory with CDPATH exported" \
+      || fail "start.sh under CDPATH=. from a relative path: rc=$vrc, output '$(printf '%s' "$vout" | tr '\n' '|')' (want '$KV')"
     if [ -d "$KR/claude-starter" ]; then
       cp -R "$KR/claude-starter" "$VS/"
       vout="$(cd "$VS" && bash start.sh --no-such-flag 2>&1)"; vrc=$?
@@ -1338,18 +1345,38 @@ if [ "$IS_KIT" = 1 ]; then
     fi
     rm -rf "$VS"
   fi
+  if [ -f "$KR/adopt.sh" ] && [ -n "$KV" ]; then
+    VA="$(mktemp -d)"; cp "$KR/adopt.sh" "$KR/VERSION" "$VA/"
+    vout="$(cd "$VA" && bash adopt.sh --version 2>&1 </dev/null)"; vrc=$?
+    if [ "$vrc" = 0 ] && [ "$vout" = "$KV" ] && [ "$(ls -A "$VA" | wc -l | tr -d ' ')" = 2 ]; then
+      pass "adopt.sh --version prints $KV before its payload check, so \`npx … update --version\` answers too"
+    else
+      fail "adopt.sh --version: rc=$vrc, output '$(printf '%s' "$vout" | head -1)' (want '$KV')"
+    fi
+    rm -rf "$VA"
+  fi
   # The npm page showed the Turkish README for 2.10.0. The swap step copied README.npm.md over README.md but left
   # README.npm.md and README.tr.md in the package, and npm chose README.tr.md among them — reproduced with npm
   # 10.8.2's own selection code, which returns the registry's exact file; its pick depends on directory order. The
-  # step is run here as written, on copies of the three READMEs, and must leave exactly one: the npm README.
+  # step is run here as written, on copies of the three READMEs, and must leave exactly one: the npm README. It
+  # must also run before `npm publish` and without an `if:`, or its effect on a copy says nothing about the
+  # package. Carriage returns are stripped first: the workflow file has no eol pin, and a CRLF checkout would
+  # otherwise hand bash a syntax error and fail this for the wrong reason.
   RY="$KR/.github/workflows/release.yml"
   if [ -f "$RY" ] && [ -f "$KR/README.npm.md" ]; then
-    RS="$(awk '/- name: Use the npm-flavoured README for the package/{f=1;next} f&&/^      - name:/{exit} f&&/^        run: \|/{r=1;next} f&&r{sub(/^          /,""); print}' "$RY")"
+    RS="$(awk '/- name: Use the npm-flavoured README for the package/{f=1;next} f&&/^      - name:/{exit} f&&/^        run: \|/{r=1;next} f&&r{sub(/\r$/,""); sub(/^          /,""); print}' "$RY")"
     RD="$(mktemp -d)"; cp "$KR/README.md" "$KR/README.npm.md" "$RD/"; [ -f "$KR/README.tr.md" ] && cp "$KR/README.tr.md" "$RD/"
     ( cd "$RD" && bash -c "$RS" >/dev/null 2>&1 )
     RN="$(ls "$RD" | grep -c -i '^readme')"
+    RSL="$(grep -n -e '- name: Use the npm-flavoured README for the package' "$RY" | head -1 | cut -d: -f1)"
+    NPL="$(grep -n -e '- name: Publish to npm' "$RY" | head -1 | cut -d: -f1)"
+    RIF="$(awk '/- name: Use the npm-flavoured README for the package/{f=1;next} f&&/^      - name:/{exit} f&&/^        if:/{print "if"}' "$RY")"
     if [ -z "$RS" ]; then
       fail "release.yml: the 'Use the npm-flavoured README for the package' step was not found — it moved; update this check"
+    elif [ -z "$NPL" ] || [ "$RSL" -gt "$NPL" ]; then
+      fail "release.yml: the README step does not run before 'Publish to npm', so it cannot shape the package"
+    elif [ -n "$RIF" ]; then
+      fail "release.yml: the README step carries an if:, so it can be skipped and npm would pack every README"
     elif [ "$RN" = 1 ] && cmp -s "$RD/README.md" "$KR/README.npm.md"; then
       pass "the npm package ends up with exactly one README, the npm one"
     else

--- a/claude-starter/eval/smoke-test.sh
+++ b/claude-starter/eval/smoke-test.sh
@@ -1357,6 +1357,22 @@ if [ "$IS_KIT" = 1 ]; then
     fi
     rm -rf "$RD"
   fi
+  # The plugin marketplace went live the moment a release PR merged, ahead of the release's gates and its approval,
+  # because the entry pointed at ./plugin on main. It now installs from the plugin-stable branch, which only the
+  # approved release job moves forward, and the update notice reads the same branch. Three facts that only work
+  # together: drop any one and the plugin either ships ungated again or is announced before it can be installed.
+  MJ="$KR/.claude-plugin/marketplace.json"; RY="$KR/.github/workflows/release.yml"; UH="$KR/claude-starter/hooks/session-update-check.sh"
+  if [ -f "$MJ" ] && [ -f "$RY" ] && [ -f "$UH" ]; then
+    PSMISS=""
+    grep -Eq '"source"[[:space:]]*:[[:space:]]*"git-subdir"' "$MJ" && grep -Eq '"ref"[[:space:]]*:[[:space:]]*"plugin-stable"' "$MJ" \
+      || PSMISS="$PSMISS marketplace.json-does-not-install-from-plugin-stable"
+    grep -Fq 'git/refs/heads/plugin-stable" -f sha="${GITHUB_SHA}" -F force=false' "$RY" \
+      || PSMISS="$PSMISS release.yml-does-not-advance-plugin-stable-fast-forward-only"
+    grep -Fq 'raw.githubusercontent.com/byerlikaya/claude-starter-kit/plugin-stable/plugin/.claude-plugin/plugin.json' "$UH" \
+      || PSMISS="$PSMISS update-notice-does-not-read-plugin-stable"
+    [ -z "$PSMISS" ] && pass "the plugin channel ships from plugin-stable, advanced only by the approved release job" \
+                     || fail "plugin channel gating is incomplete:$PSMISS"
+  fi
   # The hook TABLE is hand-written and nothing tied it to the directory it describes. session-stats.sh was on
   # disk, wired into two skills, and absent from the README — the same class as the picture that drew eleven of
   # twelve agents and the site that advertised eight commands. Every shipped hook must be documented somewhere

--- a/claude-starter/hooks/guard-bash.sh
+++ b/claude-starter/hooks/guard-bash.sh
@@ -28,10 +28,10 @@
 # from changing it. Failing closed is therefore the correct answer regardless of what a test would show, and
 # this stops being an open question: it is a decision. Should the interaction ever be specified, revisit.
 #
-# CSK_GATE_LOG=<path>, exported by the user, appends one TSV line per gate decision (BLOCK/ASK/ALLOW, section,
-# rule, command) to that file. Absent by default and write-only — it never influences a verdict. It exists
-# because a gate that cannot be observed firing cannot be measured: "the model never tried it" and "the gate
-# stopped it" leave identical artifacts behind. guard-write.sh writes to the same file.
+# The gate log gets one TSV line per logged decision (BLOCK/ASK/ALLOW, section, rule; the command only with
+# CSK_GATE_LOG_CMD=1). On by default since 2.5.0 (see _gatelog_path below); CSK_GATE_LOG=<path> redirects it.
+# Write-only, it never influences a verdict. It exists because a gate that cannot be observed firing cannot be
+# measured: "the model never tried it" and "the gate stopped it" look the same. guard-write.sh logs there too.
 #
 # CLAUDE_GIT_OK=1, exported by the user before the session starts, pre-authorises the session. It exists for
 # headless/CI runs where no one is at the keyboard. It does NOT replace approval: present the message first.
@@ -259,8 +259,8 @@ PERM_MODE="${PERM_MODE:-}"
 #
 # ON BY DEFAULT since 2.5.0, into .claude/gate-log.tsv — an evidence channel nobody switches on records nothing,
 # and "the gates hold" is a claim that needs a record, not a test suite alone. CSK_GATE_LOG overrides the path;
-# CSK_GATE_LOG=/dev/null (or a read-only .claude) turns it off. Only BLOCK/ASK decisions reach here, so an
-# ordinary command writes nothing.
+# CSK_GATE_LOG=/dev/null (or a read-only .claude) turns it off. Only BLOCK, ASK and CLAUDE_GIT_OK's ALLOW reach
+# here: an ordinary command writes nothing, and a git action CLAUDE_GIT_OK allows writes one ALLOW line.
 #
 # The COMMAND TEXT IS NOT RECORDED by default. It is the one field that can carry a path, an argument or a
 # token, and `/gates-csk` never prints it — the report is rule names and counts. Recording it by default would
@@ -271,7 +271,8 @@ PERM_MODE="${PERM_MODE:-}"
 # the path is already ignored. A kit install gitignores .claude/, so this is the normal case — but the plugin
 # edition drops into repos the installer never touched, and this repo proved the failure itself: the suite left
 # a gate-log.tsv sitting in `git status` as an untracked file waiting to be committed. One `git check-ignore`
-# runs only when a gate actually fires (never on an allowed command), so the hot path is untouched.
+# runs only when a decision is logged (a block, an approval prompt or a CLAUDE_GIT_OK allow); ordinary commands
+# never reach it.
 _gatelog_path(){
   if [ -n "${CSK_GATE_LOG:-}" ]; then printf '%s' "$CSK_GATE_LOG"; return; fi
   [ -d ".claude" ] || return 0

--- a/claude-starter/hooks/session-update-check.sh
+++ b/claude-starter/hooks/session-update-check.sh
@@ -35,7 +35,9 @@
 set -uo pipefail
 
 URL="${CSK_UPDATE_URL:-https://registry.npmjs.org/-/package/@byerlikaya%2fclaude-starter-kit/dist-tags}"
-PLUGIN_URL="${CSK_UPDATE_URL:-https://raw.githubusercontent.com/byerlikaya/claude-starter-kit/main/plugin/.claude-plugin/plugin.json}"
+# plugin-stable, not main: the marketplace installs the plugin from that branch, and only an approved release
+# moves it forward. Reading main would announce a release before the plugin channel can deliver it.
+PLUGIN_URL="${CSK_UPDATE_URL:-https://raw.githubusercontent.com/byerlikaya/claude-starter-kit/plugin-stable/plugin/.claude-plugin/plugin.json}"
 MAX_AGE="${CSK_UPDATE_MAX_AGE:-86400}"      # one day between checks
 
 # DIGITS AND DOTS, exactly three fields — nothing else survives to be printed. Deliberately stricter than semver:

--- a/claude-starter/studio/README.md
+++ b/claude-starter/studio/README.md
@@ -53,10 +53,16 @@ placeholder left standing means a full install. Neither path on disk means an
 install from a kit older than the panel, which `/update-csk` brings up to date.
 In the plugin the command is namespaced: `/claude-starter-kit:studio-csk`.
 
-**What the plugin edition cannot show.** The panel reads the project it was
-opened from for kit telemetry (`.claude/VERSION`, `kit.conf`, the gate scripts),
-and a plugin install writes none of those into a project, so those panes report
-"not measured" with the reason rather than zero. Everything else — the live
+**What the plugin edition cannot show.** A plugin install puts no
+`.claude/VERSION`, `kit.conf` or kit scripts into a project. That project's row
+in the list has no kit badge, and for the project the panel was opened from, the
+inspector's gates, stats and board tabs say "Not measured" with the reason rather
+than zero. The gates tab can still list what the gate log observed: the plugin's
+Bash guard records its blocks, approval prompts and pre-authorised git actions,
+and its gate-file write guard its blocks, in `.claude/gate-log.tsv` when the
+project has a `.claude/` directory, the file is git-ignored or the project is
+not a repo, and `CSK_GATE_LOG` does not send the log elsewhere.
+Everything else — the live
 agent graph, owned sessions, the permission bridge, the terminals — works the
 same in both editions.
 

--- a/claude-starter/studio/README.md
+++ b/claude-starter/studio/README.md
@@ -43,12 +43,22 @@ and the panel refuses requests without it. When a browser cannot be opened — o
 SSH, or headless — the server says so rather than looking like it worked, and
 `/studio-csk` reports the URL either way.
 
-**The plugin edition does not carry the panel.** A plugin install has no
-`.claude/` tree to launch it from, and `build-plugin.sh` enumerates
-`agents skills commands hooks` — Studio is not among them. `/studio-csk` ships
-there anyway and its first step says so, with the installer command, rather than
-leaving a plugin user at an unknown command. This is the same boundary
-`/doctor-csk` already documents for `eval/`, for the same reason.
+**Both editions carry the panel, in different places.** A full install has it
+at `.claude/studio/`; the plugin edition has it at `studio/` in the plugin's own
+root. One `/studio-csk` file serves both, and its first step tells them apart
+by reading `${CLAUDE_PLUGIN_ROOT}/studio/server/index.js` literally: Claude Code
+replaces that placeholder before the command is read, and only when the command
+came from the plugin. A real absolute path is the plugin's panel; the
+placeholder left standing means a full install. Neither path on disk means an
+install from a kit older than the panel, which `/update-csk` brings up to date.
+In the plugin the command is namespaced: `/claude-starter-kit:studio-csk`.
+
+**What the plugin edition cannot show.** The panel reads the project it was
+opened from for kit telemetry (`.claude/VERSION`, `kit.conf`, the gate scripts),
+and a plugin install writes none of those into a project, so those panes report
+"not measured" with the reason rather than zero. Everything else — the live
+agent graph, owned sessions, the permission bridge, the terminals — works the
+same in both editions.
 
 **The suite is not here.** It lives in `packaging/studio-test/`, beside the
 repo's other gates, and asserts things about this *repository* — the root

--- a/claude-starter/studio/ensure-node.sh
+++ b/claude-starter/studio/ensure-node.sh
@@ -77,8 +77,9 @@ candidates() {
   [ -n "${CSK_STUDIO_NODE:-}" ] && printf '%s\n' "$CSK_STUDIO_NODE"
   printf 'node\n'
   # Guarded, because that pipeline costs three processes whether or not anything is there,
-  # and a process is not always cheap: measured at 880-1483 ms on a Windows box whose EDR
-  # inspects every creation. A directory test costs none.
+  # and a process is not always cheap: a bare /usr/bin/true measured 880-1483 ms on two machines
+  # against 3-5 ms on a healthy one, and one session traced that to endpoint software inspecting every
+  # process creation. A directory test costs none.
   if [ -d "$RUNTIME" ]; then
     ls -1d "$RUNTIME"/node-v*/ 2>/dev/null | sort -r | while read -r d; do
       printf '%s\n' "${d}bin/node" "${d}node.exe"

--- a/claude-starter/studio/server/index.js
+++ b/claude-starter/studio/server/index.js
@@ -535,11 +535,13 @@ async function relay(pathname) {
   return null;
 }
 
-// Async for the same reason projects.js is, and more urgently: this runs on every
-// stream tick — 700 ms, seven times more often than the project list is polled —
-// so a synchronous stat here is seven times more chances to stop the event loop on
-// a machine where one transcript read has taken tens of seconds. The stall itself is
-// not ours to fix; keeping it inside the one tick that hit it is.
+// Async for the same reason projects.js is: this runs on every stream tick — 700 ms,
+// seven times more often than the project list is polled. No stat has been timed on
+// its own: the timed stalls were a tail read, which opens and reads, and whole
+// requests, which stat as well. The rule is the same anyway: a synchronous filesystem
+// call holds the event loop for as long as it takes, and here it would do that on
+// every tick. Keeping a slow one inside the tick that hit it is ours to do; making the
+// filesystem faster is not.
 async function signature(session) {
   const parts = [];
   try { parts.push(String((await fsp.stat(session.file)).size)); } catch { parts.push('0'); }

--- a/claude-starter/studio/server/index.js
+++ b/claude-starter/studio/server/index.js
@@ -538,8 +538,8 @@ async function relay(pathname) {
 // Async for the same reason projects.js is, and more urgently: this runs on every
 // stream tick — 700 ms, seven times more often than the project list is polled —
 // so a synchronous stat here is seven times more chances to stop the event loop on
-// a machine where one file open can take 31 s. The stall itself is not ours to fix;
-// keeping it inside the one tick that hit it is.
+// a machine where one transcript read has taken tens of seconds. The stall itself is
+// not ours to fix; keeping it inside the one tick that hit it is.
 async function signature(session) {
   const parts = [];
   try { parts.push(String((await fsp.stat(session.file)).size)); } catch { parts.push('0'); }

--- a/claude-starter/studio/server/lib/kit.js
+++ b/claude-starter/studio/server/lib/kit.js
@@ -36,17 +36,14 @@ export function latestVersionCached() {
   const fresh = latestCache && Date.now() - latestCache.at < FEED_TTL_MS;
   // Deferred to a later tick, not merely un-awaited, so the request path does no work of its own.
   //
-  // It does NOT fix the stall that is still open against this file. Measured on a Windows machine
-  // with an inspecting layer on every connection: while the feed accepts and stays silent, the
-  // first /api/projects sometimes takes 28-31 s (3 of 25) — and during that window a SEPARATE
-  // /api/health on a separate connection does not answer either. So the whole event loop is
-  // blocked, not this endpoint, and removing an await cannot help: there is no await to remove.
-  // A refused connection never reproduces it; only an accepted-and-silent one does.
-  //
-  // Four hypotheses have been tested and all four failed (libuv threadpool saturation, a cold
-  // path after idle, the fetch itself in isolation, and the await on the request path). The
-  // mechanism is unknown and is tracked separately. This line stays because starting work on a
-  // request path is wrong regardless of what turns out to be blocking.
+  // The panel stall once pinned on this feed was never the feed: a run with the feed disabled
+  // entirely stalled the same way. It was a transcript read. On the Windows machine that has it, a
+  // security layer scans a file after it is written, and a read that lands before the scan finishes
+  // waits for it — 63-65 s for a plain `tail -c 131072` of a 25 MB transcript copy with no kit code
+  // running, 0.04 s warm, 0.044 s after waiting 90 s. It comes in clusters and could not be produced
+  // on demand, so no frequency is claimed. The reads were synchronous, so the whole panel stopped
+  // answering; projects.js keeps that wait inside one request now. This line stays because starting
+  // work on a request path is wrong regardless.
   if (!fresh && !inflight) {
     setTimeout(() => { latestVersion().catch(() => {}); }, 0).unref();
   }

--- a/claude-starter/studio/server/lib/kit.js
+++ b/claude-starter/studio/server/lib/kit.js
@@ -37,13 +37,13 @@ export function latestVersionCached() {
   // Deferred to a later tick, not merely un-awaited, so the request path does no work of its own.
   //
   // The panel stall once pinned on this feed was never the feed: a run with the feed disabled
-  // entirely stalled the same way. It was a transcript read. On the Windows machine that has it, a
-  // security layer scans a file after it is written, and a read that lands before the scan finishes
-  // waits for it — 63-65 s for a plain `tail -c 131072` of a 25 MB transcript copy with no kit code
-  // running, 0.04 s warm, 0.044 s after waiting 90 s. It comes in clusters and could not be produced
-  // on demand, so no frequency is claimed. The reads were synchronous, so the whole panel stopped
-  // answering; projects.js keeps that wait inside one request now. This line stays because starting
-  // work on a request path is wrong regardless.
+  // entirely stalled the same way. It was a transcript read on one Windows machine, where a read that
+  // follows a write of the same file can wait — 63-65 s for a plain `tail -c 131072` of a freshly
+  // copied 25 MB transcript with no kit code running, 0.04 s warm, 0.044 s when the read waited 90 s
+  // after the copy. What holds the file was not identified, and the wait comes in clusters that could
+  // not be produced on demand. The reads were synchronous, so the whole panel stopped answering;
+  // projects.js keeps such a wait inside one request now. This line stays because starting work on a
+  // request path is wrong regardless.
   if (!fresh && !inflight) {
     setTimeout(() => { latestVersion().catch(() => {}); }, 0).unref();
   }
@@ -107,7 +107,7 @@ export function compareVersions(a, b) {
 /** What the kit looks like inside one working directory.
  *
  * Async because it runs once per project on the `/api/projects` path, and a
- * synchronous read there blocks the whole panel when one file open stalls —
+ * synchronous read there blocks the whole panel when one read stalls —
  * see the note at the top of projects.js for the measurement.
  */
 export async function kitStatus(cwd, latest) {

--- a/claude-starter/studio/server/lib/kit.js
+++ b/claude-starter/studio/server/lib/kit.js
@@ -37,13 +37,11 @@ export function latestVersionCached() {
   // Deferred to a later tick, not merely un-awaited, so the request path does no work of its own.
   //
   // The panel stall once pinned on this feed was never the feed: a run with the feed disabled
-  // entirely stalled the same way. It was a transcript read on one Windows machine, where a read that
-  // follows a write of the same file can wait — 63-65 s for a plain `tail -c 131072` of a freshly
-  // copied 25 MB transcript with no kit code running, 0.04 s warm, 0.044 s when the read waited 90 s
-  // after the copy. What holds the file was not identified, and the wait comes in clusters that could
-  // not be produced on demand. The reads were synchronous, so the whole panel stopped answering;
-  // projects.js keeps such a wait inside one request now. This line stays because starting work on a
-  // request path is wrong regardless.
+  // entirely stalled the same way. It was a synchronous transcript read on one Windows machine: one
+  // 128 KiB tail took 31,209 ms, and the event loop waited with it. projects.js has the panel's
+  // numbers and, kept apart from them, what was measured on that machine later. The reads are async
+  // now, so such a wait stays inside one request. This line stays because starting work on a request
+  // path is wrong regardless.
   if (!fresh && !inflight) {
     setTimeout(() => { latestVersion().catch(() => {}); }, 0).unref();
   }

--- a/claude-starter/studio/server/lib/projects.js
+++ b/claude-starter/studio/server/lib/projects.js
@@ -11,13 +11,15 @@
 // copy would break that pin.
 
 // EVERY filesystem call here is async, and that is the point rather than a style
-// choice. Measured on a Windows 11 machine whose EDR inspects file opens: reading
-// the 128 KiB tail of one transcript took 0-1 ms on fourteen runs out of fifteen
-// and 31,209 ms on the fifteenth. With `readSync` that stalled the event loop, so
-// the panel answered NOTHING for half a minute — `/api/projects` took 33,391 ms and
-// a separate `/api/health` on its own connection went unanswered for 312 of 324
-// pings. Async does not make the read faster; the same 30 s still passes. It keeps
-// the stall inside the one request that hit it while the rest of the panel stays up.
+// choice. On a Windows machine whose security layer scans a file after it is
+// written, a read that lands before the scan finishes waits for it: 63-65 s for a
+// plain `tail -c 131072` of a 25 MB transcript copy with no kit code running, 0.04 s
+// warm, 0.044 s after waiting 90 s. It comes in clusters and could not be produced
+// on demand. With `readSync` such a wait stalled the event loop, so the panel
+// answered NOTHING — `/api/projects` took 33,391 ms and a separate `/api/health` on
+// its own connection went unanswered for 312 of 324 pings. Async does not make the
+// read faster; it keeps the wait inside the one request that hit it while the rest
+// of the panel stays up.
 import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';

--- a/claude-starter/studio/server/lib/projects.js
+++ b/claude-starter/studio/server/lib/projects.js
@@ -12,7 +12,7 @@
 
 // EVERY filesystem call here is async, and that is the point rather than a style
 // choice. On a Windows machine a single synchronous 128 KiB tail read once took
-// 31,209 ms, and because it stopped the event loop the panel answered NOTHING:
+// 31,209 ms, and because it blocked the event loop other requests waited with it:
 // `/api/projects` took 33,391 ms and a separate `/api/health` on its own connection
 // went unanswered for 312 of 324 pings. Measured later on the same machine with no
 // kit code running, a plain `tail -c 131072` of a freshly copied 25 MB transcript

--- a/claude-starter/studio/server/lib/projects.js
+++ b/claude-starter/studio/server/lib/projects.js
@@ -11,15 +11,15 @@
 // copy would break that pin.
 
 // EVERY filesystem call here is async, and that is the point rather than a style
-// choice. On a Windows machine whose security layer scans a file after it is
-// written, a read that lands before the scan finishes waits for it: 63-65 s for a
-// plain `tail -c 131072` of a 25 MB transcript copy with no kit code running, 0.04 s
-// warm, 0.044 s after waiting 90 s. It comes in clusters and could not be produced
-// on demand. With `readSync` such a wait stalled the event loop, so the panel
-// answered NOTHING — `/api/projects` took 33,391 ms and a separate `/api/health` on
-// its own connection went unanswered for 312 of 324 pings. Async does not make the
-// read faster; it keeps the wait inside the one request that hit it while the rest
-// of the panel stays up.
+// choice. On a Windows machine a single synchronous 128 KiB tail read once took
+// 31,209 ms, and because it stopped the event loop the panel answered NOTHING:
+// `/api/projects` took 33,391 ms and a separate `/api/health` on its own connection
+// went unanswered for 312 of 324 pings. Measured later on the same machine with no
+// kit code running, a plain `tail -c 131072` of a freshly copied 25 MB transcript
+// waited 63-65 s right after the copy, 0.04 s warm, and 0.044 s when it waited 90 s
+// first. What holds the file was not identified, and the wait could not be produced
+// on demand. Async does not make the read faster; it keeps the wait inside the one
+// request that hit it while the rest of the panel stays up.
 import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';

--- a/claude-starter/studio/server/lib/roster.js
+++ b/claude-starter/studio/server/lib/roster.js
@@ -61,10 +61,9 @@ export function parseRoster(text) {
   return { self: self ? { name: self[1], ref: self[2] } : null, peers };
 }
 
-// Async for the reason projects.js gives: this reads the tail of a transcript — the
-// read a file-scanning security layer held for about a minute right after the file was
-// written — and it runs on the `/api/fleet` path the panel polls every 2 s, the shortest
-// cycle in the app.
+// Async for the reason projects.js gives: this reads transcript tails too (TAIL_BYTES, and
+// DEEP_BYTES for the newest few), and it runs on the `/api/fleet` path the panel polls every
+// 2 s, the shortest cycle in the app.
 async function readTail(file, size, limit = TAIL_BYTES) {
   let fh;
   try {

--- a/claude-starter/studio/server/lib/roster.js
+++ b/claude-starter/studio/server/lib/roster.js
@@ -61,9 +61,10 @@ export function parseRoster(text) {
   return { self: self ? { name: self[1], ref: self[2] } : null, peers };
 }
 
-// Async for the reason projects.js gives: this reads the tail of a transcript, which
-// is the exact operation measured at 31.2 s on one run in fifteen, and it runs on the
-// `/api/fleet` path the panel polls every 2 s — the shortest cycle in the app.
+// Async for the reason projects.js gives: this reads the tail of a transcript — the
+// read a file-scanning security layer held for about a minute right after the file was
+// written — and it runs on the `/api/fleet` path the panel polls every 2 s, the shortest
+// cycle in the app.
 async function readTail(file, size, limit = TAIL_BYTES) {
   let fh;
   try {

--- a/claude-starter/studio/server/lib/roster.js
+++ b/claude-starter/studio/server/lib/roster.js
@@ -62,8 +62,7 @@ export function parseRoster(text) {
 }
 
 // Async for the reason projects.js gives: this reads transcript tails too (TAIL_BYTES, and
-// DEEP_BYTES for the newest few), and it runs on the `/api/fleet` path the panel polls every
-// 2 s, the shortest cycle in the app.
+// DEEP_BYTES for the newest few), and it runs on the `/api/fleet` path the panel polls every 2 s.
 async function readTail(file, size, limit = TAIL_BYTES) {
   let fh;
   try {

--- a/claude-starter/studio/server/lib/transcript.js
+++ b/claude-starter/studio/server/lib/transcript.js
@@ -19,9 +19,9 @@ export class JsonlReader {
 
   /** Read everything appended since the last call. Returns parsed records.
    *
-   * Async because a transcript open can take 31 s on a machine whose security
-   * layer inspects it, and this sits under the stream tick — see the note at the
-   * top of projects.js. The read is no faster; it just no longer stops the loop.
+   * Async because a transcript read has stalled for tens of seconds on a Windows
+   * machine, and this sits under the stream tick — see the note at the top of
+   * projects.js. The read is no faster; it just no longer stops the loop.
    */
   async read() {
     let st;

--- a/evals/README.md
+++ b/evals/README.md
@@ -204,9 +204,10 @@ place for a claim to rest, because **"the model never reached for the command" a
 behind identical artifacts** — the file is unchanged either way, and the two mean opposite things about which
 half of the kit is working.
 
-`CSK_GATE_LOG` closes that. Exported by the runner, the hooks append one TSV line per decision
-(`BLOCK`/`ASK`/`ALLOW`, section, rule, command); absent otherwise, write-only, logged after the verdict so it
-cannot influence one. `run.sh` prints a **gates fired** line beside each score.
+`CSK_GATE_LOG` closes that. Exported by the runner, it points the hooks' gate log at the case directory: one
+TSV line per logged decision (`BLOCK`/`ASK`/`ALLOW`, section, rule; the command only with `CSK_GATE_LOG_CMD=1`,
+which the runner does not set), write-only, logged after the verdict so it cannot influence one. `run.sh` reads
+the first three columns and prints a **gates fired** line beside each score.
 
 It is **reported, never scored.** A channel only the kit arm can produce cannot enter the denominator without
 handing the kit points the control is structurally unable to earn — the fixed-denominator bias that had to be

--- a/packaging/check-gh-pages.sh
+++ b/packaging/check-gh-pages.sh
@@ -4,7 +4,8 @@
 # line sat at v1.6.0 through the entire 1.7.0 release while the counters had been hand-corrected separately.
 # Every other count in this project is gated (README catalogue, plugin edition, byte budgets); this one was not.
 #
-# Compares the site's version and its agent/skill counters against the payload it claims to describe. Read-only.
+# Compares the site's version, and every count of agents, skills and commands it states — counters and prose, in
+# English and Turkish — against the payload it claims to describe. Read-only.
 #
 # Usage:
 #   bash packaging/check-gh-pages.sh              # reads the site from the gh-pages ref (origin/ then local)
@@ -29,6 +30,7 @@ fi
 VER="$(tr -d ' \n\r' < VERSION 2>/dev/null)"
 AGENTS=$(ls claude-starter/agents/*.md 2>/dev/null | wc -l | tr -d ' ')
 SKILLS=$(ls -d claude-starter/skills/*/ 2>/dev/null | wc -l | tr -d ' ')
+COMMANDS=$(ls claude-starter/commands/*.md 2>/dev/null | wc -l | tr -d ' ')
 
 # The site is markup, so read the NUMBERS the way the page renders them: the version marker, and each counter as
 # the digits sitting immediately before its label. Anchored to the label, never to a bare number — the page is
@@ -42,6 +44,7 @@ count_before() {   # $1 = label word as it appears in the page ("agents" / "skil
 }
 site_agents="$(count_before agents)"
 site_skills="$(count_before skills)"
+site_commands="$(count_before commands)"
 
 FAIL=0
 echo "== published site vs payload  ($SRC) =="
@@ -58,6 +61,36 @@ chk() { # $1 label, $2 expected, $3 found(list)
 chk "version" "$VER" "$site_ver"
 chk "agents"  "$AGENTS" "$site_agents"
 chk "skills"  "$SKILLS" "$site_skills"
+chk "commands" "$COMMANDS" "$site_commands"
+
+# Counts written in prose are read too. Before 2.10.0 the page said "39 skills" in its hero, its pitch and its
+# Turkish pitch while every counter said 40, and its commands counter said 7 against 11 — and this script was
+# green, because it read only the counters. The text is the page with its tags removed plus the description meta
+# tags (those are attributes, so removing tags would lose them). A count is a number directly before the noun,
+# allowing the one adjective the page puts between them ("specialist" / "uzman"), and never part of a larger number.
+TEXT="$( { printf '%s' "$HTML" | tr '\n' ' ' | grep -oE '<meta [^>]*>' | grep -E '(name|property)="(og:|twitter:)?description"' \
+            | sed -n 's/.*content="\([^"]*\)".*/\1/p'
+          printf '%s' "$HTML" | tr '\n' ' ' | sed 's/<[^>]*>/ /g'; } | tr -s ' ' )"
+prose_chk() {   # $1 label, $2 expected, $3 noun alternation (EN|TR)
+  local nums bad n
+  nums="$(printf '%s' "$TEXT" | grep -oE "(^|[^0-9.,])[0-9]{1,3} ((specialist|uzman) )?($3)([^[:alpha:]]|$)" | grep -oE '[0-9]{1,3}')"
+  if [ -z "$nums" ]; then
+    echo "  ⚠️  $1 in the page text: no count found — the page changed; update this check, don't ignore it"; FAIL=1; return
+  fi
+  bad="$(printf '%s\n' "$nums" | grep -v -x -F "$2" | sort -u | tr '\n' ' ')"
+  if [ -z "$bad" ]; then
+    echo "  ✅ $1 in the page text: $2 (stated $(printf '%s\n' "$nums" | wc -l | tr -d ' ') time(s))"
+  else
+    echo "  ❌ $1 in the page text: says ${bad}where the payload is $2"
+    for n in $bad; do
+      printf '%s' "$TEXT" | grep -oE ".{0,40}(^|[^0-9.,])$n ((specialist|uzman) )?($3)([^[:alpha:]]|$)" | sed 's/^/        …/'
+    done
+    FAIL=1
+  fi
+}
+prose_chk "agents"   "$AGENTS"   "agents?|ajan"
+prose_chk "skills"   "$SKILLS"   "skills?"
+prose_chk "commands" "$COMMANDS" "commands?|komut"
 
 # The brand mark exists three times and no copy can see the others: assets/icon.svg is the source, the site
 # inlines it as a data: URI favicon (no file reference, so a grep of the working tree finds nothing — and one
@@ -99,7 +132,7 @@ fi
 echo "---"
 if [ "$FAIL" -eq 0 ]; then echo "GH-PAGES: in sync ✅"; exit 0; fi
 echo "GH-PAGES: drifted ❌ — fix the copy named on the failing line above, before publishing"
-echo "  version/agents/skills live in index.html on the gh-pages branch, which is hand-written and has no"
+echo "  version and the agent/skill/command counts live in index.html on the gh-pages branch, which is hand-written and has no"
 echo "  build step, so nothing else will do it. A brand-mark line points at whichever copy moved: the site's"
 echo "  inline favicon, packaging/gen-network.py, or assets/icon.svg itself if you meant to change the mark."
 exit 1

--- a/packaging/check-gh-pages.sh
+++ b/packaging/check-gh-pages.sh
@@ -65,15 +65,34 @@ chk "commands" "$COMMANDS" "$site_commands"
 
 # Counts written in prose are read too. Before 2.10.0 the page said "39 skills" in its hero, its pitch and its
 # Turkish pitch while every counter said 40, and its commands counter said 7 against 11 — and this script was
-# green, because it read only the counters. The text is the page with its tags removed plus the description meta
-# tags (those are attributes, so removing tags would lose them). A count is a number directly before the noun,
-# allowing the one adjective the page puts between them ("specialist" / "uzman"), and never part of a larger number.
-TEXT="$( { printf '%s' "$HTML" | tr '\n' ' ' | grep -oE '<meta [^>]*>' | grep -E '(name|property)="(og:|twitter:)?description"' \
-            | sed -n 's/.*content="\([^"]*\)".*/\1/p'
-          printf '%s' "$HTML" | tr '\n' ' ' | sed 's/<[^>]*>/ /g'; } | tr -s ' ' )"
+# green, because it read only the counters. The text is the page with its tags removed, plus the description and
+# title meta tags (attributes, so removing tags would lose them; either quote style). &nbsp; counts as a space.
+# The text is read word by word rather than with one regular expression: the page writes its English and Turkish
+# spans side by side ("12 agents 12 ajan"), and a pattern that consumes the space after one count cannot start a
+# match on the next. A count is a word of one to three digits (optionally after "(") followed by the noun, with
+# the one adjective the page puts between them ("specialist" / "uzman") allowed.
+TEXT="$( { printf '%s' "$HTML" | tr '\n' ' ' | grep -oiE '<meta [^>]*>' \
+            | grep -iE "(name|property)=[\"'](og:|twitter:)?(description|title)[\"']" \
+            | sed -n -E -e "s/.*content=\"([^\"]*)\".*/\1/p" -e "s/.*content='([^']*)'.*/\1/p"
+          printf '%s' "$HTML" | tr '\n' ' ' | sed 's/<[^>]*>/ /g'; } \
+        | sed -e 's/&nbsp;/ /g' -e 's/&#160;/ /g' -e 's/&#[xX][aA]0;/ /g' | LC_ALL=C sed $'s/\xc2\xa0/ /g' | tr -s ' ' )"
+prose_nums() {   # $1 noun alternation -> one number per count found
+  printf '%s' "$TEXT" | tr -s ' \t' '\n\n' | awk -v nouns="$1" '
+    { w[NR] = $0 }
+    END {
+      for (i = 1; i <= NR; i++) {
+        n = w[i]; sub(/^\(/, "", n)
+        if (n !~ /^[0-9][0-9]?[0-9]?$/) continue
+        j = i + 1; x = tolower(w[j])
+        if (x == "specialist" || x == "uzman") { j++; x = tolower(w[j]) }
+        sub(/[^a-z].*$/, "", x)
+        if (x ~ ("^(" nouns ")$")) print n
+      }
+    }'
+}
 prose_chk() {   # $1 label, $2 expected, $3 noun alternation (EN|TR)
   local nums bad n
-  nums="$(printf '%s' "$TEXT" | grep -oE "(^|[^0-9.,])[0-9]{1,3} ((specialist|uzman) )?($3)([^[:alpha:]]|$)" | grep -oE '[0-9]{1,3}')"
+  nums="$(prose_nums "$3")"
   if [ -z "$nums" ]; then
     echo "  ⚠️  $1 in the page text: no count found — the page changed; update this check, don't ignore it"; FAIL=1; return
   fi
@@ -83,7 +102,7 @@ prose_chk() {   # $1 label, $2 expected, $3 noun alternation (EN|TR)
   else
     echo "  ❌ $1 in the page text: says ${bad}where the payload is $2"
     for n in $bad; do
-      printf '%s' "$TEXT" | grep -oE ".{0,40}(^|[^0-9.,])$n ((specialist|uzman) )?($3)([^[:alpha:]]|$)" | sed 's/^/        …/'
+      printf '%s' "$TEXT" | grep -oE ".{0,40}(^|[^0-9])$n ((specialist|uzman) )?($3)" | sed 's/^/        …/'
     done
     FAIL=1
   fi

--- a/packaging/studio-serve-probe.mjs
+++ b/packaging/studio-serve-probe.mjs
@@ -43,13 +43,13 @@ let pass = 0; let na = 0; let known = 0; const failures = [];
 // never ran.
 const notApplicable = (name, why) => { na += 1; console.log(`  N/A  ${name} — ${why}`); };
 // A third word, and it is deliberately not a pass. The check ran, it measured what it was written
-// to measure, and what it found is a defect we have already isolated and cannot yet explain. Made
-// green it would be a lie; made red it would go red on one Windows run in eight and be silenced
-// within a month, which is how a gate stops being read. KNOWN keeps the observation on screen and
-// off the exit code, and it names the open item every time it prints.
+// to measure, and what it found is a wait the kit neither causes nor can remove. Made green it would
+// be a lie; made red it would fire whenever that machine's scanner happens to be busy, which cannot
+// be produced on demand, and be silenced within a month, which is how a gate stops being read. KNOWN
+// keeps the observation on screen and off the exit code, and it names the cause every time it prints.
 const knownIssue = (name, detail, issue) => {
   known += 1;
-  console.log(`  KNOWN ${name} — ${detail}\n        this is the open item: ${issue}`);
+  console.log(`  KNOWN ${name} — ${detail}\n        the cause: ${issue}`);
 };
 const check = (name, ok, detail) => {
   if (ok) { pass += 1; console.log(`  ok   ${name}${detail ? ` — ${detail}` : ''}`); }
@@ -160,7 +160,7 @@ check('projects are read from disk', projects.status === 200 && measured && Arra
 // worth not repeating: it called every slow first call "waiting on the update feed", which is a
 // cause that was later disproven. A run that hits the known block says nothing about the feed at
 // all, so it must not be reported as if it did.
-const STALL_MS = 25000;          // the block measured at 28-31 s; a feed wait would be 8 s at most
+const STALL_MS = 25000;          // scanner waits were measured at 28-31 s and at 63-65 s; a feed wait would be 8 s at most
 const LIVENESS_MS = 2000;
 const timing = `the first /api/projects took ${waited}ms with a feed that never answers; a separate `
   + `/api/health on its own connection answered ${during.status} after ${duringMs}ms while it was in flight`;
@@ -184,14 +184,15 @@ check('the panel answers other requests while a read stalls', duringMs < LIVENES
 if (waited < 3000) {
   check('the project list is served from local data, not a network round trip', true, timing);
 } else if (waited > STALL_MS) {
-  // Reported, not graded: the file open really did take half a minute, and no amount of code here
-  // makes a scanned disk faster. Green would hide it; red would fire on one Windows run in eight and
-  // be muted within a month. The graded half is above, and it stays green through exactly this run.
+  // Reported, not graded: the read really did wait that long, and no code here makes a scanner finish
+  // sooner. Green would hide it; red would fire whenever that machine's scanner is busy and be muted
+  // within a month. The graded half is above, and it stays green through exactly this run.
   knownIssue('one transcript read took the stall shape',
     `${timing} — the read itself took ~${Math.round(waited / 1000)}s`,
-    'a security layer inspecting file opens: 31.2s measured for a single 128 KiB tail read on this '
-    + 'machine, 0-1 ms on fourteen of fifteen runs. Not the kit\'s to fix; the kit\'s part was keeping '
-    + 'the rest of the panel answering, which the check above grades');
+    'a security layer that scans files after they are written: a plain tail read of a 25 MB transcript copy '
+    + 'waited 63-65 s with no kit code running and 0.044 s after waiting 90 s; it comes in clusters and could '
+    + "not be produced on demand. Not the kit's to fix; the kit's part was keeping the rest of the panel "
+    + 'answering, which the check above grades');
   notApplicable('the project list is served from local data, not a network round trip',
     'this run hit the stall above, so its timing measures the disk and cannot speak to the request path');
 } else {

--- a/packaging/studio-serve-probe.mjs
+++ b/packaging/studio-serve-probe.mjs
@@ -136,69 +136,103 @@ check('an API call without a token is refused', noTok.status === 403, `status ${
 // whether the panel is still answering at all. The distinction is the whole point. A slow endpoint
 // is an endpoint; a server that answers nothing is a panel the user calls frozen, and the two look
 // identical from a single request. Measured on the machine that has this: during a 29 s stall,
-// /api/health on its own connection did not answer for 20 s either.
+// /api/health on its own connection did not answer either.
+// The list's own time is taken when its request resolves. Reading the clock at the `await` below would
+// come after the 1.5 s sleep and the health call: every fast list would print ~1.5 s, and a slow health
+// call would pass for a slow list.
 const t0 = Date.now();
-const inFlight = get(port, `/api/projects?token=${TOKEN}`);
+let waited = null;
+const inFlight = get(port, `/api/projects?token=${TOKEN}`).then((r) => { waited = Date.now() - t0; return r; });
 await sleep(1500);
+// Whether the list was still being served when the health request went out. A list that finished inside
+// the sleep leaves nothing in flight, so the health answer below cannot say anything about a stall.
+const listInFlight = waited === null;
 const duringStart = Date.now();
 const during = await get(port, `/api/health?token=${TOKEN}`);
 const duringMs = Date.now() - duringStart;
+// Whether the health answer came back before the list did. Only that shows the panel answering during it.
+const healthFirst = waited === null;
 const projects = await inFlight;
-const waited = Date.now() - t0;
 let measured = null;
 try { measured = JSON.parse(projects.body); } catch { /* reported below */ }
 check('projects are read from disk', projects.status === 200 && measured && Array.isArray(measured.projects),
   measured ? `${measured.projects?.length} project(s)` : `status ${projects.status}`);
 
-// The list is local data. It used to await the update feed, so a hanging registry cost the full
-// 8 s fetch timeout on the first request — measured at 8.37 s, and reported from a corporate
-// network as a 12-second panel that read as hung. CSK_UPDATE_URL points at a socket that accepts
-// and never answers, which is exactly that condition; an unreachable host would NOT reproduce it,
-// because a refused connection returns at once.
+// The list is local data. It used to await the update feed, so a registry that accepts and never
+// answers cost the full 8 s fetch timeout on the first request — measured at 8.37 s. (The work began
+// from a report of a 12-second /api/projects; its reporter withdrew the feed as the cause after
+// re-measuring.) CSK_UPDATE_URL points at a socket that accepts and never answers, which is exactly
+// that condition; an unreachable host would NOT reproduce it, because a refused connection returns at once.
 // One measurement, three outcomes — because two independent checks on the same numbers could
 // disagree with each other, and because the first version of this got the naming wrong in a way
 // worth not repeating: it called every slow first call "waiting on the update feed", which is a
 // cause that was later disproven. A run that hits the known block says nothing about the feed at
 // all, so it must not be reported as if it did.
-const STALL_MS = 25000;          // earlier stalls held the first request 28-31 s; a read after a write waited 63-65 s; a feed wait would be 8 s at most
+const STALL_MS = 25000;          // earlier stalls held the first request 28-31 s; a feed wait measured 8.37 s against an 8 s timeout
 const LIVENESS_MS = 2000;
+const listLeftMs = listInFlight ? t0 + waited - duringStart : 0;   // how long the list outlived the health request
 const timing = `the first /api/projects took ${waited}ms with a feed that never answers; a separate `
-  + `/api/health on its own connection answered ${during.status} after ${duringMs}ms while it was in flight`;
+  + `/api/health on its own connection ${during.status ? `answered ${during.status}` : 'got no answer'} after ${duringMs}ms`
+  + (!listInFlight ? '; the list had already finished when it was sent'
+    : healthFirst ? ', before the list finished'
+      : `, only after the list, which finished ${listLeftMs}ms after it was sent`);
 
 // LIVENESS is the graded claim, and the timing is not.
 //
 // It used to be the other way round, and that was wrong twice over. `waited` says nothing about the
 // update feed — a run with the feed disabled entirely still stalled, which is what disproved that
-// reading — and it says nothing about the panel either: it is how long ONE read took, which on the
-// machine that stalls is a property of that machine, not of this code. What the
-// panel owes its user is that a slow read stays inside the request that hit it. That is gradeable,
-// deterministic, and it is exactly what the async conversion bought:
+// reading — and it cannot grade the panel either. It is the wall time of the whole first
+// /api/projects request, transcript reads included, and on the machine that stalls, waits past
+// STALL_MS also happened with no kit code running. What the panel owes its user is that a slow read
+// stays inside the request that hit it. That is gradeable when the list outlives the health request
+// long enough to tell a blocked loop from a free one (below), and it is what the async conversion bought:
 //
 //   sync  (main)   /api/projects 33,391 ms · a separate /api/health went unanswered 312 pings of 324
 //   async (here)   /api/projects 38,918 ms · the same health endpoint answered 195 of 195
 //
 // The read did not get faster. Nothing else went dark.
-check('the panel answers other requests while a read stalls', duringMs < LIVENESS_MS,
-  `${timing}${duringMs < LIVENESS_MS ? '' : ' — the event loop was blocked, so nothing the panel serves responded'}`);
+// Three outcomes, because a blocked loop and a free one look alike when the list ends soon after the
+// health request goes out: a blocked loop answers health right after the list, a free one right away.
+// - health did not answer 200: red, whatever the list did, because the panel did not answer;
+// - health came back before the list: graded, on how long it took;
+// - health came back only after a list that outlived its request by LIVENESS_MS or more: graded, and red,
+//   because a free loop would have answered inside that time (the real /api/health does no waiting);
+// - anything else cannot tell the two apart, so it is not applicable rather than a pass.
+if (during.status !== 200) {
+  check('the panel answers other requests while a read stalls', false,
+    `${timing} — ${during.status ? `a ${during.status} is not a health answer` : 'the request failed, was reset or timed out'}`);
+} else if (listInFlight && healthFirst) {
+  check('the panel answers other requests while a read stalls', duringMs < LIVENESS_MS,
+    `${timing}${duringMs < LIVENESS_MS ? '' : ` — slower than the ${LIVENESS_MS} ms liveness line`}`);
+} else if (listInFlight && listLeftMs >= LIVENESS_MS) {
+  check('the panel answers other requests while a read stalls', false,
+    `${timing} — /api/health on its own connection was held until the list finished`);
+} else {
+  notApplicable('the panel answers other requests while a read stalls', listInFlight
+    ? `${timing}, too soon after the health request to tell a blocked panel from a free one`
+    : `${timing}, so nothing was in flight for it to wait on`);
+}
 
 if (waited < 3000) {
   check('the project list is served from local data, not a network round trip', true, timing);
 } else if (waited > STALL_MS) {
-  // Reported, not graded: the read really did wait that long, and no code here makes it finish sooner.
+  // Reported, not graded: the request really did wait that long, and no code here makes it finish sooner.
   // Green would hide it; red would fire whenever such a wait happens and be muted within a month. The
   // graded half is above, and it stays green through exactly this run. What is known comes from one
-  // Windows machine, so any other platform gets "not measured here" rather than that machine's story.
-  knownIssue('one transcript read took the stall shape',
-    `${timing} — the read itself took ~${Math.round(waited / 1000)}s`,
+  // Windows machine, so any other platform gets "not measured on <platform>" rather than that machine's story.
+  knownIssue('the first project list took the stall shape',
+    `${timing} — ~${Math.round(waited / 1000)}s, past the ${STALL_MS / 1000} s stall line`,
     process.platform === 'win32'
-      ? 'seen on a Windows machine as a read that follows a write of the same file: a plain tail read of a freshly '
-        + 'copied 25 MB transcript waited 63-65 s with no kit code running and 0.044 s when it waited 90 s first; '
-        + "what holds the file was not identified. Not the kit's to fix; the kit's part was keeping the rest of "
-        + 'the panel answering, which the check above grades'
+      ? 'seen before on a Windows machine, where the first request stalled 28-31 s in 3 runs of 25 and one '
+        + 'synchronous 128 KiB transcript tail took 31,209 ms. Separately, with no kit code running, a plain '
+        + 'tail read of a freshly copied 25 MB transcript waited 63-65 s on 3 of 3 reads in one round and on '
+        + 'none of 8 in a later one, and what holds the file was not identified. Making the reads async did not '
+        + 'make the list faster (33,391 ms before, 38,918 ms after); it kept the rest of the panel answering, '
+        + 'which the check above grades'
       : `not measured on ${process.platform}: the only recorded case is a Windows machine, so this wait is `
         + 'unexplained here; the check above still grades whether the rest of the panel kept answering');
   notApplicable('the project list is served from local data, not a network round trip',
-    'this run hit the stall above, so its timing measures the disk and cannot speak to the request path');
+    'this run hit the stall above, so its timing is that wait and cannot speak to the request path');
 } else {
   // Neither a local read nor the shape of the known stall. Something else, and it should be loud.
   check('the project list is served from local data, not a network round trip', false,

--- a/packaging/studio-serve-probe.mjs
+++ b/packaging/studio-serve-probe.mjs
@@ -44,12 +44,12 @@ let pass = 0; let na = 0; let known = 0; const failures = [];
 const notApplicable = (name, why) => { na += 1; console.log(`  N/A  ${name} — ${why}`); };
 // A third word, and it is deliberately not a pass. The check ran, it measured what it was written
 // to measure, and what it found is a wait the kit neither causes nor can remove. Made green it would
-// be a lie; made red it would fire whenever that machine's scanner happens to be busy, which cannot
-// be produced on demand, and be silenced within a month, which is how a gate stops being read. KNOWN
-// keeps the observation on screen and off the exit code, and it names the cause every time it prints.
+// be a lie; made red it would fire whenever such a wait happens to occur, which cannot be produced on
+// demand, and be silenced within a month, which is how a gate stops being read. KNOWN keeps the
+// observation on screen and off the exit code, and says what is known about it every time it prints.
 const knownIssue = (name, detail, issue) => {
   known += 1;
-  console.log(`  KNOWN ${name} — ${detail}\n        the cause: ${issue}`);
+  console.log(`  KNOWN ${name} — ${detail}\n        what is known: ${issue}`);
 };
 const check = (name, ok, detail) => {
   if (ok) { pass += 1; console.log(`  ok   ${name}${detail ? ` — ${detail}` : ''}`); }
@@ -160,7 +160,7 @@ check('projects are read from disk', projects.status === 200 && measured && Arra
 // worth not repeating: it called every slow first call "waiting on the update feed", which is a
 // cause that was later disproven. A run that hits the known block says nothing about the feed at
 // all, so it must not be reported as if it did.
-const STALL_MS = 25000;          // scanner waits were measured at 28-31 s and at 63-65 s; a feed wait would be 8 s at most
+const STALL_MS = 25000;          // earlier stalls held the first request 28-31 s; a read after a write waited 63-65 s; a feed wait would be 8 s at most
 const LIVENESS_MS = 2000;
 const timing = `the first /api/projects took ${waited}ms with a feed that never answers; a separate `
   + `/api/health on its own connection answered ${during.status} after ${duringMs}ms while it was in flight`;
@@ -169,8 +169,8 @@ const timing = `the first /api/projects took ${waited}ms with a feed that never 
 //
 // It used to be the other way round, and that was wrong twice over. `waited` says nothing about the
 // update feed — a run with the feed disabled entirely still stalled, which is what disproved that
-// reading — and it says nothing about the panel either: it is how long ONE file open took, which on a
-// machine whose security layer inspects opens is a property of the disk, not of this code. What the
+// reading — and it says nothing about the panel either: it is how long ONE read took, which on the
+// machine that stalls is a property of that machine, not of this code. What the
 // panel owes its user is that a slow read stays inside the request that hit it. That is gradeable,
 // deterministic, and it is exactly what the async conversion bought:
 //
@@ -184,15 +184,19 @@ check('the panel answers other requests while a read stalls', duringMs < LIVENES
 if (waited < 3000) {
   check('the project list is served from local data, not a network round trip', true, timing);
 } else if (waited > STALL_MS) {
-  // Reported, not graded: the read really did wait that long, and no code here makes a scanner finish
-  // sooner. Green would hide it; red would fire whenever that machine's scanner is busy and be muted
-  // within a month. The graded half is above, and it stays green through exactly this run.
+  // Reported, not graded: the read really did wait that long, and no code here makes it finish sooner.
+  // Green would hide it; red would fire whenever such a wait happens and be muted within a month. The
+  // graded half is above, and it stays green through exactly this run. What is known comes from one
+  // Windows machine, so any other platform gets "not measured here" rather than that machine's story.
   knownIssue('one transcript read took the stall shape',
     `${timing} — the read itself took ~${Math.round(waited / 1000)}s`,
-    'a security layer that scans files after they are written: a plain tail read of a 25 MB transcript copy '
-    + 'waited 63-65 s with no kit code running and 0.044 s after waiting 90 s; it comes in clusters and could '
-    + "not be produced on demand. Not the kit's to fix; the kit's part was keeping the rest of the panel "
-    + 'answering, which the check above grades');
+    process.platform === 'win32'
+      ? 'seen on a Windows machine as a read that follows a write of the same file: a plain tail read of a freshly '
+        + 'copied 25 MB transcript waited 63-65 s with no kit code running and 0.044 s when it waited 90 s first; '
+        + "what holds the file was not identified. Not the kit's to fix; the kit's part was keeping the rest of "
+        + 'the panel answering, which the check above grades'
+      : `not measured on ${process.platform}: the only recorded case is a Windows machine, so this wait is `
+        + 'unexplained here; the check above still grades whether the rest of the panel kept answering');
   notApplicable('the project list is served from local data, not a network round trip',
     'this run hit the stall above, so its timing measures the disk and cannot speak to the request path');
 } else {

--- a/plugin/commands/doctor-csk.md
+++ b/plugin/commands/doctor-csk.md
@@ -30,5 +30,11 @@ running as a **plugin**, whose hooks are managed by Claude Code itself; there's 
 scripts are developer instruments: they inspect an installation from outside it, and the plugin edition has no
 installation to inspect. Say this plainly when someone asks why `/doctor-csk` reports nothing on a plugin install,
 rather than treating it as a defect. The Studio panel is not in that group: both editions carry it, and
-`/studio-csk` finds it in either. On a plugin install its kit-telemetry panes report "not measured": a plugin
-install writes none of the files they read (`.claude/VERSION`, `kit.conf`, the gate scripts) into the project.
+`/studio-csk` finds it in either. A plugin install puts no `.claude/VERSION`, `kit.conf` or kit scripts into a
+project, so that project's row in the panel has no kit badge, and for the project the panel was opened from, the
+inspector's gates, stats and board tabs say "Not measured" with the reason. The gates tab can still list observed
+entries below that. The plugin's Bash guard logs its blocks, approval prompts and `CLAUDE_GIT_OK` pre-authorised
+git actions, and its gate-file write guard logs its blocks, to `.claude/gate-log.tsv` when the project has a
+`.claude/` directory and the file is git-ignored or the project is not a repo. With `CSK_GATE_LOG` set they write
+wherever it points instead, and the panel reads only the project's own `.claude/gate-log.tsv`, so a log sent
+anywhere else does not show. The commit scan and the board gate refuse without writing a line.

--- a/plugin/commands/doctor-csk.md
+++ b/plugin/commands/doctor-csk.md
@@ -30,5 +30,5 @@ running as a **plugin**, whose hooks are managed by Claude Code itself; there's 
 scripts are developer instruments: they inspect an installation from outside it, and the plugin edition has no
 installation to inspect. Say this plainly when someone asks why `/doctor-csk` reports nothing on a plugin install,
 rather than treating it as a defect. The Studio panel is not in that group: both editions carry it, and
-`/studio-csk` finds it in either. On a plugin install its kit-telemetry panes report "not measured", for the same
-reason this command has nothing to check there: a plugin install writes no kit files into the project.
+`/studio-csk` finds it in either. On a plugin install its kit-telemetry panes report "not measured": a plugin
+install writes none of the files they read (`.claude/VERSION`, `kit.conf`, the gate scripts) into the project.

--- a/plugin/commands/doctor-csk.md
+++ b/plugin/commands/doctor-csk.md
@@ -25,10 +25,10 @@ Verify the kit is actually *active* in this project (not just present on disk):
 If `.claude/eval/doctor.sh` doesn't exist, this is not a full (start.sh / adopt.sh) install — the kit is likely
 running as a **plugin**, whose hooks are managed by Claude Code itself; there's nothing for the doctor to check.
 
-**The eval scripts and the Studio panel are installer-only, by decision.** `eval/` — `doctor.sh`,
-`smoke-test.sh`, `routing-eval.sh`, `scan-skill.sh`, `utilization.sh` — and `studio/` ship with `start.sh` and
-`adopt.sh` and NOT with the plugin edition. The eval scripts are developer instruments: they inspect an
-installation from outside it, and the plugin edition has no installation to inspect. The panel is the same
-boundary from the other side: it needs a place on disk to be launched from, and a plugin install has no
-`.claude/studio/`. Say this plainly when someone asks why `/doctor-csk` reports nothing or why `/studio-csk`
-declines on a plugin install, rather than treating either as a defect.
+**The eval scripts are installer-only, by decision.** `eval/` — `doctor.sh`, `smoke-test.sh`, `routing-eval.sh`,
+`scan-skill.sh`, `utilization.sh` — ships with `start.sh` and `adopt.sh` and NOT with the plugin edition. The eval
+scripts are developer instruments: they inspect an installation from outside it, and the plugin edition has no
+installation to inspect. Say this plainly when someone asks why `/doctor-csk` reports nothing on a plugin install,
+rather than treating it as a defect. The Studio panel is not in that group: both editions carry it, and
+`/studio-csk` finds it in either. On a plugin install its kit-telemetry panes report "not measured", for the same
+reason this command has nothing to check there: a plugin install writes no kit files into the project.

--- a/plugin/commands/studio-csk.md
+++ b/plugin/commands/studio-csk.md
@@ -30,11 +30,18 @@ fails, say which one and stop — do not improvise a different launch.
    `npx @byerlikaya/claude-starter-kit@latest update --here --yes` at the project root, or `/update-csk`.
    Then stop. Do not go hunting for the panel anywhere else on disk.
 
-   **What the plugin edition cannot show.** The panel reads the *project you opened it from* for kit
-   telemetry — `.claude/VERSION`, `kit.conf`, the gate scripts. A plugin install writes none of those into
-   a project, so the kit panes report "not measured" with the reason, rather than zero. Say that once when
-   you hand over the URL, so an honest blank is not read as a broken panel. Everything else — the live
-   agent graph, owned sessions, the permission bridge, the terminals — works the same in both editions.
+   **What the plugin edition cannot show.** A plugin install puts no `.claude/VERSION`, `kit.conf` or kit
+   scripts into a project. So that project's row in the list has no kit badge (each row reads its own
+   project), and for the project you opened the panel from, the inspector's gates, stats and board tabs
+   say "Not measured" with the reason, rather than zero. The gates tab can still list observed entries
+   below that. The plugin's Bash guard logs its blocks, approval prompts and `CLAUDE_GIT_OK` pre-authorised
+   git actions, and its gate-file write guard logs its blocks, to `.claude/gate-log.tsv` when the project
+   has a `.claude/` directory and the file is git-ignored or the project is not a repo. With `CSK_GATE_LOG`
+   set they write wherever it points instead, and the panel reads only the project's own
+   `.claude/gate-log.tsv`, so a log sent anywhere else does not show. The commit scan and the board gate
+   refuse without writing a line. Say this once when you hand over the URL, so an honest blank is not
+   read as a broken panel. Everything else — the live agent graph, owned sessions, the permission bridge,
+   the terminals — works the same in both editions.
 
 2. **Resolve a runtime — do not ask whether a name resolves.** `ensure-node.sh` sits beside the panel, so
    use whichever root step 1 settled on:

--- a/plugin/hooks/guard-bash.sh
+++ b/plugin/hooks/guard-bash.sh
@@ -28,10 +28,10 @@
 # from changing it. Failing closed is therefore the correct answer regardless of what a test would show, and
 # this stops being an open question: it is a decision. Should the interaction ever be specified, revisit.
 #
-# CSK_GATE_LOG=<path>, exported by the user, appends one TSV line per gate decision (BLOCK/ASK/ALLOW, section,
-# rule, command) to that file. Absent by default and write-only — it never influences a verdict. It exists
-# because a gate that cannot be observed firing cannot be measured: "the model never tried it" and "the gate
-# stopped it" leave identical artifacts behind. guard-write.sh writes to the same file.
+# The gate log gets one TSV line per logged decision (BLOCK/ASK/ALLOW, section, rule; the command only with
+# CSK_GATE_LOG_CMD=1). On by default since 2.5.0 (see _gatelog_path below); CSK_GATE_LOG=<path> redirects it.
+# Write-only, it never influences a verdict. It exists because a gate that cannot be observed firing cannot be
+# measured: "the model never tried it" and "the gate stopped it" look the same. guard-write.sh logs there too.
 #
 # CLAUDE_GIT_OK=1, exported by the user before the session starts, pre-authorises the session. It exists for
 # headless/CI runs where no one is at the keyboard. It does NOT replace approval: present the message first.
@@ -259,8 +259,8 @@ PERM_MODE="${PERM_MODE:-}"
 #
 # ON BY DEFAULT since 2.5.0, into .claude/gate-log.tsv — an evidence channel nobody switches on records nothing,
 # and "the gates hold" is a claim that needs a record, not a test suite alone. CSK_GATE_LOG overrides the path;
-# CSK_GATE_LOG=/dev/null (or a read-only .claude) turns it off. Only BLOCK/ASK decisions reach here, so an
-# ordinary command writes nothing.
+# CSK_GATE_LOG=/dev/null (or a read-only .claude) turns it off. Only BLOCK, ASK and CLAUDE_GIT_OK's ALLOW reach
+# here: an ordinary command writes nothing, and a git action CLAUDE_GIT_OK allows writes one ALLOW line.
 #
 # The COMMAND TEXT IS NOT RECORDED by default. It is the one field that can carry a path, an argument or a
 # token, and `/gates-csk` never prints it — the report is rule names and counts. Recording it by default would
@@ -271,7 +271,8 @@ PERM_MODE="${PERM_MODE:-}"
 # the path is already ignored. A kit install gitignores .claude/, so this is the normal case — but the plugin
 # edition drops into repos the installer never touched, and this repo proved the failure itself: the suite left
 # a gate-log.tsv sitting in `git status` as an untracked file waiting to be committed. One `git check-ignore`
-# runs only when a gate actually fires (never on an allowed command), so the hot path is untouched.
+# runs only when a decision is logged (a block, an approval prompt or a CLAUDE_GIT_OK allow); ordinary commands
+# never reach it.
 _gatelog_path(){
   if [ -n "${CSK_GATE_LOG:-}" ]; then printf '%s' "$CSK_GATE_LOG"; return; fi
   [ -d ".claude" ] || return 0

--- a/plugin/hooks/session-update-check.sh
+++ b/plugin/hooks/session-update-check.sh
@@ -35,7 +35,9 @@
 set -uo pipefail
 
 URL="${CSK_UPDATE_URL:-https://registry.npmjs.org/-/package/@byerlikaya%2fclaude-starter-kit/dist-tags}"
-PLUGIN_URL="${CSK_UPDATE_URL:-https://raw.githubusercontent.com/byerlikaya/claude-starter-kit/main/plugin/.claude-plugin/plugin.json}"
+# plugin-stable, not main: the marketplace installs the plugin from that branch, and only an approved release
+# moves it forward. Reading main would announce a release before the plugin channel can deliver it.
+PLUGIN_URL="${CSK_UPDATE_URL:-https://raw.githubusercontent.com/byerlikaya/claude-starter-kit/plugin-stable/plugin/.claude-plugin/plugin.json}"
 MAX_AGE="${CSK_UPDATE_MAX_AGE:-86400}"      # one day between checks
 
 # DIGITS AND DOTS, exactly three fields — nothing else survives to be printed. Deliberately stricter than semver:

--- a/plugin/studio/README.md
+++ b/plugin/studio/README.md
@@ -53,10 +53,16 @@ placeholder left standing means a full install. Neither path on disk means an
 install from a kit older than the panel, which `/update-csk` brings up to date.
 In the plugin the command is namespaced: `/claude-starter-kit:studio-csk`.
 
-**What the plugin edition cannot show.** The panel reads the project it was
-opened from for kit telemetry (`.claude/VERSION`, `kit.conf`, the gate scripts),
-and a plugin install writes none of those into a project, so those panes report
-"not measured" with the reason rather than zero. Everything else — the live
+**What the plugin edition cannot show.** A plugin install puts no
+`.claude/VERSION`, `kit.conf` or kit scripts into a project. That project's row
+in the list has no kit badge, and for the project the panel was opened from, the
+inspector's gates, stats and board tabs say "Not measured" with the reason rather
+than zero. The gates tab can still list what the gate log observed: the plugin's
+Bash guard records its blocks, approval prompts and pre-authorised git actions,
+and its gate-file write guard its blocks, in `.claude/gate-log.tsv` when the
+project has a `.claude/` directory, the file is git-ignored or the project is
+not a repo, and `CSK_GATE_LOG` does not send the log elsewhere.
+Everything else — the live
 agent graph, owned sessions, the permission bridge, the terminals — works the
 same in both editions.
 

--- a/plugin/studio/README.md
+++ b/plugin/studio/README.md
@@ -43,12 +43,22 @@ and the panel refuses requests without it. When a browser cannot be opened — o
 SSH, or headless — the server says so rather than looking like it worked, and
 `/studio-csk` reports the URL either way.
 
-**The plugin edition does not carry the panel.** A plugin install has no
-`.claude/` tree to launch it from, and `build-plugin.sh` enumerates
-`agents skills commands hooks` — Studio is not among them. `/studio-csk` ships
-there anyway and its first step says so, with the installer command, rather than
-leaving a plugin user at an unknown command. This is the same boundary
-`/doctor-csk` already documents for `eval/`, for the same reason.
+**Both editions carry the panel, in different places.** A full install has it
+at `.claude/studio/`; the plugin edition has it at `studio/` in the plugin's own
+root. One `/studio-csk` file serves both, and its first step tells them apart
+by reading `${CLAUDE_PLUGIN_ROOT}/studio/server/index.js` literally: Claude Code
+replaces that placeholder before the command is read, and only when the command
+came from the plugin. A real absolute path is the plugin's panel; the
+placeholder left standing means a full install. Neither path on disk means an
+install from a kit older than the panel, which `/update-csk` brings up to date.
+In the plugin the command is namespaced: `/claude-starter-kit:studio-csk`.
+
+**What the plugin edition cannot show.** The panel reads the project it was
+opened from for kit telemetry (`.claude/VERSION`, `kit.conf`, the gate scripts),
+and a plugin install writes none of those into a project, so those panes report
+"not measured" with the reason rather than zero. Everything else — the live
+agent graph, owned sessions, the permission bridge, the terminals — works the
+same in both editions.
 
 **The suite is not here.** It lives in `packaging/studio-test/`, beside the
 repo's other gates, and asserts things about this *repository* — the root

--- a/plugin/studio/ensure-node.sh
+++ b/plugin/studio/ensure-node.sh
@@ -77,8 +77,9 @@ candidates() {
   [ -n "${CSK_STUDIO_NODE:-}" ] && printf '%s\n' "$CSK_STUDIO_NODE"
   printf 'node\n'
   # Guarded, because that pipeline costs three processes whether or not anything is there,
-  # and a process is not always cheap: measured at 880-1483 ms on a Windows box whose EDR
-  # inspects every creation. A directory test costs none.
+  # and a process is not always cheap: a bare /usr/bin/true measured 880-1483 ms on two machines
+  # against 3-5 ms on a healthy one, and one session traced that to endpoint software inspecting every
+  # process creation. A directory test costs none.
   if [ -d "$RUNTIME" ]; then
     ls -1d "$RUNTIME"/node-v*/ 2>/dev/null | sort -r | while read -r d; do
       printf '%s\n' "${d}bin/node" "${d}node.exe"

--- a/plugin/studio/server/index.js
+++ b/plugin/studio/server/index.js
@@ -535,11 +535,13 @@ async function relay(pathname) {
   return null;
 }
 
-// Async for the same reason projects.js is, and more urgently: this runs on every
-// stream tick — 700 ms, seven times more often than the project list is polled —
-// so a synchronous stat here is seven times more chances to stop the event loop on
-// a machine where one transcript read has taken tens of seconds. The stall itself is
-// not ours to fix; keeping it inside the one tick that hit it is.
+// Async for the same reason projects.js is: this runs on every stream tick — 700 ms,
+// seven times more often than the project list is polled. No stat has been timed on
+// its own: the timed stalls were a tail read, which opens and reads, and whole
+// requests, which stat as well. The rule is the same anyway: a synchronous filesystem
+// call holds the event loop for as long as it takes, and here it would do that on
+// every tick. Keeping a slow one inside the tick that hit it is ours to do; making the
+// filesystem faster is not.
 async function signature(session) {
   const parts = [];
   try { parts.push(String((await fsp.stat(session.file)).size)); } catch { parts.push('0'); }

--- a/plugin/studio/server/index.js
+++ b/plugin/studio/server/index.js
@@ -538,8 +538,8 @@ async function relay(pathname) {
 // Async for the same reason projects.js is, and more urgently: this runs on every
 // stream tick — 700 ms, seven times more often than the project list is polled —
 // so a synchronous stat here is seven times more chances to stop the event loop on
-// a machine where one file open can take 31 s. The stall itself is not ours to fix;
-// keeping it inside the one tick that hit it is.
+// a machine where one transcript read has taken tens of seconds. The stall itself is
+// not ours to fix; keeping it inside the one tick that hit it is.
 async function signature(session) {
   const parts = [];
   try { parts.push(String((await fsp.stat(session.file)).size)); } catch { parts.push('0'); }

--- a/plugin/studio/server/lib/kit.js
+++ b/plugin/studio/server/lib/kit.js
@@ -36,17 +36,14 @@ export function latestVersionCached() {
   const fresh = latestCache && Date.now() - latestCache.at < FEED_TTL_MS;
   // Deferred to a later tick, not merely un-awaited, so the request path does no work of its own.
   //
-  // It does NOT fix the stall that is still open against this file. Measured on a Windows machine
-  // with an inspecting layer on every connection: while the feed accepts and stays silent, the
-  // first /api/projects sometimes takes 28-31 s (3 of 25) — and during that window a SEPARATE
-  // /api/health on a separate connection does not answer either. So the whole event loop is
-  // blocked, not this endpoint, and removing an await cannot help: there is no await to remove.
-  // A refused connection never reproduces it; only an accepted-and-silent one does.
-  //
-  // Four hypotheses have been tested and all four failed (libuv threadpool saturation, a cold
-  // path after idle, the fetch itself in isolation, and the await on the request path). The
-  // mechanism is unknown and is tracked separately. This line stays because starting work on a
-  // request path is wrong regardless of what turns out to be blocking.
+  // The panel stall once pinned on this feed was never the feed: a run with the feed disabled
+  // entirely stalled the same way. It was a transcript read. On the Windows machine that has it, a
+  // security layer scans a file after it is written, and a read that lands before the scan finishes
+  // waits for it — 63-65 s for a plain `tail -c 131072` of a 25 MB transcript copy with no kit code
+  // running, 0.04 s warm, 0.044 s after waiting 90 s. It comes in clusters and could not be produced
+  // on demand, so no frequency is claimed. The reads were synchronous, so the whole panel stopped
+  // answering; projects.js keeps that wait inside one request now. This line stays because starting
+  // work on a request path is wrong regardless.
   if (!fresh && !inflight) {
     setTimeout(() => { latestVersion().catch(() => {}); }, 0).unref();
   }

--- a/plugin/studio/server/lib/kit.js
+++ b/plugin/studio/server/lib/kit.js
@@ -37,13 +37,13 @@ export function latestVersionCached() {
   // Deferred to a later tick, not merely un-awaited, so the request path does no work of its own.
   //
   // The panel stall once pinned on this feed was never the feed: a run with the feed disabled
-  // entirely stalled the same way. It was a transcript read. On the Windows machine that has it, a
-  // security layer scans a file after it is written, and a read that lands before the scan finishes
-  // waits for it — 63-65 s for a plain `tail -c 131072` of a 25 MB transcript copy with no kit code
-  // running, 0.04 s warm, 0.044 s after waiting 90 s. It comes in clusters and could not be produced
-  // on demand, so no frequency is claimed. The reads were synchronous, so the whole panel stopped
-  // answering; projects.js keeps that wait inside one request now. This line stays because starting
-  // work on a request path is wrong regardless.
+  // entirely stalled the same way. It was a transcript read on one Windows machine, where a read that
+  // follows a write of the same file can wait — 63-65 s for a plain `tail -c 131072` of a freshly
+  // copied 25 MB transcript with no kit code running, 0.04 s warm, 0.044 s when the read waited 90 s
+  // after the copy. What holds the file was not identified, and the wait comes in clusters that could
+  // not be produced on demand. The reads were synchronous, so the whole panel stopped answering;
+  // projects.js keeps such a wait inside one request now. This line stays because starting work on a
+  // request path is wrong regardless.
   if (!fresh && !inflight) {
     setTimeout(() => { latestVersion().catch(() => {}); }, 0).unref();
   }
@@ -107,7 +107,7 @@ export function compareVersions(a, b) {
 /** What the kit looks like inside one working directory.
  *
  * Async because it runs once per project on the `/api/projects` path, and a
- * synchronous read there blocks the whole panel when one file open stalls —
+ * synchronous read there blocks the whole panel when one read stalls —
  * see the note at the top of projects.js for the measurement.
  */
 export async function kitStatus(cwd, latest) {

--- a/plugin/studio/server/lib/kit.js
+++ b/plugin/studio/server/lib/kit.js
@@ -37,13 +37,11 @@ export function latestVersionCached() {
   // Deferred to a later tick, not merely un-awaited, so the request path does no work of its own.
   //
   // The panel stall once pinned on this feed was never the feed: a run with the feed disabled
-  // entirely stalled the same way. It was a transcript read on one Windows machine, where a read that
-  // follows a write of the same file can wait — 63-65 s for a plain `tail -c 131072` of a freshly
-  // copied 25 MB transcript with no kit code running, 0.04 s warm, 0.044 s when the read waited 90 s
-  // after the copy. What holds the file was not identified, and the wait comes in clusters that could
-  // not be produced on demand. The reads were synchronous, so the whole panel stopped answering;
-  // projects.js keeps such a wait inside one request now. This line stays because starting work on a
-  // request path is wrong regardless.
+  // entirely stalled the same way. It was a synchronous transcript read on one Windows machine: one
+  // 128 KiB tail took 31,209 ms, and the event loop waited with it. projects.js has the panel's
+  // numbers and, kept apart from them, what was measured on that machine later. The reads are async
+  // now, so such a wait stays inside one request. This line stays because starting work on a request
+  // path is wrong regardless.
   if (!fresh && !inflight) {
     setTimeout(() => { latestVersion().catch(() => {}); }, 0).unref();
   }

--- a/plugin/studio/server/lib/projects.js
+++ b/plugin/studio/server/lib/projects.js
@@ -11,13 +11,15 @@
 // copy would break that pin.
 
 // EVERY filesystem call here is async, and that is the point rather than a style
-// choice. Measured on a Windows 11 machine whose EDR inspects file opens: reading
-// the 128 KiB tail of one transcript took 0-1 ms on fourteen runs out of fifteen
-// and 31,209 ms on the fifteenth. With `readSync` that stalled the event loop, so
-// the panel answered NOTHING for half a minute — `/api/projects` took 33,391 ms and
-// a separate `/api/health` on its own connection went unanswered for 312 of 324
-// pings. Async does not make the read faster; the same 30 s still passes. It keeps
-// the stall inside the one request that hit it while the rest of the panel stays up.
+// choice. On a Windows machine whose security layer scans a file after it is
+// written, a read that lands before the scan finishes waits for it: 63-65 s for a
+// plain `tail -c 131072` of a 25 MB transcript copy with no kit code running, 0.04 s
+// warm, 0.044 s after waiting 90 s. It comes in clusters and could not be produced
+// on demand. With `readSync` such a wait stalled the event loop, so the panel
+// answered NOTHING — `/api/projects` took 33,391 ms and a separate `/api/health` on
+// its own connection went unanswered for 312 of 324 pings. Async does not make the
+// read faster; it keeps the wait inside the one request that hit it while the rest
+// of the panel stays up.
 import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';

--- a/plugin/studio/server/lib/projects.js
+++ b/plugin/studio/server/lib/projects.js
@@ -12,7 +12,7 @@
 
 // EVERY filesystem call here is async, and that is the point rather than a style
 // choice. On a Windows machine a single synchronous 128 KiB tail read once took
-// 31,209 ms, and because it stopped the event loop the panel answered NOTHING:
+// 31,209 ms, and because it blocked the event loop other requests waited with it:
 // `/api/projects` took 33,391 ms and a separate `/api/health` on its own connection
 // went unanswered for 312 of 324 pings. Measured later on the same machine with no
 // kit code running, a plain `tail -c 131072` of a freshly copied 25 MB transcript

--- a/plugin/studio/server/lib/projects.js
+++ b/plugin/studio/server/lib/projects.js
@@ -11,15 +11,15 @@
 // copy would break that pin.
 
 // EVERY filesystem call here is async, and that is the point rather than a style
-// choice. On a Windows machine whose security layer scans a file after it is
-// written, a read that lands before the scan finishes waits for it: 63-65 s for a
-// plain `tail -c 131072` of a 25 MB transcript copy with no kit code running, 0.04 s
-// warm, 0.044 s after waiting 90 s. It comes in clusters and could not be produced
-// on demand. With `readSync` such a wait stalled the event loop, so the panel
-// answered NOTHING — `/api/projects` took 33,391 ms and a separate `/api/health` on
-// its own connection went unanswered for 312 of 324 pings. Async does not make the
-// read faster; it keeps the wait inside the one request that hit it while the rest
-// of the panel stays up.
+// choice. On a Windows machine a single synchronous 128 KiB tail read once took
+// 31,209 ms, and because it stopped the event loop the panel answered NOTHING:
+// `/api/projects` took 33,391 ms and a separate `/api/health` on its own connection
+// went unanswered for 312 of 324 pings. Measured later on the same machine with no
+// kit code running, a plain `tail -c 131072` of a freshly copied 25 MB transcript
+// waited 63-65 s right after the copy, 0.04 s warm, and 0.044 s when it waited 90 s
+// first. What holds the file was not identified, and the wait could not be produced
+// on demand. Async does not make the read faster; it keeps the wait inside the one
+// request that hit it while the rest of the panel stays up.
 import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';

--- a/plugin/studio/server/lib/roster.js
+++ b/plugin/studio/server/lib/roster.js
@@ -61,10 +61,9 @@ export function parseRoster(text) {
   return { self: self ? { name: self[1], ref: self[2] } : null, peers };
 }
 
-// Async for the reason projects.js gives: this reads the tail of a transcript — the
-// read a file-scanning security layer held for about a minute right after the file was
-// written — and it runs on the `/api/fleet` path the panel polls every 2 s, the shortest
-// cycle in the app.
+// Async for the reason projects.js gives: this reads transcript tails too (TAIL_BYTES, and
+// DEEP_BYTES for the newest few), and it runs on the `/api/fleet` path the panel polls every
+// 2 s, the shortest cycle in the app.
 async function readTail(file, size, limit = TAIL_BYTES) {
   let fh;
   try {

--- a/plugin/studio/server/lib/roster.js
+++ b/plugin/studio/server/lib/roster.js
@@ -61,9 +61,10 @@ export function parseRoster(text) {
   return { self: self ? { name: self[1], ref: self[2] } : null, peers };
 }
 
-// Async for the reason projects.js gives: this reads the tail of a transcript, which
-// is the exact operation measured at 31.2 s on one run in fifteen, and it runs on the
-// `/api/fleet` path the panel polls every 2 s — the shortest cycle in the app.
+// Async for the reason projects.js gives: this reads the tail of a transcript — the
+// read a file-scanning security layer held for about a minute right after the file was
+// written — and it runs on the `/api/fleet` path the panel polls every 2 s, the shortest
+// cycle in the app.
 async function readTail(file, size, limit = TAIL_BYTES) {
   let fh;
   try {

--- a/plugin/studio/server/lib/roster.js
+++ b/plugin/studio/server/lib/roster.js
@@ -62,8 +62,7 @@ export function parseRoster(text) {
 }
 
 // Async for the reason projects.js gives: this reads transcript tails too (TAIL_BYTES, and
-// DEEP_BYTES for the newest few), and it runs on the `/api/fleet` path the panel polls every
-// 2 s, the shortest cycle in the app.
+// DEEP_BYTES for the newest few), and it runs on the `/api/fleet` path the panel polls every 2 s.
 async function readTail(file, size, limit = TAIL_BYTES) {
   let fh;
   try {

--- a/plugin/studio/server/lib/transcript.js
+++ b/plugin/studio/server/lib/transcript.js
@@ -19,9 +19,9 @@ export class JsonlReader {
 
   /** Read everything appended since the last call. Returns parsed records.
    *
-   * Async because a transcript open can take 31 s on a machine whose security
-   * layer inspects it, and this sits under the stream tick — see the note at the
-   * top of projects.js. The read is no faster; it just no longer stops the loop.
+   * Async because a transcript read has stalled for tens of seconds on a Windows
+   * machine, and this sits under the stream tick — see the note at the top of
+   * projects.js. The read is no faster; it just no longer stops the loop.
    */
   async read() {
     let st;

--- a/start.sh
+++ b/start.sh
@@ -9,6 +9,16 @@
 # start.sh + claude-starter/ must be in the SAME directory. At the project root:  bash start.sh [flags]
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
+
+# --version is answered first, before the source-checkout and payload checks below: it reads only VERSION, so it
+# must work wherever start.sh sits, including a directory those checks would refuse.
+for a in "$@"; do
+  if [ "$a" = "--version" ]; then
+    if [ -f "$HERE/VERSION" ]; then head -1 "$HERE/VERSION" | tr -d '\r'; else echo unknown; fi
+    exit 0
+  fi
+done
+
 SRC="$HERE/claude-starter"
 DEVARCH_URL="https://github.com/DevArchitecture/DevArchitecture"
 
@@ -52,6 +62,7 @@ If no flag is given, the script asks interactively (wizard).
 
 Every install ships the whole kit: all agents, all skills — backend, web and mobile (RN/Expo) together.
   --backend | --frontend | --mobile | --fullstack   accepted, no effect (kept so older commands still run)
+  --version  print the kit version and exit
 USAGE
 }
 

--- a/start.sh
+++ b/start.sh
@@ -8,12 +8,12 @@
 # varies is the backend pattern, because devarch-module is .NET-specific and wrong in a Node/Go/Python repo.
 # start.sh + claude-starter/ must be in the SAME directory. At the project root:  bash start.sh [flags]
 set -euo pipefail
-HERE="$(cd "$(dirname "$0")" && pwd)"
+HERE="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 
-# --version is answered first, before the source-checkout and payload checks below: it reads only VERSION, so it
+# --version (or -v) is answered first, before the source-checkout and payload checks below: it reads only VERSION, so it
 # must work wherever start.sh sits, including a directory those checks would refuse.
 for a in "$@"; do
-  if [ "$a" = "--version" ]; then
+  if [ "$a" = "--version" ] || [ "$a" = "-v" ]; then
     if [ -f "$HERE/VERSION" ]; then head -1 "$HERE/VERSION" | tr -d '\r'; else echo unknown; fi
     exit 0
   fi
@@ -62,7 +62,7 @@ If no flag is given, the script asks interactively (wizard).
 
 Every install ships the whole kit: all agents, all skills — backend, web and mobile (RN/Expo) together.
   --backend | --frontend | --mobile | --fullstack   accepted, no effect (kept so older commands still run)
-  --version  print the kit version and exit
+  --version, -v  print the kit version and exit
 USAGE
 }
 


### PR DESCRIPTION
Closes the open items from the 2.10.0 report. There is no version bump. Most of this reaches users only with the next
release; the plugin channel's branch and ruleset already exist and are described below.

## Commits

| Commits | What they close |
|:--|:--|
| `31de44a` docs(studio) | The Studio README, `/doctor-csk` and both READMEs said the plugin edition has no panel. It has carried one since 2.9.0. |
| `0e88068` · `52e67ea` fix(cli) | `--version` staged the payload and failed. `-v` and `--version` now answer from npx, Homebrew, `start.sh` and `adopt.sh` before any side effect, including with CDPATH exported. |
| `a8fad2d` fix(release) | The npm page showed `README.tr.md`. The README step now leaves exactly one README, and its smoke check requires the step to run before `npm publish`, unconditionally. The stale "full verify" comment is corrected. |
| `754d5e9` · `60dcc3f` fix(site-gate) | `check-gh-pages.sh` read only two counters. It now reads the commands counter and every count in the page text, word by word: side-by-side EN/TR counts, `&nbsp;`, and description or title meta tags in either quote style. |
| `3d7ca27` fix(gitattributes) | `.js`, `.py`, `.html` and `.css` had no eol pin. They are pinned, and smoke §14 keeps every shipped text file pinned. It fails if git lists nothing and ignores symlinks. |
| `663cf43` · `5dcd032` · `3469fc7` docs(studio), fix(studio) | The stall comments claimed a frequency and a mechanism nobody measured, and the plugin-edition and gate-log notes (both commands, both READMEs, the Studio README, evals/README.md, guard-bash.sh's comments, smoke §7k's heading and label) said a plugin install leaves every kit pane blank and that the gate log is off by default. They now state only the measurement: the gates tab's entries come with the cases measured, the decisions each guard logs, and the log's real default. The serve probe, which e2e runs as a gate, times the project list when its request resolves (it printed about 1.5 s for every fast list). Its liveness check is now red whenever health does not answer 200, and otherwise grades only runs that can tell a blocked event loop from a free one. Before, a fast list passed it without testing a stall, a blocked loop passed whenever the read ended within 2 s of the health request, and a reset health request passed. Calibrated against a stand-in panel that holds its loop, waits on a timer, or resets, hangs or fails its health endpoint. The released 2.9.0 and 2.10.0 CHANGELOG entries are corrected; the published release notes are not edited. |
| `8cdf44e` feat(plugin) | The plugin edition went live when a release PR merged, before the release gates and the approval. It now installs from `plugin-stable`, which only the approved release job moves forward. |

## Measured

- **npm README.** npm 10.8.2's own manifest preparation returns the registry's exact file, `README.tr.md`, on the published
  layout. Its pick depends on directory order. With one README it returns `README.md`, the npm README's content, under all
  four orders tried.
- **`--version`.** On this branch the seven checks pass. On the 2.10.0 files every version check and the README check fail.
  The review's repros were re-run as calibration: a CRLF `release.yml` passes, and a step moved after npm or given
  `if: false` fails, naming why.
- **Site gate.** The published page and the new install cards pass. The pre-2.10.0 page fails. The review's four mutations
  (adjacent counts, `&nbsp;`, a single-quoted description, an og:title) fail, each naming the count. All seven page results
  are identical under ubuntu 24.04's mawk, GNU grep and GNU sed and under macOS's tools.
- **eol pins.** On a clean clone, `git -c core.autocrlf=true archive` differs from the autocrlf=false build in 22 of 150 files
  at v2.10.0 and in 0 of 150 on this branch; renormalizing changes 0 files. The gate passes here and with a staged symlink.
  It fails on 2.10.0 listing 45 files, on a newly staged `.ts` file, and with an emptied index.
- **Plugin channel.** Measured with an isolated `CLAUDE_CONFIG_DIR`, with `~/.claude`'s plugin records unchanged by hash.
  A `git-subdir` entry with a ref passes `claude plugin validate --strict`. Installing through this branch's exact entry
  delivered 2.10.0 from commit `f28b49b`, 134 files. A `./plugin` install at 2.9.0 moved to 2.10.0 when the entry switched.
  A ref moved back to an older release took 2.10.0 down to 2.9.0, which is why the branch may only move forward.
- **Stall.** On one Windows machine, with no kit code running, a plain tail read of a freshly copied 25 MB transcript waited
  63-65 s right after the copy and took 0.044 s when it waited 90 s first. What holds the file was not identified.
- **Independent review.** Three reviewers found 16 problems in the first six commits (5 in the CLI and release commits,
  5 in the gate commits, 6 in the docs commits, one of them major). Each was reproduced and is fixed above. A second
  series on the reworded docs and messages ran five rounds of read-only reviewers: 9, 26, 14, 11 and 9 findings (lenses in
  one round sometimes reported the same issue twice), with majors in four rounds, among them the serve probe passing a panel
  whose event loop a read blocked. Each finding was reproduced and fixed. A last scoped check confirmed the fifth round's
  fixes and found two gaps in the probe (a hanging health request could come out not applicable, and a non-200 answer was
  labelled as no answer); both are fixed, and every liveness branch is calibrated against a stand-in panel, as the last
  commit message records.
- `bash packaging/verify.sh` on the head: **7/7** on `3469fc7`: smoke 668 graded, 0 skipped · §6f discipline 12200 ≤ 12250 bytes · studio 239/239 and 38/0 · e2e: every installer rehearsal passed, and the panel passed 10 served checks from both the install and the plugin edition, with the liveness check not applicable because the list finished before the health request went out.

## Already done outside this branch

- `plugin-stable` exists at `f28b49b` (v2.10.0), protected by the ruleset `protect-plugin-stable`: deletion and
  non-fast-forward are refused, with no bypass. Calibrated on the live branch: a fast-forward push and the release step's own
  API call went through; a force-push, an API rollback (422) and a deletion were refused.
- The site's install cards are published as `6f80bb6`, a fast-forward from `492882b`: four channel cards (npx, Homebrew,
  release tarball, plugin) with a copy button on each of the 11 commands. This branch's `check-gh-pages.sh` passes against
  the published ref (version 2.10.0; 12 agents, 40 skills, 11 commands, including every count written in prose), the
  Pages build finished on `6f80bb6`, and the live page is byte-identical to the commit (41,288 B).
- Merged remote branches were deleted after checking that each was merged with no open PR; their SHAs are recorded.

## Measured on Windows before merge

- The measurement script was first run on macOS against known answers. Between `autocrlf=true` and `false`, the tarball
  differs in 22 of 150 files at v2.10.0 and in 0 at the head; the shipped paths (tarball, npm `files[]`, `plugin/`) in
  45 of 287 and in 0. An existing clone moved from v2.10.0 to the head reports a clean status, and so do a touch and a
  renormalize, while 35 pinned files stay CRLF on disk until a re-checkout. A fresh clone has none. The tarball is built
  with `git archive`, so that working-tree state does not reach it.
- On Windows, the same script (sha256 `603610ce…`) against `3469fc7`, with git 2.55.0.windows.5 and `core.autocrlf=true` from
  the system config, which is the Git for Windows installer default. The tarball differs in 22 of 150 files at v2.10.0 and in
  0 at the head; the shipped paths in 45 of 287 and in 0. An existing clone moved to the head shows 0 status lines, and 0
  again after a touch and a renormalize, while 35 pinned files stay CRLF on disk: the two sample files carry the same CR counts
  (146 and 1,456) before and after the move, so the move did not rewrite them. A re-checkout and a fresh clone bring that to
  0. The 32 files without an eol attribute that are CRLF in a fresh clone all sit outside the shipped paths. All nine numbers
  match macOS. Output sha256 `c27914df…`.

## Not in this PR

- The §6f CRLF diagnosis is #55.

## After merge

- Release note for the next version: clones of this repository keep the 35 newly pinned files CRLF on disk until they are
  checked out again, while `git status` stays clean. In a clean working tree, `git rm -r --cached . && git reset --hard`
  brought that to 0 on macOS and on Windows. Installed projects are not affected: the published 2.10.0 npm package has no
  CR byte in any of its 156 files, and the published release tarball none in its 150, counted on macOS and on Windows. Both
  are built on `ubuntu-latest`, so they were LF before these pins as well; what the pins change is a tarball built from a
  Windows checkout, which now differs in 0 of 150 files between `autocrlf=true` and `false`.

The marketplace starts reading `plugin-stable`, which holds 2.10.0, the version plugin users already have. The next release
is the first to move it, and it does so inside the approved job.
